### PR TITLE
fix: resolve the adversarial-review findings on the pair/navigator span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.656"
+version = "0.1.657"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.656"
+version = "0.1.657"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/MULTIPLAYER.md
+++ b/docs/MULTIPLAYER.md
@@ -542,8 +542,12 @@ interaction into turn-based driver/navigator pairing:
 - **Proactive looks (0.1.640).** The navigator re-engages on its own as
   the driver works: when tree-sitter sees a NEW completed construct in the
   active file (an outline symbol for code — a half-typed `fn foo(` parses
-  as an error and never fires — or a new heading / added paragraph in
-  markdown, `src/pair/proactive.rs`) and typing pauses for 2s, the App
+  as an error and never fires, and member-level symbols like a struct
+  field or enum variant count as edits inside their construct, not
+  constructs — or a new heading / purely added top-level paragraph in
+  markdown: list bullets and block quotes are not paragraphs, and a
+  paragraph split in two is a reshape, `src/pair/proactive.rs`) and
+  typing pauses for 2s, the App
   hands it the same comment-only yield turn `Cmd+K Y` would, anchored at
   the new construct. Only files the navigator has already looked at
   re-engage it (re-engagement, not ambush); one buffer state is scanned at

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16260,9 +16260,9 @@ impl App {
             .editor
             .comment_focus
             .as_ref()
-            .and_then(|f| notes.iter().find(|(id, ..)| *id == f.id))
-            .map(|(_, row, _)| *row)
-            .unwrap_or(self.editor.cursor_row);
+            .and_then(|f| notes.iter().position(|(id, ..)| *id == f.id))
+            .map(|i| (notes[i].1, i))
+            .unwrap_or((self.editor.cursor_row, usize::MAX));
         let idx = next_note_by_row(notes, here);
         Some((notes[idx].0, notes[idx].1))
     }
@@ -29744,17 +29744,25 @@ fn is_extensions_jump_key(key: KeyEvent) -> bool {
     is_cmd_shift_letter(key, 'x')
 }
 
