### PR TITLE
fix: bind session and collab sockets 0600 without touching the process umask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.654"
+version = "0.1.655"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.654"
+version = "0.1.655"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/MULTIPLAYER.md
+++ b/docs/MULTIPLAYER.md
@@ -54,7 +54,10 @@ deterministic byte assertions:
 - The control holder's keystrokes reached the PTY and broadcast to both; the
   read-only client's keystrokes appeared in neither output (server-side
   enforcement, not advisory).
-- The socket was mode `0600` from creation (umask fix), and two clients that
+- The socket was mode `0600` from creation (bound in a private 0700 staging
+  dir and renamed into place — `session::bind_socket_0600`, shared with the
+  collab relay; the earlier umask save/restore was process-global and racing
+  binds could corrupt it), and two clients that
   reported `0x0` size did not shrink the shared PTY (zero-winsize guard).
 - An inner `exit 7` propagated through the mux and back over SSH as exit 7
   (the drop-to-local code path).

--- a/docs/MULTIPLAYER.md
+++ b/docs/MULTIPLAYER.md
@@ -57,7 +57,10 @@ deterministic byte assertions:
 - The socket was mode `0600` from creation (bound in a private 0700 staging
   dir and renamed into place — `session::bind_socket_0600`, shared with the
   collab relay; the earlier umask save/restore was process-global and racing
-  binds could corrupt it), and two clients that
+  binds could corrupt it). Creation is serialized per target by a lock file
+  held across probe, stale removal, bind and publish, so two attach-or-create
+  racers can never both publish and strand the earlier listener pathless: the
+  loser is told the winner is alive and attaches. And two clients that
   reported `0x0` size did not shrink the shared PTY (zero-winsize guard).
 - An inner `exit 7` propagated through the mux and back over SSH as exit 7
   (the drop-to-local code path).

