### PR TITLE
fix: resolve the adversarial-review findings on the Finder/explorer span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.655"
+version = "0.1.656"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.655"
+version = "0.1.656"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2113,10 +2113,12 @@ pub struct App {
     /// Required to bake OSC-1337 images at exact viewport pixel size so
     /// iTerm draws them with no stretching or letterboxing.
     cell_pixel: Option<(u32, u32)>,
-    /// Last wheel step applied to a PDF preview (when, and in which
-    /// direction), so a momentum flick's same-direction burst coalesces
-    /// instead of queueing one blocking rasteriser run per event.
-    last_pdf_wheel: Option<(std::time::Instant, i32)>,
+    /// Last wheel step applied to a PDF preview (when, in which direction,
+    /// and on which document), so a momentum flick's same-direction burst
+    /// coalesces instead of queueing one blocking rasteriser run per event.
+    /// Keyed by document: switching to another PDF starts fresh - a reader's
+    /// first gesture there is not a repeat.
+    last_pdf_wheel: Option<(std::time::Instant, i32, Option<PathBuf>)>,
     /// Pre-encoded inline-image for the source-control change-count badge (an
     /// accent pill + count, VS Code's `activityBarBadge`), emitted at z=1 over
     /// the SCM activity icon's bottom-right. `None` when there are no changes,
@@ -8430,17 +8432,21 @@ impl App {
 
     fn cycle_focus(&mut self) {
         // Skip hidden panes when cycling.
+        let mut next = self.focus;
         for _ in 0..3 {
-            self.focus = match self.focus {
+            next = match next {
                 Pane::Tree => Pane::Editor,
                 Pane::Editor => Pane::Terminal,
                 Pane::Terminal => Pane::Tree,
             };
-            if self.pane_visible(self.focus) {
+            if self.pane_visible(next) {
                 break;
             }
         }
-        self.sync_focus_flags();
+        // Through `focus_pane`, never a bare assignment: every route into a
+        // pane shares its guarantees (terminal find/copy-mode teardown, and
+        // restoring the editor from under a maximized terminal).
+        self.focus_pane(next);
     }
 
     /// Returns true exactly once after the welcome OSC-1337 image has been
@@ -27547,13 +27553,15 @@ impl App {
     fn wheel_pdf_page(&mut self, delta: i32) {
         const COOLDOWN: std::time::Duration = std::time::Duration::from_millis(150);
         let now = std::time::Instant::now();
-        if let Some((at, dir)) = self.last_pdf_wheel
-            && dir == delta.signum()
-            && now.duration_since(at) < COOLDOWN
+        let doc = self.editor.path.clone();
+        if let Some((at, dir, last_doc)) = &self.last_pdf_wheel
+            && *dir == delta.signum()
+            && *last_doc == doc
+            && now.duration_since(*at) < COOLDOWN
         {
             return;
         }
-        self.last_pdf_wheel = Some((now, delta.signum()));
+        self.last_pdf_wheel = Some((now, delta.signum(), doc));
         let Some(cur) = self.editor.pdf_page() else {
             return;
         };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2113,6 +2113,10 @@ pub struct App {
     /// Required to bake OSC-1337 images at exact viewport pixel size so
     /// iTerm draws them with no stretching or letterboxing.
     cell_pixel: Option<(u32, u32)>,
+    /// Last wheel step applied to a PDF preview (when, and in which
+    /// direction), so a momentum flick's same-direction burst coalesces
+    /// instead of queueing one blocking rasteriser run per event.
+    last_pdf_wheel: Option<(std::time::Instant, i32)>,
     /// Pre-encoded inline-image for the source-control change-count badge (an
     /// accent pill + count, VS Code's `activityBarBadge`), emitted at z=1 over
     /// the SCM activity icon's bottom-right. `None` when there are no changes,
@@ -3409,6 +3413,7 @@ impl App {
             search_query_tx,
             search_results_rx,
             cell_pixel: None,
+            last_pdf_wheel: None,
             scm_change_badge: None,
             scm_change_badge_count: 0,
             explorer_unsaved_badge: None,
@@ -26240,7 +26245,7 @@ impl App {
                     if let Some(diff) = self.editor.diff.as_mut() {
                         diff.scroll_down_by(3);
                     } else if self.editor.pdf_page().is_some() {
-                        self.step_pdf_page(1);
+                        self.wheel_pdf_page(1);
                     } else {
                         self.editor.scroll_down(3);
                     }
@@ -26301,7 +26306,7 @@ impl App {
                     if let Some(diff) = self.editor.diff.as_mut() {
                         diff.scroll_up_by(3);
                     } else if self.editor.pdf_page().is_some() {
-                        self.step_pdf_page(-1);
+                        self.wheel_pdf_page(-1);
                     } else {
                         self.editor.scroll_up(3);
                     }
@@ -27495,11 +27500,40 @@ impl App {
         }
     }
 
-    /// Step the focused PDF preview by `delta` pages. The overlay re-bakes on
-    /// its own (the page is part of its re-emit key), so this is the single
-    /// entry point every gesture - arrows, wheel, menu - can call.
+    /// Step the focused PDF preview by `delta` pages, wrapping at the
+    /// document ends. The overlay re-bakes on its own (the page is part of
+    /// its re-emit key). Deliberate gestures only - arrows, menu; the wheel
+    /// goes through [`Self::wheel_pdf_page`].
     fn step_pdf_page(&mut self, delta: i32) {
         self.editor.change_pdf_page(delta);
+    }
+
+    /// Wheel paging for the PDF preview. Differs from the key path twice
+    /// over: it clamps at the document ends (no scroll wheel wraps a PDF),
+    /// and a same-direction repeat inside the cooldown is dropped - every
+    /// page step is a synchronous rasteriser run on the UI thread, so a
+    /// momentum flick's burst of wheel events must coalesce instead of
+    /// freezing the TUI for one render per event. A reversal is deliberate
+    /// and always passes.
+    fn wheel_pdf_page(&mut self, delta: i32) {
+        const COOLDOWN: std::time::Duration = std::time::Duration::from_millis(150);
+        let now = std::time::Instant::now();
+        if let Some((at, dir)) = self.last_pdf_wheel
+            && dir == delta.signum()
+            && now.duration_since(at) < COOLDOWN
+        {
+            return;
+        }
+        self.last_pdf_wheel = Some((now, delta.signum()));
+        let Some(cur) = self.editor.pdf_page() else {
+            return;
+        };
+        let target = if delta >= 0 {
+            cur.saturating_add(delta as u32)
+        } else {
+            cur.saturating_sub(delta.unsigned_abs()).max(1)
+        };
+        self.editor.set_pdf_page(target);
     }
 
     fn jump_pdf_page(&mut self, page: u32) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9780,6 +9780,14 @@ impl App {
         if p != Pane::Terminal && self.terminal_copy_mode.is_some() {
             self.close_terminal_copy_mode();
         }
+        // A maximized terminal gives the editor zero rows; focusing the
+        // editor is always an intent to use it, so restore it (VS Code's
+        // convention when a file is revealed over a maximized panel).
+        // `terminal_pane_maximized` (width, among terminal panes) is
+        // unrelated and stays.
+        if p == Pane::Editor && self.terminal_maximized {
+            self.terminal_maximized = false;
+        }
         self.focus = p;
         self.sync_focus_flags();
         if self.editor.focused {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26637,6 +26637,22 @@ impl App {
         }
     }
 
+    /// Whether an open context menu (or its submenu panel) overlaps `rect`
+    /// on a protocol with no image z-layer (iTerm2 OSC-1337, Sixel), where
+    /// the image blit would overpaint the menu. Kitty layers images below
+    /// text, so it never needs this.
+    fn context_menu_covers_rect(&self, rect: Rect) -> bool {
+        match self.inline_protocol {
+            crate::iterm2_inline::InlineImageProtocol::ITerm2
+            | crate::iterm2_inline::InlineImageProtocol::Sixel => {}
+            _ => return false,
+        }
+        self.menu_rect()
+            .into_iter()
+            .chain(self.submenu_rect())
+            .any(|m| rects_intersect(m, rect))
+    }
+
     /// Compute the menu's bounding rect from current state.
     fn menu_rect(&self) -> Option<Rect> {
         let menu = self.context_menu.as_ref()?;
@@ -27673,6 +27689,22 @@ impl App {
                 .and_then(|g| g.image.as_ref())
                 .map_or(0, |i| i.generation),
         };
+        // The cell-buffer protocols (iTerm2 OSC-1337, Sixel) have no
+        // z-layer, so the post-frame image blit would overpaint an open
+        // context menu (Kitty puts the image at deep-negative z instead).
+        // Hold the overlay cleared while a menu overlaps it; the layout
+        // was invalidated, so the first frame after the menu closes or
+        // moves off re-bakes the picture.
+        if self.context_menu_covers_rect(Rect {
+            x: cell_x,
+            y: cell_y,
+            width: cell_w,
+            height: cell_h,
+        }) {
+            self.overlays.editor[side].request_clear_if_displayed();
+            self.overlays.editor[side].invalidate_layout();
+            return;
+        }
         // Skip the bake when nothing about the layout changed - this is
         // the hot path on every frame an image is on screen.
         if self.overlays.editor[side].layout_matches(&desired) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2802,6 +2802,11 @@ pub struct EditorImageLayout {
     /// path and rect are unchanged on a page turn and the stale picture stays
     /// on screen unless every call site remembers to invalidate the layout.
     pub page: u32,
+    /// Content stamp of the baked bytes ([`crate::widgets::editor::ImageView::generation`]).
+    /// Part of the re-emit key so a file rebuilt on disk re-bakes even when
+    /// the path, rect and page are all unchanged (a pdflatex rebuild lands
+    /// on the same page the reader was on).
+    pub generation: u64,
 }
 
 /// Re-emit key for the terminal pane's inline-image overlay: the cell rect
@@ -27663,6 +27668,10 @@ impl App {
                 .and_then(|g| g.image.as_ref())
                 .and_then(|i| i.pdf.as_ref())
                 .map_or(1, |p| p.current_page),
+            generation: self
+                .group_on_side(side)
+                .and_then(|g| g.image.as_ref())
+                .map_or(0, |i| i.generation),
         };
         // Skip the bake when nothing about the layout changed - this is
         // the hot path on every frame an image is on screen.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20908,6 +20908,60 @@ fn a_context_menu_over_the_editor_image_suppresses_the_blit_on_no_z_protocols() 
     );
 }
 
+/// F6 must give the same guarantee as every other route into the editor:
+/// it used to assign focus directly, bypassing `focus_pane`, so cycling
+/// into the editor under a maximized terminal focused a zero-height pane.
+#[test]
+fn cycling_focus_into_the_editor_also_restores_a_maximized_terminal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.terminal_maximized = true;
+    for _ in 0..3 {
+        app.cycle_focus();
+        if matches!(app.focus, Pane::Editor) {
+            break;
+        }
+    }
+    assert!(
+        matches!(app.focus, Pane::Editor),
+        "F6 must reach the editor"
+    );
+    assert!(
+        !app.terminal_maximized,
+        "cycling into the editor must restore it, same as any other route"
+    );
+}
+
+/// The wheel cooldown is per document: scrolling one PDF and immediately
+/// wheeling in a second, freshly focused PDF is that document's FIRST
+/// gesture, not a repeat - an app-global cooldown swallowed it.
+#[test]
+fn the_wheel_cooldown_does_not_leak_across_pdf_documents() {
+    require_pdf_backend();
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a.pdf");
+    let b = tmp.path().join("b.pdf");
+    write_three_page_pdf(&a);
+    write_three_page_pdf(&b);
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open(&a).unwrap();
+    let (col, row) = place_editor_pane(&mut app);
+    wheel(&mut app, MouseEventKind::ScrollDown, col, row);
+    assert_eq!(current_pdf_page(&app), 2);
+    app.editor.open(&b).unwrap();
+    let (col, row) = place_editor_pane(&mut app);
+    // Pin the cooldown stamp to "just now, same direction, other document"
+    // so the window is deterministically open regardless of how long the
+    // rasteriser took: only the document identity may let this tick through.
+    app.last_pdf_wheel = Some((std::time::Instant::now(), 1, Some(a.clone())));
+    wheel(&mut app, MouseEventKind::ScrollDown, col, row);
+    assert_eq!(
+        current_pdf_page(&app),
+        2,
+        "the second document's first wheel tick must not be dropped"
+    );
+}
+
 #[test]
 fn a_spreadsheet_opened_from_the_explorer_scrolls_with_the_arrow_keys() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20803,6 +20803,53 @@ fn the_wheel_pages_a_pdf_under_the_pointer() {
     assert_eq!(current_pdf_page(&app), 1, "wheel up pages back");
 }
 
+/// A momentum flick delivers a burst of same-direction wheel events, and
+/// every PDF page step is a synchronous rasteriser run on the UI thread: the
+/// burst must coalesce (rate-limited per direction) instead of queueing
+/// dozens of blocking renders. A reversal is deliberate and passes through
+/// immediately (the paging test above depends on that).
+#[test]
+fn a_wheel_flick_over_a_pdf_coalesces_to_one_page_step() {
+    require_pdf_backend();
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("doc.pdf");
+    write_three_page_pdf(&path);
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open(&path).unwrap();
+    let (col, row) = place_editor_pane(&mut app);
+    wheel(&mut app, MouseEventKind::ScrollDown, col, row);
+    wheel(&mut app, MouseEventKind::ScrollDown, col, row);
+    wheel(&mut app, MouseEventKind::ScrollDown, col, row);
+    assert_eq!(
+        current_pdf_page(&app),
+        2,
+        "a same-direction burst steps one page, not one per event"
+    );
+}
+
+/// The wheel never wraps the document: page 1 stays put on wheel up and the
+/// last page stays put on wheel down. (The arrow keys wrap deliberately;
+/// no PDF viewer wraps on scroll.)
+#[test]
+fn the_wheel_does_not_wrap_a_pdf_at_its_ends() {
+    require_pdf_backend();
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("doc.pdf");
+    write_three_page_pdf(&path);
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open(&path).unwrap();
+    let (col, row) = place_editor_pane(&mut app);
+    wheel(&mut app, MouseEventKind::ScrollUp, col, row);
+    assert_eq!(current_pdf_page(&app), 1, "wheel up on page 1 must not wrap");
+    app.jump_pdf_page(3);
+    wheel(&mut app, MouseEventKind::ScrollDown, col, row);
+    assert_eq!(
+        current_pdf_page(&app),
+        3,
+        "wheel down on the last page must not wrap"
+    );
+}
+
 #[test]
 fn a_spreadsheet_opened_from_the_explorer_scrolls_with_the_arrow_keys() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11977,6 +11977,7 @@ fn closing_image_tab_requests_overlay_clear_on_next_render() {
             cell_h: 10,
             path: tmp.path().join("doomed.png"),
             page: 1,
+            generation: 0,
         }),
         true,
     );
@@ -15184,6 +15185,7 @@ fn editor_image_overlay_is_dual_slot_and_clear_ors_both_columns() {
         cell_h: 10,
         path: tmp.path().join(name),
         page: 1,
+        generation: 0,
     };
     // Both physical columns can hold an inline image at once.
     app.overlays.editor[0].set_test_state(Some("left-osc".into()), Some(layout("l.png")), true);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20842,7 +20842,11 @@ fn the_wheel_does_not_wrap_a_pdf_at_its_ends() {
     app.editor.open(&path).unwrap();
     let (col, row) = place_editor_pane(&mut app);
     wheel(&mut app, MouseEventKind::ScrollUp, col, row);
-    assert_eq!(current_pdf_page(&app), 1, "wheel up on page 1 must not wrap");
+    assert_eq!(
+        current_pdf_page(&app),
+        1,
+        "wheel up on page 1 must not wrap"
+    );
     app.jump_pdf_page(3);
     wheel(&mut app, MouseEventKind::ScrollDown, col, row);
     assert_eq!(
@@ -20868,6 +20872,39 @@ fn opening_a_file_over_a_maximized_terminal_restores_the_editor() {
     assert!(
         !app.terminal_maximized,
         "focusing the editor must restore it from under a maximized terminal"
+    );
+}
+
+/// iTerm2 OSC-1337 and Sixel have no image z-layer: the post-frame image
+/// blit overwrites whatever text sits in those cells, so an open context
+/// menu overlapping the editor preview must suppress the overlay (Kitty
+/// instead layers images below text and needs nothing).
+#[test]
+fn a_context_menu_over_the_editor_image_suppresses_the_blit_on_no_z_protocols() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    let img = ratatui::layout::Rect::new(2, 2, 30, 15);
+    assert!(
+        !app.context_menu_covers_rect(img),
+        "no menu open: nothing to suppress"
+    );
+    app.context_menu = Some(ContextMenu::flat(
+        (4, 4),
+        vec![(
+            String::from("Rename"),
+            MenuAction::Rename(tmp.path().into()),
+        )],
+        tmp.path().into(),
+    ));
+    app.inline_protocol = crate::iterm2_inline::InlineImageProtocol::ITerm2;
+    assert!(
+        app.context_menu_covers_rect(img),
+        "an overlapping menu must suppress the image on iTerm2"
+    );
+    app.inline_protocol = crate::iterm2_inline::InlineImageProtocol::Kitty;
+    assert!(
+        !app.context_menu_covers_rect(img),
+        "Kitty layers images below text; the menu already wins"
     );
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20850,6 +20850,25 @@ fn the_wheel_does_not_wrap_a_pdf_at_its_ends() {
     );
 }
 
+/// Opening a file while the terminal is maximized (Ctrl+Shift+J) must
+/// restore the editor - the same convention VS Code follows when a file is
+/// revealed over a maximized panel. Before this, focus silently moved into
+/// an editor the layout gave zero rows: arrows did nothing visible and
+/// typing dirtied a hidden buffer.
+#[test]
+fn opening_a_file_over_a_maximized_terminal_restores_the_editor() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "hello").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.terminal_maximized = true;
+    open_from_explorer(&mut app, "a.txt");
+    assert!(matches!(app.focus, Pane::Editor));
+    assert!(
+        !app.terminal_maximized,
+        "focusing the editor must restore it from under a maximized terminal"
+    );
+}
+
 #[test]
 fn a_spreadsheet_opened_from_the_explorer_scrolls_with_the_arrow_keys() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -32,18 +32,33 @@ const APP_NAME: &str = "Croft";
 /// the Explorer and terminal stay one keystroke away (Cmd+B / Cmd+J). Clicking
 /// the launcher itself opens the workspace with the normal layout.
 fn launcher_script(croft_bin: &str, open_dir: &str) -> String {
+    // The command crosses two shells (`do shell script`, then Ghostty runs
+    // `--initial-command` through `/bin/sh -c`), so each path is its own
+    // `quoted form of` component - hand-rolled quotes died on an apostrophe
+    // in the workspace path. `on open` receives every selected/dropped file
+    // in one event; each gets its own window.
+    let bin = applescript_lit(croft_bin);
+    let dir = applescript_lit(open_dir);
     format!(
         r#"on run
-	do shell script "open -na Ghostty.app --args --initial-command=" & quoted form of "{croft_bin} '{open_dir}'"
+	set inner to quoted form of {bin} & " " & quoted form of {dir}
+	do shell script "open -na Ghostty.app --args --initial-command=" & quoted form of inner
 end run
 
 on open theFiles
-	set f to POSIX path of (item 1 of theFiles)
-	set inner to "{croft_bin} " & quoted form of f & " --zen"
-	do shell script "open -na Ghostty.app --args --initial-command=" & quoted form of inner
+	repeat with f in theFiles
+		set inner to quoted form of {bin} & " " & quoted form of (POSIX path of f) & " --zen"
+		do shell script "open -na Ghostty.app --args --initial-command=" & quoted form of inner
+	end repeat
 end open
 "#
     )
+}
+
+/// A string as an AppleScript literal: backslashes and quotes escaped, so an
+/// arbitrary path can never break out of (or fail to compile) the script.
+fn applescript_lit(s: &str) -> String {
+    format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
 /// `PlistBuddy` edits applied to the bundle `osacompile` generates. It writes a
@@ -197,7 +212,8 @@ mod tests {
         let s = launcher_script("/Users/v/.cargo/bin/croft", "/Users/v/Documents");
         assert!(s.contains("on run"));
         assert!(s.contains("open -na Ghostty.app --args"));
-        assert!(s.contains("/Users/v/.cargo/bin/croft '/Users/v/Documents'"));
+        assert!(s.contains(r#"quoted form of "/Users/v/.cargo/bin/croft""#));
+        assert!(s.contains(r#"quoted form of "/Users/v/Documents""#));
     }
 
     /// A plain `#!/bin/sh` bundle executable never sees the opened document:
@@ -207,10 +223,9 @@ mod tests {
     fn script_handles_opened_documents_through_an_open_handler() {
         let s = launcher_script("/Users/v/.cargo/bin/croft", "/Users/v/Documents");
         assert!(s.contains("on open theFiles"));
-        assert!(s.contains("POSIX path of (item 1 of theFiles)"));
         // The dropped path is passed through as croft's workspace argument;
         // croft itself roots a file at its parent (see cli::resolve_workspace).
-        assert!(s.contains("quoted form of f"));
+        assert!(s.contains("quoted form of (POSIX path of f)"));
     }
 
     /// Opening a document means "show me this file", so the window starts with
@@ -222,6 +237,56 @@ mod tests {
         let (run, open) = s.split_once("on open theFiles").unwrap();
         assert!(open.contains("--zen"));
         assert!(!run.contains("--zen"));
+    }
+
+    /// Ghostty runs `--initial-command` through `/bin/sh -c`, and the outer
+    /// `do shell script` is a second shell: every path component must go
+    /// through AppleScript's `quoted form of` individually. Hand-rolled
+    /// single quotes died on an apostrophe in the workspace path, and a raw
+    /// binary path broke on spaces.
+    #[test]
+    fn an_apostrophe_in_a_path_survives_both_shell_layers() {
+        let s = launcher_script("/Users/v/my tools/croft", "/Users/v/Vitali's Docs");
+        assert!(
+            s.contains(r#"quoted form of "/Users/v/Vitali's Docs""#),
+            "the workspace dir must be quoted as its own component: {s}"
+        );
+        assert!(
+            s.contains(r#"quoted form of "/Users/v/my tools/croft""#),
+            "the binary path must be quoted as its own component: {s}"
+        );
+        assert!(
+            !s.contains("croft '"),
+            "no hand-rolled single quotes may remain: {s}"
+        );
+    }
+
+    /// A quote or backslash in a path must be escaped into the AppleScript
+    /// string literal, or `osacompile` fails after the old bundle was
+    /// already deleted.
+    #[test]
+    fn quotes_and_backslashes_cannot_break_the_applescript_source() {
+        let s = launcher_script("/Users/v/.cargo/bin/croft", r#"/Users/v/say "hi"\now"#);
+        assert!(
+            s.contains(r#""/Users/v/say \"hi\"\\now""#),
+            "the literal must escape quotes and backslashes: {s}"
+        );
+    }
+
+    /// Selecting several files in Finder (or dropping several on the Dock
+    /// icon) delivers them all in one `on open`; every one must open, not
+    /// just the first.
+    #[test]
+    fn every_dropped_file_opens_not_just_the_first() {
+        let s = launcher_script("/Users/v/.cargo/bin/croft", "/Users/v/Documents");
+        assert!(
+            s.contains("repeat with"),
+            "the open handler must loop over theFiles: {s}"
+        );
+        assert!(
+            !s.contains("item 1 of theFiles"),
+            "no file may be silently dropped: {s}"
+        );
     }
 
     #[test]

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -398,7 +398,12 @@ fn unique_temp_dir(stem: &str) -> std::io::Result<PathBuf> {
     static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let pid = std::process::id();
     let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let path = std::env::temp_dir().join(format!("{stem}-{pid}-{seq}"));
+    // Under croft's own cache dir, never the system temp dir: /tmp is
+    // world-writable on Linux, so a same-named leftover owned by another
+    // user would make the remove_dir_all below fail and the render with it.
+    let base = crate::session_state::dirs_cache_croft().join("tmp");
+    std::fs::create_dir_all(&base)?;
+    let path = base.join(format!("{stem}-{pid}-{seq}"));
     if path.exists() {
         std::fs::remove_dir_all(&path)?;
     }

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -59,7 +59,21 @@ pub struct ReleaseNote {
 }
 
 /// What shipped in the current release. Replace on every version bump.
-pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Fix,
-    summary: "Session and collab sockets are now bound owner-only without touching the process umask: the old save/restore dance raced concurrent binds, could leave a relay socket readable by other users, and could corrupt the process umask for good.",
-}];
+pub const RELEASE_NOTES: &[ReleaseNote] = &[
+    ReleaseNote {
+        kind: NoteKind::Fix,
+        summary: "The wheel over a PDF no longer freezes croft on a momentum flick (same-direction bursts coalesce) and stops at the first and last page instead of wrapping around.",
+    },
+    ReleaseNote {
+        kind: NoteKind::Fix,
+        summary: "A PDF rebuilt on disk shows its fresh render immediately: the preview re-bakes on content change, not just on a page or layout change.",
+    },
+    ReleaseNote {
+        kind: NoteKind::Fix,
+        summary: "Croft.app opens every file you selected in Finder, and paths with apostrophes, quotes or spaces survive the launcher's two shell layers.",
+    },
+    ReleaseNote {
+        kind: NoteKind::Fix,
+        summary: "Opening a file while the terminal is maximized restores the editor instead of typing into an invisible buffer, a right-click menu over an image survives on iTerm2 and Sixel, and End on a PDF with an unknown page count says so instead of failing on page 4294967295.",
+    },
+];

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -2726,6 +2726,13 @@ impl Editor {
         let Some(pdf) = self.image.as_ref().and_then(|i| i.pdf.clone()) else {
             return false;
         };
+        // "Last page" is unanswerable without a page count (sips-only Macs
+        // where mdls reports nothing): rendering the sentinel itself would
+        // just spray "PDF page 4294967295 failed" into the status bar.
+        if page == u32::MAX && pdf.page_count.is_none() {
+            self.status = String::from("PDF page count unknown; cannot jump to the last page");
+            return false;
+        }
         let last = pdf.page_count.unwrap_or(u32::MAX).max(1);
         self.render_pdf_page(page.clamp(1, last))
     }
@@ -11876,6 +11883,38 @@ mod tests {
             first, second,
             "a reload must stamp fresh content, or the baked overlay stays stale"
         );
+    }
+
+    /// End means "last page", which is unanswerable when the page count is
+    /// unknown (sips-only Macs where mdls reports nothing): the sentinel
+    /// must not be rendered literally, which sprayed
+    /// "PDF page 4294967295 failed" into the status bar.
+    #[test]
+    fn end_with_an_unknown_page_count_reports_instead_of_rendering_the_sentinel() {
+        let mut e = Editor::new();
+        e.image = Some(ImageView {
+            bytes: Vec::new(),
+            format_label: String::from("PDF"),
+            pixel_w: 1,
+            pixel_h: 1,
+            byte_size: 0,
+            generation: 0,
+            pdf: Some(PdfState {
+                source_path: PathBuf::from("/nonexistent/doc.pdf"),
+                current_page: 1,
+                page_count: None,
+                backend: crate::pdf::PdfBackend::SipsCli,
+                source_byte_size: 0,
+                links: None,
+            }),
+        });
+        assert!(!e.set_pdf_page(u32::MAX));
+        assert!(
+            !e.status.contains("4294967295"),
+            "the sentinel page must not leak into the status: {}",
+            e.status
+        );
+        assert_eq!(e.pdf_page(), Some(1), "the page must not move");
     }
 
     #[test]

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -39,10 +39,22 @@ pub struct ImageView {
     pub pixel_w: u32,
     pub pixel_h: u32,
     pub byte_size: u64,
+    /// Monotonic content stamp, fresh on every (re)load of the bytes. Part
+    /// of the overlay's re-emit key: a PDF rebuilt on disk reloads to the
+    /// same path, rect and page, and without this stamp the baked overlay
+    /// kept showing the pre-rebuild pixels until a page turn.
+    pub generation: u64,
     /// Set when this preview was rasterised from a PDF page; tracks the
     /// page-navigation state so re-renders on Page Down/Up know which
     /// page to ask the rasteriser for next.
     pub pdf: Option<PdfState>,
+}
+
+/// Next value for [`ImageView::generation`]: process-wide monotonic counter,
+/// bumped on every byte (re)load anywhere.
+fn next_image_generation() -> u64 {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -2602,6 +2614,7 @@ impl Editor {
             pixel_w,
             pixel_h,
             byte_size: meta.len(),
+            generation: next_image_generation(),
             pdf: None,
         });
         self.sheet = None;
@@ -2662,6 +2675,7 @@ impl Editor {
             pixel_w,
             pixel_h,
             byte_size: meta.len(),
+            generation: next_image_generation(),
             pdf: Some(PdfState {
                 source_path: path.to_path_buf(),
                 current_page: 1,
@@ -2738,6 +2752,7 @@ impl Editor {
             Err(_) => return false,
         };
         image.bytes = bytes;
+        image.generation = next_image_generation();
         image.pixel_w = pixel_w;
         image.pixel_h = pixel_h;
         if let Some(state) = image.pdf.as_mut() {
@@ -11836,6 +11851,31 @@ mod tests {
         assert!(e.path.is_some());
         assert!(e.lang.is_none());
         assert!(!e.dirty);
+    }
+
+    /// A file rebuilt on disk reloads to the same path (and, for a PDF, the
+    /// same page and rect) - the overlay's re-emit key tells the loads apart
+    /// only through the content generation, so every reload must stamp a
+    /// fresh one even when the bytes happen to be identical.
+    #[test]
+    fn a_reloaded_image_carries_a_fresh_generation() {
+        let img: image::RgbaImage = image::ImageBuffer::from_pixel(1, 1, image::Rgba([0, 0, 0, 0]));
+        let mut buf: Vec<u8> = Vec::new();
+        image::DynamicImage::ImageRgba8(img)
+            .write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pic.png");
+        std::fs::write(&path, &buf).unwrap();
+        let mut e = Editor::new();
+        e.open(&path).unwrap();
+        let first = e.image.as_ref().unwrap().generation;
+        e.open(&path).unwrap();
+        let second = e.image.as_ref().unwrap().generation;
+        assert_ne!(
+            first, second,
+            "a reload must stamp fresh content, or the baked overlay stays stale"
+        );
     }
 
     #[test]


### PR DESCRIPTION
An adversarial review of the twelve-commit Finder/explorer span (99eadc7..b66a51f, judged against current HEAD) produced eight findings; six are fixed here RED-test-first and two were refuted against the source.

Fixed:
- Croft.app launcher: every path component now crosses both shell layers ("do shell script", then Ghostty's /bin/sh -c) through its own "quoted form of", paths are escaped into the AppleScript literals, and "on open" loops over every selected/dropped file instead of silently keeping only the first.
- PDF wheel: same-direction momentum bursts coalesce (each page step is a synchronous rasteriser run on the UI thread; a flick used to queue 10-30 of them), and the wheel clamps at the document ends instead of wrapping (arrow-key wrap stays).
- A PDF rebuilt on disk re-bakes its preview: the overlay re-emit key gains a content generation, so an unchanged path/rect/page no longer pins the pre-rebuild pixels.
- Opening a file while the terminal is maximized restores the editor (VS Code's convention) instead of moving focus into a zero-height pane where typing dirtied an invisible buffer.
- On iTerm2/Sixel (no image z-layer) an open context menu overlapping the editor preview suppresses the image blit that overpainted it; Kitty keeps its deep-negative z path.
- Minors: End on a PDF with an unknown page count reports honestly instead of rendering page 4294967295, and the render scratch dir moves out of shared /tmp into croft's own cache dir.

Refuted (no change):
- "Caret paints a hint-width left of a click on the anchor char": the caret-before-hint painting is deliberate VS Code affinity, documented and pinned by cursor_screen_pos_shifts_past_inlay_hints.
- "Inlay click inversion wrong on wrapped rows": impossible scenario; row_inlay_spans returns empty whenever wrap is enabled, so hints are never rendered in wrap mode and the inversion degrades to the identity.

Full suite: 2765 + 5 CLI tests, 0 failed, clippy zero warnings. Ships as 0.1.656.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF wheel navigation with smoother, throttled paging that stops at document boundaries.
  * Fixed PDF and image previews refreshing reliably after content or page changes.
  * Prevented image overlays from appearing beneath context menus.
  * Restored maximized terminals when returning to the editor.
  * Improved handling of unknown PDF page counts.
  * Fixed launching multiple files from Finder, including paths with spaces and special characters.
  * Stored temporary PDF files in the application cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