-/// Index of the next navigator note to visit from caret row `here`: the note
-/// with the smallest row strictly greater than `here`, wrapping to the
-/// smallest row overall. `notes` are in landing (stream) order, not row
-/// order, so a naive `position(row > here)` would skip notes and could stick.
-fn next_note_by_row(notes: &[(u64, usize, String)], here: usize) -> usize {
+/// Index of the next navigator note to visit from `here` = (row, index of
+/// the currently focused note, or `usize::MAX` when the walk starts from a
+/// bare caret row): the note with the smallest (row, index) strictly greater
+/// than `here`, wrapping to the smallest overall. The index tie-break makes
+/// every note on a shared row reachable - the reply flow anchors the
+/// navigator's answer on the answered note's own row, and a row-only walk
+/// could never step from the first co-anchored note to the second.
+fn next_note_by_row(notes: &[(u64, usize, String)], here: (usize, usize)) -> usize {
     notes
         .iter()
         .enumerate()
-        .filter(|(_, (_, row, _))| *row > here)
-        .min_by_key(|(_, (_, row, _))| *row)
-        .or_else(|| notes.iter().enumerate().min_by_key(|(_, (_, row, _))| *row))
+        .filter(|(i, (_, row, _))| (*row, *i) > here)
+        .min_by_key(|(i, (_, row, _))| (*row, *i))
+        .or_else(|| {
+            notes
+                .iter()
+                .enumerate()
+                .min_by_key(|(i, (_, row, _))| (*row, *i))
+        })
         .map(|(i, _)| i)
         .unwrap_or(0)
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16022,8 +16022,27 @@ impl App {
                         // where it last commented). A file that is not live
                         // any more falls back to the OUTPUT channel rather
                         // than losing the navigator's words.
-                        let anchor =
-                            origin.or_else(|| file.clone().map(|f| (f, self.editor.cursor_row)));
+                        let anchor = origin.or_else(|| {
+                            file.clone().map(|f| {
+                                // The caret row only means something in the
+                                // file it is in: pairing the last-noted
+                                // file with the ACTIVE tab's cursor row
+                                // anchored the box at an unrelated line.
+                                // Any other file clamps to its end.
+                                let same = self
+                                    .editor
+                                    .path
+                                    .as_ref()
+                                    .and_then(|p| collab_file_key(&self.tree.root, p))
+                                    .is_some_and(|active| active == f);
+                                let row = if same {
+                                    self.editor.cursor_row
+                                } else {
+                                    usize::MAX
+                                };
+                                (f, row)
+                            })
+                        });
                         let landed = anchor.as_ref().and_then(|(f, row)| {
                             self.pair_host
                                 .as_ref()
@@ -16200,9 +16219,12 @@ impl App {
             return;
         };
         let content = self.editor.lines.join("\n");
-        host.append_to_note(focus.id, &format!("you: {reply}"));
         match host.send_reply_turn(&file, row, &note_body, &reply, &content) {
             Ok(()) => {
+                // Only after the send: a failed send keeps the draft for a
+                // retry, and appending first would duplicate the reply in
+                // the box on every attempt.
+                host.append_to_note(focus.id, &format!("you: {reply}"));
                 self.pair_turn_origin = Some((file, row));
                 self.status = format!("Replied to {}", host.name());
                 self.editor.comment_focus = None;
@@ -26941,6 +26963,10 @@ impl App {
         self.pair_host_lock_path = crate::session::pair_host_lock_path(&new_root);
         self.navigator_down = false; // the death latch belonged to the old root
         self.last_pair_check = None; // read the new record this tick, not in 1s
+        // Old-workspace carets are keyed by root-relative file, so a
+        // same-named file under the new root would wear a departed peer's
+        // caret. The live session repopulates its own on the next poll.
+        self.collab_carets.clear();
         self.status = if shell_synced {
             format!("Workspace root: {display}")
         } else {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19744,10 +19744,46 @@ fn next_note_by_row_walks_rows_in_order_and_wraps() {
     // From the top: nearest row strictly greater.
     assert_eq!(notes[super::next_note_by_row(&notes, (0, usize::MAX))].1, 2);
     assert_eq!(notes[super::next_note_by_row(&notes, (2, usize::MAX))].1, 6);
-    assert_eq!(notes[super::next_note_by_row(&notes, (6, usize::MAX))].1, 10);
+    assert_eq!(
+        notes[super::next_note_by_row(&notes, (6, usize::MAX))].1,
+        10
+    );
     // Past the last note: wrap to the smallest row (not stick on row 10).
-    assert_eq!(notes[super::next_note_by_row(&notes, (10, usize::MAX))].1, 2);
-    assert_eq!(notes[super::next_note_by_row(&notes, (99, usize::MAX))].1, 2);
+    assert_eq!(
+        notes[super::next_note_by_row(&notes, (10, usize::MAX))].1,
+        2
+    );
+    assert_eq!(
+        notes[super::next_note_by_row(&notes, (99, usize::MAX))].1,
+        2
+    );
+}
+
+/// Collab carets are keyed by root-relative file paths: after a re-root, a
+/// same-named file under the new root would wear a departed peer's caret
+/// from the old workspace. Re-rooting clears them; a live session
+/// repopulates its own on the next poll.
+#[test]
+fn changing_the_workspace_root_drops_stale_collab_carets() {
+    let tmp = tempfile::tempdir().unwrap();
+    let inner = tmp.path().join("inner");
+    std::fs::create_dir_all(&inner).unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.collab_carets.insert(
+        7,
+        CollabCaret {
+            file: String::from("src/main.rs"),
+            row: 3,
+            col: 1,
+            name: String::from("guest"),
+            last_moved: std::time::Instant::now(),
+        },
+    );
+    app.change_workspace_root(inner);
+    assert!(
+        app.collab_carets.is_empty(),
+        "old-workspace carets must not survive a re-root"
+    );
 }
 
 /// Replying anchors the navigator's answer on the answered note's own row,
@@ -19981,11 +20017,21 @@ fn cmd_k_y_yields_the_active_file_and_commentary_reaches_output() {
         std::thread::sleep(Duration::from_millis(10));
     }
     // The fake's "Reviewing." commentary flows to the Navigator channel.
+    // OUTPUT is process-global, so only lines past this test's own baseline
+    // count: a sibling test's residue on the same channel must not be able
+    // to satisfy the wait.
+    let baseline = crate::output::snapshot("Navigator")
+        .unwrap_or_default()
+        .len();
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         app.poll_pair();
         let lines = crate::output::snapshot("Navigator").unwrap_or_default();
-        if lines.iter().any(|l| l.text.contains("Reviewing.")) {
+        if lines
+            .iter()
+            .skip(baseline)
+            .any(|l| l.text.contains("Reviewing."))
+        {
             break;
         }
         assert!(

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19742,12 +19742,30 @@ fn next_note_by_row_walks_rows_in_order_and_wraps() {
         (3u64, 6usize, String::from("mid")),
     ];
     // From the top: nearest row strictly greater.
-    assert_eq!(notes[super::next_note_by_row(&notes, 0)].1, 2);
-    assert_eq!(notes[super::next_note_by_row(&notes, 2)].1, 6);
-    assert_eq!(notes[super::next_note_by_row(&notes, 6)].1, 10);
+    assert_eq!(notes[super::next_note_by_row(&notes, (0, usize::MAX))].1, 2);
+    assert_eq!(notes[super::next_note_by_row(&notes, (2, usize::MAX))].1, 6);
+    assert_eq!(notes[super::next_note_by_row(&notes, (6, usize::MAX))].1, 10);
     // Past the last note: wrap to the smallest row (not stick on row 10).
-    assert_eq!(notes[super::next_note_by_row(&notes, 10)].1, 2);
-    assert_eq!(notes[super::next_note_by_row(&notes, 99)].1, 2);
+    assert_eq!(notes[super::next_note_by_row(&notes, (10, usize::MAX))].1, 2);
+    assert_eq!(notes[super::next_note_by_row(&notes, (99, usize::MAX))].1, 2);
+}
+
+/// Replying anchors the navigator's answer on the answered note's own row,
+/// so two notes on one row is the NORMAL state after one reply. The index
+/// tie-break must step through both and wrap - a row-only walk went
+/// first-note → first-note forever and the answer was unreachable by F4.
+#[test]
+fn next_note_by_row_steps_through_co_anchored_notes() {
+    let notes = vec![
+        (1u64, 5usize, String::from("original")),
+        (2u64, 5usize, String::from("answer")),
+    ];
+    // Focused on the first note at row 5: F4 reaches its co-anchored answer.
+    assert_eq!(super::next_note_by_row(&notes, (5, 0)), 1);
+    // Focused on the answer: F4 wraps back to the first.
+    assert_eq!(super::next_note_by_row(&notes, (5, 1)), 0);
+    // From a bare caret on that row, neither is "past" it: wrap to first.
+    assert_eq!(super::next_note_by_row(&notes, (5, usize::MAX)), 0);
 }
 
 /// Only one croft self-appoints the navigator owner per workspace: a second

--- a/src/pair/proactive.rs
+++ b/src/pair/proactive.rs
@@ -133,9 +133,18 @@ fn markdown_new_row(old: &str, new: &str) -> Option<usize> {
     {
         return None;
     }
+    // Anchor at the ADDED occurrence, not merely a hash whose global count
+    // grew: for a paragraph duplicating earlier prose the global check is
+    // true at the first copy too, and anchoring there scoped the look to
+    // unrelated earlier text. The running count singles out the new copy.
+    let mut running: HashMap<u64, usize> = HashMap::new();
     new_paras
         .iter()
-        .find(|(h, _)| new_counts[h] > old_counts.get(h).copied().unwrap_or(0))
+        .find(|(h, _)| {
+            let seen = running.entry(*h).or_default();
+            *seen += 1;
+            *seen > old_counts.get(h).copied().unwrap_or(0)
+        })
         .or(new_paras.last())
         .map(|(_, r)| *r)
 }
@@ -296,6 +305,17 @@ mod tests {
         // A genuinely new paragraph with the old ones intact still fires.
         let added = "alpha beta gamma delta.\n\nfresh thought.\n";
         assert_eq!(new_construct_row(LangKind::Markdown, old, added), Some(2));
+    }
+
+    /// Appending a paragraph whose text duplicates earlier prose must
+    /// anchor at the NEW copy: a global-count check is true at the first
+    /// occurrence too, and anchoring there scoped the navigator's look to
+    /// unrelated earlier text.
+    #[test]
+    fn a_duplicated_paragraph_anchors_at_the_new_copy() {
+        let old = "repeat paragraph.\n\nother paragraph.\n";
+        let dup = "repeat paragraph.\n\nother paragraph.\n\nrepeat paragraph.\n";
+        assert_eq!(new_construct_row(LangKind::Markdown, old, dup), Some(4));
     }
 
     #[test]

--- a/src/pair/proactive.rs
+++ b/src/pair/proactive.rs
@@ -21,6 +21,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use tree_sitter::Parser;
 
 use crate::highlight::LangKind;
+use crate::lsp::manager::{OutlineKind, OutlineSymbol};
 use crate::outline_syntax::symbols_for;
 
 /// The 0-based row of a construct present in `new` but not in `old` (the
@@ -40,11 +41,27 @@ pub fn new_construct_row(kind: LangKind, old: &str, new: &str) -> Option<usize> 
 /// likely just typed. The population must GROW: a rename swaps one key
 /// for another without adding anything, and is an edit, not a construct.
 fn code_new_row(kind: LangKind, old: &str, new: &str) -> Option<usize> {
-    let fresh = symbols_for(kind, new.as_bytes());
+    // Member-level symbols (a struct field, an enum variant, an object key)
+    // are edits INSIDE a construct, not completed constructs: typing one
+    // `label: String,` into an existing struct must not summon the
+    // navigator. The outline keeps them; only this trigger filters.
+    fn construct(s: &OutlineSymbol) -> bool {
+        !matches!(
+            s.kind,
+            OutlineKind::Field | OutlineKind::EnumMember | OutlineKind::Property | OutlineKind::Key
+        )
+    }
+    let fresh: Vec<OutlineSymbol> = symbols_for(kind, new.as_bytes())
+        .into_iter()
+        .filter(construct)
+        .collect();
     if fresh.is_empty() {
         return None; // no outline query for this language, or nothing parsed
     }
-    let old_syms = symbols_for(kind, old.as_bytes());
+    let old_syms: Vec<OutlineSymbol> = symbols_for(kind, old.as_bytes())
+        .into_iter()
+        .filter(construct)
+        .collect();
     if fresh.len() <= old_syms.len() {
         return None; // nothing added — at most edits, moves, or renames
     }
@@ -98,10 +115,27 @@ fn markdown_new_row(old: &str, new: &str) -> Option<usize> {
     if new_paras.len() <= old_paras.len() {
         return None;
     }
-    let old_hashes: std::collections::HashSet<u64> = old_paras.iter().map(|(h, _)| *h).collect();
+    // Pure addition only: every old paragraph must survive intact. A split
+    // grows the count but destroys the original's hash - that is a reshape
+    // of existing prose (the module contract: reshapes never fire), and
+    // firing would anchor at the wrong half anyway.
+    let mut new_counts: HashMap<u64, usize> = HashMap::new();
+    for (h, _) in &new_paras {
+        *new_counts.entry(*h).or_default() += 1;
+    }
+    let mut old_counts: HashMap<u64, usize> = HashMap::new();
+    for (h, _) in &old_paras {
+        *old_counts.entry(*h).or_default() += 1;
+    }
+    if old_counts
+        .iter()
+        .any(|(h, n)| new_counts.get(h).copied().unwrap_or(0) < *n)
+    {
+        return None;
+    }
     new_paras
         .iter()
-        .find(|(h, _)| !old_hashes.contains(h))
+        .find(|(h, _)| new_counts[h] > old_counts.get(h).copied().unwrap_or(0))
         .or(new_paras.last())
         .map(|(_, r)| *r)
 }
@@ -127,6 +161,13 @@ fn markdown_scan(src: &str) -> (Headings, Paragraphs) {
     let mut paras = Vec::new();
     let mut stack = vec![tree.root_node()];
     while let Some(node) = stack.pop() {
+        // A list bullet and a block-quote line each wrap their text in a
+        // `paragraph` node in tree-sitter-md; those are not prose
+        // paragraphs (a TODO list must not read as one new paragraph per
+        // bullet), so their subtrees are not walked at all.
+        if matches!(node.kind(), "list" | "block_quote") {
+            continue;
+        }
         match node.kind() {
             "atx_heading" | "setext_heading" => {
                 let text = node
@@ -214,6 +255,47 @@ mod tests {
             new_construct_row(LangKind::Markdown, old_md, reworded),
             None
         );
+    }
+
+    /// A struct field or enum variant is an edit INSIDE a construct, not a
+    /// completed construct: typing one `label: String,` into an existing
+    /// struct must not summon the navigator.
+    #[test]
+    fn a_single_member_addition_is_an_edit_not_a_construct() {
+        let old = "struct S {\n    a: u32,\n}\n";
+        let field = "struct S {\n    a: u32,\n    label: String,\n}\n";
+        assert_eq!(new_construct_row(LangKind::Rust, old, field), None);
+        let old_e = "enum E {\n    A,\n}\n";
+        let variant = "enum E {\n    A,\n    B,\n}\n";
+        assert_eq!(new_construct_row(LangKind::Rust, old_e, variant), None);
+        // A whole new struct still fires.
+        let grown = "struct S {\n    a: u32,\n}\n\nstruct T {\n    b: u32,\n}\n";
+        assert_eq!(new_construct_row(LangKind::Rust, old, grown), Some(4));
+    }
+
+    /// tree-sitter-md wraps every list bullet and block-quote line in a
+    /// `paragraph` node: those are not prose paragraphs, and writing a TODO
+    /// list must not fire one unsolicited turn per bullet.
+    #[test]
+    fn a_list_bullet_is_not_a_new_paragraph() {
+        let old = "intro prose.\n\n- one\n- two\n";
+        let bullet = "intro prose.\n\n- one\n- two\n- three\n";
+        assert_eq!(new_construct_row(LangKind::Markdown, old, bullet), None);
+        let quote = "intro prose.\n\n- one\n- two\n\n> quoted line\n";
+        assert_eq!(new_construct_row(LangKind::Markdown, old, quote), None);
+    }
+
+    /// Splitting one paragraph in two reshapes existing prose (the module
+    /// contract: reshapes must never fire) - both halves are new hashes but
+    /// the original hash disappeared, so it is not a pure addition.
+    #[test]
+    fn splitting_a_paragraph_is_a_reshape_not_an_addition() {
+        let old = "alpha beta gamma delta.\n";
+        let split = "alpha beta.\n\ngamma delta.\n";
+        assert_eq!(new_construct_row(LangKind::Markdown, old, split), None);
+        // A genuinely new paragraph with the old ones intact still fires.
+        let added = "alpha beta gamma delta.\n\nfresh thought.\n";
+        assert_eq!(new_construct_row(LangKind::Markdown, old, added), Some(2));
     }
 
     #[test]

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -62,18 +62,18 @@ pub struct ReleaseNote {
 pub const RELEASE_NOTES: &[ReleaseNote] = &[
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "The wheel over a PDF no longer freezes croft on a momentum flick (same-direction bursts coalesce) and stops at the first and last page instead of wrapping around.",
+        summary: "Navigator comment boxes taller than the window are fully readable: non-wrap scrolling steps into and past a box, the scrollbar is live and accurate with boxes on screen, and a long reply windows around the caret instead of going blind.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "A PDF rebuilt on disk shows its fresh render immediately: the preview re-bakes on content change, not just on a page or layout change.",
+        summary: "F4 reaches every comment, including the navigator's answer anchored on the same line as the note you replied to.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "Croft.app opens every file you selected in Finder, and paths with apostrophes, quotes or spaces survive the launcher's two shell layers.",
+        summary: "Proactive navigator looks stop over-firing: list bullets, block quotes, paragraph splits, and single struct fields or enum variants no longer summon an unsolicited comment turn.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "Opening a file while the terminal is maximized restores the editor instead of typing into an invisible buffer, a right-click menu over an image survives on iTerm2 and Sixel, and End on a PDF with an unknown page count says so instead of failing on page 4294967295.",
+        summary: "A failed reply no longer duplicates your text in the box, commentary anchors only in its own file, and changing the workspace root drops the old workspace's collaborator carets.",
     },
 ];

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -5646,12 +5646,15 @@ impl Editor {
             self.wrap_set_top(scrollbar::scroll_for_y(metrics, y));
             return true;
         }
-        let Some(metrics) = scrollbar::vertical_metrics(
-            self.last_scrollbar,
-            self.lines.len(),
-            viewport,
-            self.scroll,
-        ) else {
+        // Same content length the render sized the bar with: lines plus
+        // comment-box rows. Mapping through bare `lines.len()` made the bar
+        // of a short file with a tall navigator comment dead (metrics said
+        // "no overflow") and a long file's thumb run away from the pointer.
+        let bw = self.visible_text_width();
+        let content = self.lines.len() + self.box_rows_between(0, self.lines.len(), bw);
+        let Some(metrics) =
+            scrollbar::vertical_metrics(self.last_scrollbar, content, viewport, self.scroll)
+        else {
             return false;
         };
         self.scroll_view_to(scrollbar::scroll_for_y(metrics, y));
@@ -11882,6 +11885,38 @@ mod tests {
         assert_ne!(
             first, second,
             "a reload must stamp fresh content, or the baked overlay stays stale"
+        );
+    }
+
+    /// The scrollbar is drawn against `lines + comment-box rows`, so the
+    /// drag must map through the same content length. Mapping through bare
+    /// `lines.len()` made the bar of a short file with a tall navigator
+    /// comment completely dead (metrics said "no overflow"), and made a
+    /// long file's thumb run away from the pointer.
+    #[test]
+    fn dragging_the_scrollbar_of_a_file_with_a_comment_box_scrolls() {
+        let mut e = editor_with("a\nb\nc\nd\ne");
+        e.comment_boxes.push(CommentBox {
+            id: 1,
+            line: 1,
+            author: String::from("navigator"),
+            body: (0..20).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n"),
+        });
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 10,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e as &mut Editor).render(area, &mut buf);
+        assert!(
+            e.last_scrollbar.width > 0,
+            "the box overflows the viewport, so a bar must be drawn"
+        );
+        assert!(
+            e.scroll_to_bar_y(e.last_scrollbar.y + e.last_scrollbar.height / 2),
+            "a drag on the drawn bar must scroll, not be refused as no-overflow"
         );
     }
 

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -5618,8 +5618,10 @@ impl Editor {
         if self.wrap_enabled() {
             let top = self.top_visual_row(self.visible_text_width());
             self.wrap_set_top(top.saturating_sub(n));
-        } else {
+        } else if self.comment_boxes.is_empty() {
             self.scroll_view_to(self.scroll.saturating_sub(n));
+        } else {
+            self.nonwrap_set_top(self.nonwrap_top_content_row().saturating_sub(n));
         }
     }
 
@@ -5633,8 +5635,10 @@ impl Editor {
         if self.wrap_enabled() {
             let top = self.top_visual_row(self.visible_text_width());
             self.wrap_set_top(top.saturating_add(n));
-        } else {
+        } else if self.comment_boxes.is_empty() {
             self.scroll_view_to(self.scroll.saturating_add(n));
+        } else {
+            self.nonwrap_set_top(self.nonwrap_top_content_row().saturating_add(n));
         }
     }
 
@@ -5660,12 +5664,15 @@ impl Editor {
         // "no overflow") and a long file's thumb run away from the pointer.
         let bw = self.visible_text_width();
         let content = self.lines.len() + self.box_rows_between(0, self.lines.len(), bw);
-        let Some(metrics) =
-            scrollbar::vertical_metrics(self.last_scrollbar, content, viewport, self.scroll)
-        else {
+        let Some(metrics) = scrollbar::vertical_metrics(
+            self.last_scrollbar,
+            content,
+            viewport,
+            self.nonwrap_top_content_row(),
+        ) else {
             return false;
         };
-        self.scroll_view_to(scrollbar::scroll_for_y(metrics, y));
+        self.nonwrap_set_top(scrollbar::scroll_for_y(metrics, y));
         true
     }
 
@@ -5796,6 +5803,56 @@ impl Editor {
             }
         }
         buf
+    }
+
+    /// The non-wrap viewport top in CONTENT rows: buffer lines plus the
+    /// comment-box rows above (and inside, via `scroll_sub`) the top line.
+    fn nonwrap_top_content_row(&self) -> usize {
+        let bw = self.visible_text_width();
+        self.scroll + self.box_rows_between(0, self.scroll, bw) + self.scroll_sub
+    }
+
+    /// Set the non-wrap viewport top to content row `row`, landing mid-box
+    /// when it falls inside a comment box (`scroll_sub` counts rows past
+    /// the top line's own text row). Mirrors `wrap_set_top` for the
+    /// box-extended non-wrap layout; a tall box is unreadable and its
+    /// Reply/Ignore footer unreachable with a line-granular top. Pulls the
+    /// cursor along like `scroll_view_to`.
+    fn nonwrap_set_top(&mut self, row: usize) {
+        let viewport = self.text_rows();
+        if viewport == 0 || self.lines.is_empty() {
+            self.scroll = 0;
+            self.scroll_sub = 0;
+            return;
+        }
+        if self.comment_boxes.is_empty() {
+            self.scroll_sub = 0;
+            self.scroll_view_to(row);
+            return;
+        }
+        let bw = self.visible_text_width();
+        let total = self.lines.len() + self.box_rows_between(0, self.lines.len(), bw);
+        let row = row.min(total.saturating_sub(viewport));
+        let mut acc = 0usize;
+        let mut line = 0usize;
+        while line < self.lines.len() {
+            let group = 1 + self.box_rows_between(line, line + 1, bw);
+            if acc + group > row {
+                break;
+            }
+            acc += group;
+            line += 1;
+        }
+        self.scroll = line.min(self.lines.len().saturating_sub(1));
+        self.scroll_sub = row.saturating_sub(acc);
+        let last_visible = (self.scroll + viewport - 1).min(self.lines.len().saturating_sub(1));
+        if self.cursor_row < self.scroll {
+            self.cursor_row = self.scroll;
+        } else if self.cursor_row > last_visible {
+            self.cursor_row = last_visible;
+        }
+        self.cursor_col = self.cursor_col.min(self.line_char_len(self.cursor_row));
+        self.last_edit_kind = None;
     }
 
     fn scroll_view_to(&mut self, top: usize) {
@@ -6700,7 +6757,17 @@ impl Widget for &mut Editor {
             );
             (tw as u16, metrics)
         } else {
-            self.scroll_sub = 0;
+            // `scroll_sub` counts rows INTO the top line's comment box (set
+            // by the content-row scroller); clamp it to the group and drop
+            // it entirely when a cursor clamp below moves the top line.
+            if self.comment_boxes.is_empty() {
+                self.scroll_sub = 0;
+            } else {
+                let bw = inner.width.saturating_sub(gutter_width + 3) as usize;
+                let group = 1 + self.box_rows_between(self.scroll, self.scroll + 1, bw);
+                self.scroll_sub = self.scroll_sub.min(group - 1);
+            }
+            let scroll_before = self.scroll;
             if text_height > 0 {
                 if self.cursor_row < self.scroll {
                     self.scroll = self.cursor_row;
@@ -6721,15 +6788,18 @@ impl Widget for &mut Editor {
                     }
                 }
             }
-            let box_rows = {
-                let bw = inner.width.saturating_sub(gutter_width + 3) as usize;
-                self.box_rows_between(0, self.lines.len(), bw)
-            };
+            if self.scroll != scroll_before {
+                self.scroll_sub = 0;
+            }
+            let bw = inner.width.saturating_sub(gutter_width + 3) as usize;
+            let box_rows = self.box_rows_between(0, self.lines.len(), bw);
             let metrics = scrollbar::vertical_metrics(
                 scrollbar_area,
                 self.lines.len() + box_rows,
                 text_height,
-                self.scroll,
+                // Content-row top: lines above plus box rows above plus the
+                // rows scrolled into the top line's own box.
+                self.scroll + self.box_rows_between(0, self.scroll, bw) + self.scroll_sub,
             );
             let sw = u16::from(metrics.is_some());
             let tw = inner.width.saturating_sub(gutter_width + 2 + sw);
@@ -6823,14 +6893,21 @@ impl Widget for &mut Editor {
             // skipping any hidden inside a collapsed fold.
             let tw = text_width as usize;
             let mut line = self.scroll;
+            // Group-position skip on the top line: 0 = its text row, 1..
+            // = rows into its comment box, so the viewport can start
+            // mid-box exactly like the wrap path.
+            let mut skip = self.scroll_sub;
             while line < self.lines.len() && visual_rows.len() < text_height {
                 if !self.is_line_hidden(line) {
-                    visual_rows.push(VisRow::Text {
-                        line,
-                        start: self.scroll_col,
-                        end: self.scroll_col + text_width as usize,
-                    });
-                    push_box_rows(&mut visual_rows, self, line, 0, 1, tw);
+                    if skip == 0 && visual_rows.len() < text_height {
+                        visual_rows.push(VisRow::Text {
+                            line,
+                            start: self.scroll_col,
+                            end: self.scroll_col + text_width as usize,
+                        });
+                    }
+                    push_box_rows(&mut visual_rows, self, line, skip, 1, tw);
+                    skip = 0;
                 }
                 line += 1;
             }
@@ -10072,6 +10149,57 @@ mod tests {
         assert_eq!(e.cursor_row, 1, "the caret skips the box");
         e.move_up();
         assert_eq!(e.cursor_row, 0);
+    }
+
+    /// A comment box taller than the viewport must be reachable in non-wrap
+    /// mode: scrolling used to be line-granular (a 3-line file cannot
+    /// scroll at all), so a tall box was truncated at the viewport edge and
+    /// its footer - the Reply field and ✕ Ignore - could never be seen.
+    #[test]
+    fn nonwrap_scrolling_reaches_a_tall_comment_boxes_footer() {
+        let mut e = editor_with("first\nsecond\nthird");
+        e.comment_boxes = vec![CommentBox {
+            id: 1,
+            line: 0,
+            author: "navigator".into(),
+            body: (0..30)
+                .map(|i| format!("point {i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }];
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 10,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e as &mut Editor).render(area, &mut buf);
+        let screen = |buf: &ratatui::buffer::Buffer| -> String {
+            (0..area.height)
+                .map(|y| {
+                    (0..area.width)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        assert!(
+            !screen(&buf).contains("Ignore"),
+            "the tall box overflows: its footer starts off-screen"
+        );
+        // Scroll far enough that the footer row must be inside the viewport.
+        for _ in 0..12 {
+            e.scroll_down(3);
+        }
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e as &mut Editor).render(area, &mut buf);
+        assert!(
+            screen(&buf).contains("Ignore"),
+            "scrolling must reach the box footer; got:\n{}",
+            screen(&buf)
+        );
     }
 
     /// A reply longer than the footer field must window around the caret:

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -2149,7 +2149,12 @@ impl Editor {
         (0..self.comment_boxes.len())
             .filter(|&i| {
                 let l = self.comment_boxes[i].line;
-                l >= from && l < to
+                // A box on a line hidden inside a collapsed fold is never
+                // painted (the layout skips hidden lines wholesale), so it
+                // must not count toward any scroll geometry either - it
+                // kept a scrollbar alive for invisible content and let the
+                // wheel walk the viewport into blank space.
+                l >= from && l < to && !self.is_line_hidden(l)
             })
             .map(|i| self.comment_box_height(i, tw))
             .sum()
@@ -10149,6 +10154,46 @@ mod tests {
         assert_eq!(e.cursor_row, 1, "the caret skips the box");
         e.move_up();
         assert_eq!(e.cursor_row, 0);
+    }
+
+    /// A comment box on a line hidden inside a collapsed fold is never
+    /// painted, so it must not count toward the scroll extent either: it
+    /// used to inflate the content length, keeping a scrollbar alive for
+    /// invisible content and letting the wheel scroll into blank space.
+    #[test]
+    fn a_box_hidden_by_a_fold_does_not_extend_the_scroll_geometry() {
+        let mut e = editor_with("fn a() {\n    body();\n}\nlast");
+        e.comment_boxes = vec![CommentBox {
+            id: 1,
+            line: 1,
+            author: "navigator".into(),
+            body: (0..20)
+                .map(|i| format!("p{i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }];
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 10,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e as &mut Editor).render(area, &mut buf);
+        e.toggle_fold(0);
+        assert!(e.is_line_hidden(1), "the box's line folds away");
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e as &mut Editor).render(area, &mut buf);
+        assert_eq!(
+            e.last_scrollbar.width, 0,
+            "4 lines minus a fold fit the viewport; nothing left to scroll"
+        );
+        e.scroll_down(3);
+        assert_eq!(
+            (e.scroll, e.scroll_sub),
+            (0, 0),
+            "scrolling must not walk into folded-away box rows"
+        );
     }
 
     /// A comment box taller than the viewport must be reachable in non-wrap

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -2216,8 +2216,15 @@ impl Editor {
             // Footer: `╰ ❯ <reply>            ✕ Ignore ╯`
             let focus = self.comment_focus.as_ref().filter(|f| f.id == b.id);
             let field_w = w.saturating_sub(4 + IGNORE_TAIL_COLS);
+            // Window the draft around the caret: a reply longer than the
+            // field otherwise froze at its first field_w chars and the
+            // user typed blind, with no caret drawn anywhere.
+            let win = focus.map_or(0, |f| f.cursor.saturating_sub(field_w.saturating_sub(1)));
             let (draft, style) = match focus {
-                Some(f) => (pad(&f.reply, field_w), body_st),
+                Some(f) => {
+                    let visible: String = f.reply.chars().skip(win).take(field_w).collect();
+                    (pad(&visible, field_w), body_st)
+                }
                 None => (pad("Reply", field_w), dim),
             };
             let mut spans = vec![
@@ -2225,12 +2232,13 @@ impl Editor {
                 Span::styled("\u{276f} ", accent),
             ];
             match focus {
-                Some(f) if f.cursor < field_w => {
+                Some(f) if field_w > 0 && f.cursor - win < field_w => {
                     // Split the draft around the caret cell so it shows.
+                    let cursor = f.cursor - win;
                     let chars: Vec<char> = draft.chars().collect();
-                    let before: String = chars[..f.cursor].iter().collect();
-                    let at: String = chars[f.cursor..=f.cursor].iter().collect();
-                    let after: String = chars[f.cursor + 1..].iter().collect();
+                    let before: String = chars[..cursor].iter().collect();
+                    let at: String = chars[cursor..=cursor].iter().collect();
+                    let after: String = chars[cursor + 1..].iter().collect();
                     spans.push(Span::styled(before, style));
                     spans.push(Span::styled(
                         at,
@@ -10066,6 +10074,50 @@ mod tests {
         assert_eq!(e.cursor_row, 0);
     }
 
+    /// A reply longer than the footer field must window around the caret:
+    /// the frozen first-N-chars rendering meant typing past the field width
+    /// went blind - no caret anywhere and the new text never appearing.
+    #[test]
+    fn a_long_reply_windows_so_the_caret_and_tail_stay_visible() {
+        let mut e = editor_with("first\nsecond\nthird");
+        e.comment_boxes = vec![CommentBox {
+            id: 7,
+            line: 0,
+            author: "navigator".into(),
+            body: "tighten this".into(),
+        }];
+        let reply = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_TAIL";
+        e.comment_focus = Some(CommentFocus {
+            id: 7,
+            reply: reply.into(),
+            cursor: reply.chars().count(),
+        });
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 60,
+            height: 10,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e as &mut Editor).render(area, &mut buf);
+        let footer: String = (0..area.width)
+            .map(|x| buf[(x, 4)].symbol().to_string())
+            .collect();
+        assert!(
+            footer.contains("_TAIL"),
+            "the field must window to keep the tail under the caret visible: {footer:?}"
+        );
+        let caret_cells = (0..area.width)
+            .filter(|&x| {
+                buf[(x, 4)]
+                    .style()
+                    .add_modifier
+                    .contains(ratatui::style::Modifier::REVERSED)
+            })
+            .count();
+        assert_eq!(caret_cells, 1, "exactly one caret cell renders: {footer:?}");
+    }
+
     /// The focused box renders the typed reply in its footer field.
     #[test]
     fn focused_comment_box_renders_the_reply_draft() {
@@ -11900,7 +11952,10 @@ mod tests {
             id: 1,
             line: 1,
             author: String::from("navigator"),
-            body: (0..20).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n"),
+            body: (0..20)
+                .map(|i| format!("line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
         });
         let area = Rect {
             x: 0,


### PR DESCRIPTION
An adversarial review of the four-commit AI-pair/navigator span (ad4e1f7..eef9d3f, judged against current HEAD) produced ten findings; all ten are addressed here, fixed RED-test-first.

- Scrollbar with comment boxes: the drag now maps through the same content length the bar was drawn with (lines + box rows). A short file with a tall navigator comment had a completely dead scrollbar; a long file's thumb ran away from the pointer.
- F4 review key: next-note walking is ordered by (row, index), so both notes on a shared row are reachable. Replying anchors the navigator's answer on the answered note's own row, which made the answer permanently unreachable by F4 before.
- Tall comment boxes in non-wrap mode: the viewport top is now a content row (line plus rows into its box), mirroring the wrap path, so a box taller than the window scrolls into view and its Reply/Ignore footer is reachable; the wheel, the scrollbar drag, and the thumb position all go through the same model.
- Proactive looks: tree-sitter-md wraps list bullets and quote lines in paragraph nodes, so a TODO list fired one unsolicited turn per bullet, and a paragraph split in two fired anchored at the wrong half; both are now excluded (only purely-added top-level prose counts). A single struct field or enum variant no longer counts as a completed construct.
- Reply UX: the footer field windows horizontally around the caret (typing past the field width used to go blind with no caret drawn), and the "you: ..." line is appended only after a successful send, so a failed send no longer duplicates the reply on retry.
- Workspace re-root drops the old workspace's collab carets (they are keyed by root-relative paths and would dress same-named files in the new root), and turn commentary anchors at the active cursor row only when the noted file IS the active tab.
- Test hardening: the Cmd+K Y OUTPUT assertion only accepts lines past its own baseline on the process-global channel, so sibling-test residue cannot satisfy it.

Full suite: 2775 + 5 CLI tests, 0 failed, clippy zero warnings. Ships as 0.1.657.