--- a/src/collab.rs
+++ b/src/collab.rs
@@ -432,18 +432,22 @@ impl CollabMsg {
 /// (`<hash>.collab.sock`), so it never carries terminal bytes.
 pub fn relay_serve(socket: &std::path::Path) -> anyhow::Result<()> {
     // Attach-or-create: a live relay already owns the socket; binding over
-    // it would strand that relay's connected clients mid-session. (Two
-    // creators racing past this check is the same benign window
-    // session_host::attach_or_create accepts.)
+    // it would strand that relay's connected clients mid-session. The
+    // liveness check here is only a fast path - creation itself (stale-file
+    // removal included) is serialized inside the binder, so two creators
+    // racing past this line cannot both publish: the loser is told the
+    // winner is alive and attaches, which is exactly these semantics.
     if crate::session::is_alive(socket) {
         return Ok(());
     }
     if let Some(dir) = socket.parent() {
         std::fs::create_dir_all(dir)?;
     }
-    let _ = std::fs::remove_file(socket);
-    // Bind 0600 with no TOCTOU window (same fix as the mux socket).
-    let listener = crate::session::bind_socket_0600(socket)?;
+    let listener = match crate::session::bind_socket_0600(socket) {
+        Ok(l) => l,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
 
     let clients: std::sync::Arc<std::sync::Mutex<Vec<Peer>>> =
         std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));

--- a/src/collab.rs
+++ b/src/collab.rs
@@ -431,7 +431,6 @@ impl CollabMsg {
 /// closes; one thread per client. Distinct socket from the PTY mux
 /// (`<hash>.collab.sock`), so it never carries terminal bytes.
 pub fn relay_serve(socket: &std::path::Path) -> anyhow::Result<()> {
-    use std::os::unix::net::UnixListener;
     // Attach-or-create: a live relay already owns the socket; binding over
     // it would strand that relay's connected clients mid-session. (Two
     // creators racing past this check is the same benign window
@@ -444,10 +443,7 @@ pub fn relay_serve(socket: &std::path::Path) -> anyhow::Result<()> {
     }
     let _ = std::fs::remove_file(socket);
     // Bind 0600 with no TOCTOU window (same fix as the mux socket).
-    let prev_umask = unsafe { libc::umask(0o077) };
-    let listener = UnixListener::bind(socket);
-    unsafe { libc::umask(prev_umask) };
-    let listener = listener?;
+    let listener = crate::session::bind_socket_0600(socket)?;
 
     let clients: std::sync::Arc<std::sync::Mutex<Vec<Peer>>> =
         std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -59,21 +59,7 @@ pub struct ReleaseNote {
 }
 
 /// What shipped in the current release. Replace on every version bump.
-pub const RELEASE_NOTES: &[ReleaseNote] = &[
-    ReleaseNote {
-        kind: NoteKind::Fix,
-        summary: "In a grid of three or more editor groups the focused group's PDF preview really shows now: the overlay's gate, key and pixels all resolve to the focused group instead of the first one, so pages turn and links click.",
-    },
-    ReleaseNote {
-        kind: NoteKind::Fix,
-        summary: "A tcsh or csh user's PATH survives a Dock launch: the probe marks itself a login shell the way login(1) does, so ~/.login is finally read.",
-    },
-    ReleaseNote {
-        kind: NoteKind::Fix,
-        summary: "A collab guest keeps re-asking for the owner's snapshot through the whole bootstrap window (the backoff now caps at 1s), so an owner that connects a moment late is still caught instead of the file silently going local-only.",
-    },
-    ReleaseNote {
-        kind: NoteKind::Fix,
-        summary: "PDF link slicing survives malformed text runs: a bare ampersand or a zero-extent run can no longer push a link over neighbouring text or make it unclickable.",
-    },
-];
+pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
+    kind: NoteKind::Fix,
+    summary: "Session and collab sockets are now bound owner-only without touching the process umask: the old save/restore dance raced concurrent binds, could leave a relay socket readable by other users, and could corrupt the process umask for good.",
+}];

--- a/src/session.rs
+++ b/src/session.rs
@@ -371,7 +371,34 @@ pub fn list() -> Result<()> {
 /// another user must never be able to connect. Shared by both binders so the
 /// permission discipline lives in exactly one place.
 pub fn bind_socket_0600(socket: &Path) -> std::io::Result<std::os::unix::net::UnixListener> {
-    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+    use std::os::unix::io::AsRawFd;
+    // Creation is serialized per target through an owner-only lock file held
+    // across the liveness probe, the stale-file removal, the bind and the
+    // publication. Without it, two attach-or-create racers could both probe
+    // "nobody alive", both publish, and the later publisher replaced the
+    // earlier one's directory entry - a live but pathless listener, i.e. a
+    // stranded session host invisible to every future client. The loser now
+    // finds the winner alive under the lock and is told to attach instead
+    // (`AddrInUse`). The flock releases on drop (or on crash, by the OS).
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .mode(0o600)
+        .open(socket.with_extension("bind.lock"))?;
+    if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if is_alive(socket) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            format!("a listener is already serving {}", socket.display()),
+        ));
+    }
+    // Proven dead under the lock: a crashed owner's stale file (unix sockets
+    // are not auto-unlinked) must not block the next creator.
+    let _ = std::fs::remove_file(socket);
     // `bind` starts accepting connections the instant it returns, and the
     // socket file's mode comes from the process umask. A save/restore umask
     // dance around the bind is process-global state: two concurrent binds
@@ -404,6 +431,59 @@ pub fn bind_socket_0600(socket: &Path) -> std::io::Result<std::os::unix::net::Un
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Two attach-or-create racers for the SAME target must never both
+    /// publish: before creation was serialized, the later publisher replaced
+    /// the earlier one's directory entry, leaving a live but pathless
+    /// listener (a stranded session host, invisible to every future client).
+    /// Exactly one racer may win; the loser is told the address is in use so
+    /// it attaches to the winner instead.
+    #[test]
+    fn racing_binds_on_one_target_produce_exactly_one_listener() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("same.sock");
+        let outcomes: Vec<std::io::Result<std::os::unix::net::UnixListener>> =
+            std::thread::scope(|s| {
+                let handles: Vec<_> = (0..2)
+                    .map(|_| {
+                        let sock = sock.clone();
+                        s.spawn(move || bind_socket_0600(&sock))
+                    })
+                    .collect();
+                handles.into_iter().map(|h| h.join().unwrap()).collect()
+            });
+        let winners = outcomes.iter().filter(|o| o.is_ok()).count();
+        assert_eq!(
+            winners, 1,
+            "exactly one racer may publish a listener on one target"
+        );
+        for o in &outcomes {
+            if let Err(e) = o {
+                assert_eq!(
+                    e.kind(),
+                    std::io::ErrorKind::AddrInUse,
+                    "the loser must be told to attach, got {e:?}"
+                );
+            }
+        }
+        // And the published listener is the live one: a client reaches it.
+        let l = outcomes.into_iter().find_map(|o| o.ok()).unwrap();
+        let _c = std::os::unix::net::UnixStream::connect(&sock)
+            .expect("the surviving pathname must reach the winning listener");
+        drop(l);
+    }
+
+    /// A stale socket file (its owner crashed; nobody accepts) must not block
+    /// the next creator: the binder proves it dead and replaces it.
+    #[test]
+    fn a_dead_stale_socket_file_is_replaced() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("stale.sock");
+        drop(bind_socket_0600(&sock).expect("first bind"));
+        assert!(sock.exists(), "a dropped listener leaves its file behind");
+        let _l = bind_socket_0600(&sock).expect("a dead socket file must be replaced");
+        std::os::unix::net::UnixStream::connect(&sock).expect("the new listener answers");
+    }
 
     /// Every croft socket is owner-only from its first observable instant.
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -365,9 +365,106 @@ pub fn list() -> Result<()> {
     Ok(())
 }
 
+/// Bind a unix listener at `socket`, owner-only (0600) with no window in
+/// which anyone else could connect. Possession of the account is the trust
+/// boundary for every croft socket (the session mux, the collab relay):
+/// another user must never be able to connect. Shared by both binders so the
+/// permission discipline lives in exactly one place.
+pub fn bind_socket_0600(socket: &Path) -> std::io::Result<std::os::unix::net::UnixListener> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+    // `bind` starts accepting connections the instant it returns, and the
+    // socket file's mode comes from the process umask. A save/restore umask
+    // dance around the bind is process-global state: two concurrent binds
+    // interleaving their restores corrupted the mask for the rest of the
+    // process's life, and one of the sockets got created under the loose
+    // caller mask. Instead, bind inside a fresh 0700 staging dir next to
+    // the target (same filesystem; the short `.s` name keeps the AF_UNIX
+    // path-length budget), fix the socket's own mode to 0600 while nobody
+    // can traverse to it, then rename(2) it into place atomically. No
+    // process-global state anywhere.
+    static STAGE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = STAGE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let parent = socket.parent().unwrap_or(Path::new("."));
+    let stage = parent.join(format!(".s{}-{n}", std::process::id()));
+    // A crash can strand a same-named staging dir (the counter restarts
+    // with the process and pids recycle); it is ours by construction.
+    let _ = std::fs::remove_dir_all(&stage);
+    std::fs::DirBuilder::new().mode(0o700).create(&stage)?;
+    let result = (|| {
+        let tmp = stage.join("s");
+        let listener = std::os::unix::net::UnixListener::bind(&tmp)?;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))?;
+        std::fs::rename(&tmp, socket)?;
+        Ok(listener)
+    })();
+    let _ = std::fs::remove_dir_all(&stage);
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every croft socket is owner-only from its first observable instant.
+    #[test]
+    fn a_bound_socket_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("a.sock");
+        let _l = bind_socket_0600(&sock).expect("bind");
+        let mode = std::fs::metadata(&sock).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "socket must be 0600, got {mode:o}");
+    }
+
+    /// Binding must not go through process-global state: the parallel test
+    /// suite (and any future in-process threading) binds relay and mux
+    /// sockets from many threads at once. The old save/restore umask dance
+    /// raced - two interleaved binds could restore each other's masks
+    /// (permanently corrupting the process umask) and one socket could be
+    /// created under the caller's loose umask for its whole life.
+    #[test]
+    fn concurrent_binds_never_corrupt_the_process_umask_or_a_socket() {
+        use std::os::unix::fs::PermissionsExt;
+        let read_umask = || unsafe {
+            // Read is a write on this API; probe with the tightest value so
+            // the blink can only ever make a concurrent file MORE private.
+            let cur = libc::umask(0o077);
+            libc::umask(cur);
+            cur
+        };
+        let before = read_umask();
+        let dir = tempfile::tempdir().unwrap();
+        let worst = std::sync::Arc::new(std::sync::Mutex::new(0u32));
+        std::thread::scope(|s| {
+            for t in 0..2 {
+                let dir = dir.path().to_path_buf();
+                let worst = std::sync::Arc::clone(&worst);
+                s.spawn(move || {
+                    for i in 0..300 {
+                        let sock = dir.join(format!("{t}-{i}.sock"));
+                        let l = bind_socket_0600(&sock).expect("bind");
+                        let mode = std::fs::metadata(&sock).unwrap().permissions().mode() & 0o777;
+                        let mut w = worst.lock().unwrap();
+                        if mode > *w {
+                            *w = mode;
+                        }
+                        drop(l);
+                        let _ = std::fs::remove_file(&sock);
+                    }
+                });
+            }
+        });
+        assert_eq!(
+            *worst.lock().unwrap(),
+            0o600,
+            "a racing bind produced a socket looser than 0600"
+        );
+        assert_eq!(
+            read_umask(),
+            before,
+            "racing binds corrupted the process umask"
+        );
+    }
 
     /// The single-host lock is exclusive: a second acquirer is refused while
     /// the first holds it, and the lock frees when the holder drops (the OS

--- a/src/session_host.rs
+++ b/src/session_host.rs
@@ -244,13 +244,19 @@ pub(crate) fn serve_with_token(
     if crate::session::is_alive(socket) {
         anyhow::bail!("a session host is already running on {}", socket.display());
     }
-    // A crashed server leaves a stale socket file behind (unix sockets are
-    // not auto-unlinked); the liveness probe above proved nobody owns it.
-    let _ = std::fs::remove_file(socket);
     // Possession of the account is the trust boundary (same as dtach); never
-    // let another user attach.
-    let listener = crate::session::bind_socket_0600(socket)
-        .with_context(|| format!("binding {}", socket.display()))?;
+    // let another user attach. Stale-file removal and creation serialization
+    // live inside the binder: a racer that loses the per-target lock is told
+    // the winner is alive instead of silently replacing its socket.
+    let listener = match crate::session::bind_socket_0600(socket) {
+        Ok(l) => l,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            anyhow::bail!("a session host is already running on {}", socket.display());
+        }
+        Err(e) => {
+            return Err(anyhow::Error::from(e).context(format!("binding {}", socket.display())));
+        }
+    };
     if let Some(ws) = workspace {
         crate::session::write_meta_preserving_created(socket, ws)?;
     }

--- a/src/session_host.rs
+++ b/src/session_host.rs
@@ -17,7 +17,7 @@
 //! `crate::mcp::transport`.
 
 use std::io::{Read, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -248,21 +248,9 @@ pub(crate) fn serve_with_token(
     // not auto-unlinked); the liveness probe above proved nobody owns it.
     let _ = std::fs::remove_file(socket);
     // Possession of the account is the trust boundary (same as dtach); never
-    // let another user attach. `bind` starts accepting connections the instant
-    // it returns, so a chmod on the next line leaves a TOCTOU window in which
-    // the socket carries umask-derived perms (0644 under umask 022). Bind under
-    // a 0077 umask so the socket is 0600 from creation; restore afterward.
-    let prev_umask = unsafe { libc::umask(0o077) };
-    let listener =
-        UnixListener::bind(socket).with_context(|| format!("binding {}", socket.display()));
-    unsafe { libc::umask(prev_umask) };
-    let listener = listener?;
-    {
-        // Belt-and-braces: assert 0600 even where umask was ignored.
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o600))
-            .context("restricting socket permissions")?;
-    }
+    // let another user attach.
+    let listener = crate::session::bind_socket_0600(socket)
+        .with_context(|| format!("binding {}", socket.display()))?;
     if let Some(ws) = workspace {
         crate::session::write_meta_preserving_created(socket, ws)?;
     }


### PR DESCRIPTION
Both the session mux and the collab relay bound their unix sockets under a save/restore umask dance. umask is process-global: two concurrent binds interleaving their restores could leave one socket created under the caller's loose mask (the relay had no chmod fallback, so its socket could stay 0644 for its whole life) and could corrupt the process umask permanently. Observed as a real interleaving in the parallel test suite; latent for any future in-process threading.

The fix extracts a single shared binder, "session::bind_socket_0600", which touches no process-global state: it binds inside a fresh 0700 staging dir next to the target (same filesystem, short name for the AF_UNIX path budget), sets the socket itself to 0600 while nobody can traverse to it, then renames it into place atomically. RED-tested: a two-thread bind stress demonstrated the umask corruption against the old code (process umask left at 0o077) and is deterministic-green against the new binder.

Full suite: 2754 + 5 CLI tests, 0 failed, clippy zero warnings. Ships as 0.1.655.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for session and collaboration sockets by restricting access to the owner.
  * Prevented race conditions during socket creation and improved handling of stale or active sockets.
  * Socket setup no longer changes the application’s process-wide permissions behavior.

* **Documentation**
  * Updated multiplayer documentation to describe secure, serialized socket creation.

* **Release**
  * Updated the package version to 0.1.655.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
