### PR TITLE
fix: resolve the adversarial-review findings on the local-model navigator span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "tree-sitter-yaml",
  "tui-input",
  "ureq",
+ "url",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,8 @@ dependencies = [
  "tree-sitter-typescript",
  "tree-sitter-yaml",
  "tui-input",
- "ureq",
+ "ureq 2.12.1",
+ "ureq 3.3.0",
  "url",
  "zip",
 ]
@@ -1190,6 +1191,22 @@ checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "iana-time-zone"
@@ -3452,6 +3469,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,6 +3536,12 @@ dependencies = [
  "tiny-skia-path",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.657"
+version = "0.1.658"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.657"
+version = "0.1.658"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,15 @@ color_quant = "1.1"
 # codicons are pure `<path>` glyphs, so this trims fontdb/rustybuzz entirely.
 resvg = { version = "0.47", default-features = false }
 ureq = { version = "2", default-features = false, features = ["tls"] }
+# The local-model navigator transport only (src/pair/local.rs). Version 3's
+# phased timeouts check the remaining budget before EVERY socket read, so one
+# per-request global timeout enforces the turn deadline at the socket layer
+# and a deadline cut drops the response and closes the socket. Version 2's
+# only knob is a fixed per-read timeout, which parked a blocked read (plus a
+# helper thread and the socket) long past the deadline on a silent peer.
+# The rest of the tree stays on ureq 2 until those call sites migrate.
+# 3.3.0 verified current on crates.io 2026-07-31.
+ureq3 = { package = "ureq", version = "3", default-features = false, features = ["rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Text CRDT for multiplayer Phase D (independent viewports): tracks concurrent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,11 @@ cola = { version = "0.5", features = ["serde"] }
 # terminal command line (`rg -w "two words"`) into args when seeding Search
 # from the last grep/rg command (src/quickfix.rs).
 shlex = "1.3"
+# URL parsing for the pair endpoint (--base-url validation, and the
+# loopback/https gate that keeps the gateway credential off cleartext remote
+# hops). Already in the tree transitively via ureq, so promoting it to a
+# direct dep adds no new version to the lock.
+url = "2"
 csv = "1.4"
 calamine = "0.34"
 # Decompression for the `Provision::Binary` LSP backend (src/lsp/install.rs):

--- a/docs/MULTIPLAYER.md
+++ b/docs/MULTIPLAYER.md
@@ -601,8 +601,13 @@ croft pair --base-url http://box:8080 --model qwen3-coder:30b   # implies ollama
   the seat stays; the next ask retries. The idle badge names the model:
   `◆ claude (qwen3-coder:30b) seated`.
 - **Auth.** Keyed Anthropic-compatible gateways read `ANTHROPIC_AUTH_TOKEN`
-  from croft's environment; `pair.json` records only provider, base_url, and
-  model — never a token.
+  from croft's environment, sent as `Authorization: Bearer` (Anthropic's own
+  convention for that variable) and mirrored into `x-api-key` for gateways
+  of the other style, alongside `anthropic-version`. The credential only
+  ever travels over https or to a loopback host — a cleartext remote
+  `--base-url http://box:8080` gets a harmless placeholder instead, so the
+  token cannot be sniffed off the wire. `pair.json` records only provider,
+  base_url, and model — never a token.
 
 ### Slice 3 design: op transport and the process model
 

--- a/docs/MULTIPLAYER.md
+++ b/docs/MULTIPLAYER.md
@@ -520,9 +520,12 @@ interaction into turn-based driver/navigator pairing:
   — the old turn-supersession rule is gone, only the driver closes a box.
 - **Turn commentary.** The model's non-fence prose accumulates over the
   turn and lands as ONE comment box at the turn's origin (the asked line,
-  the yield caret, or the replied note) when the turn ends. There is no
-  Navigator OUTPUT channel any more; only when the origin file is no
-  longer live does the prose fall back to OUTPUT rather than being lost.
+  the yield caret, or the replied note) when the turn ends. Commentary no
+  longer streams to a Navigator OUTPUT channel; OUTPUT ("Navigator") now
+  carries only diagnostics — prose whose origin file is no longer live
+  (rather than losing it) and warnings like a dropped inverted fence range
+  (which must never hit stderr: the seat runs in-process and stderr would
+  corrupt the alternate screen).
   The NOTE fence is model-protocol only — nothing new rides the relay, so
   0.1.633/634 peers interop untouched.
 - **The navigator's caret (0.1.639).** The seat has a persistent, visible

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16441,12 +16441,16 @@ impl App {
         let record = crate::session::PairRecord {
             model: current.as_ref().and_then(|r| r.model.clone()),
             name: current
-                .map(|r| r.name)
+                .as_ref()
+                .map(|r| r.name.clone())
                 .unwrap_or_else(|| String::from("claude")),
             enabled,
             task: None,
-            provider: None,
-            base_url: None,
+            // The seat's backend survives an off/on round trip: erasing it
+            // silently reseated a local-only navigator on the cloud claude
+            // CLI - with a model name claude does not even have.
+            provider: current.as_ref().and_then(|r| r.provider.clone()),
+            base_url: current.as_ref().and_then(|r| r.base_url.clone()),
         };
         if let Some(dir) = self.pair_record_path.parent() {
             let _ = std::fs::create_dir_all(dir);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19759,6 +19759,36 @@ fn next_note_by_row_walks_rows_in_order_and_wraps() {
     );
 }
 
+/// The palette off/on round trip must keep the seat's backend: writing
+/// `provider: None` silently reseated a local-only ollama navigator on the
+/// cloud claude CLI - shipping the workspace to a remote service the user
+/// explicitly avoided, under a model name claude does not have.
+#[test]
+fn toggling_the_navigator_preserves_its_provider() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.pair_record_path = tmp.path().join("pair.json");
+    crate::session::write_pair_record(
+        &app.pair_record_path,
+        &crate::session::PairRecord {
+            model: Some(String::from("qwen3-coder:30b")),
+            name: String::from("navigator"),
+            enabled: true,
+            task: None,
+            provider: Some(String::from("ollama")),
+            base_url: Some(String::from("http://localhost:11434")),
+        },
+    )
+    .unwrap();
+    app.toggle_navigator(); // off
+    app.toggle_navigator(); // back on
+    let r = crate::session::read_pair_record(&app.pair_record_path).unwrap();
+    assert!(r.enabled);
+    assert_eq!(r.provider.as_deref(), Some("ollama"));
+    assert_eq!(r.base_url.as_deref(), Some("http://localhost:11434"));
+    assert_eq!(r.model.as_deref(), Some("qwen3-coder:30b"));
+}
+
 /// Collab carets are keyed by root-relative file paths: after a re-root, a
 /// same-named file under the new root would wear a departed peer's caret
 /// from the old workspace. Re-rooting clears them; a live session

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19781,6 +19781,9 @@ fn toggling_the_navigator_preserves_its_provider() {
     )
     .unwrap();
     app.toggle_navigator(); // off
+    let mid = crate::session::read_pair_record(&app.pair_record_path).unwrap();
+    assert!(!mid.enabled, "the first toggle really deactivates");
+    assert_eq!(mid.provider.as_deref(), Some("ollama"));
     app.toggle_navigator(); // back on
     let r = crate::session::read_pair_record(&app.pair_record_path).unwrap();
     assert!(r.enabled);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19790,6 +19790,7 @@ fn toggling_the_navigator_preserves_its_provider() {
     assert_eq!(r.provider.as_deref(), Some("ollama"));
     assert_eq!(r.base_url.as_deref(), Some("http://localhost:11434"));
     assert_eq!(r.model.as_deref(), Some("qwen3-coder:30b"));
+    assert_eq!(r.name, "navigator", "the seat keeps its name too");
 }
 
 /// Collab carets are keyed by root-relative file paths: after a re-root, a

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19783,7 +19783,10 @@ fn toggling_the_navigator_preserves_its_provider() {
     app.toggle_navigator(); // off
     let mid = crate::session::read_pair_record(&app.pair_record_path).unwrap();
     assert!(!mid.enabled, "the first toggle really deactivates");
+    assert_eq!(mid.name, "navigator");
     assert_eq!(mid.provider.as_deref(), Some("ollama"));
+    assert_eq!(mid.base_url.as_deref(), Some("http://localhost:11434"));
+    assert_eq!(mid.model.as_deref(), Some("qwen3-coder:30b"));
     app.toggle_navigator(); // back on
     let r = crate::session::read_pair_record(&app.pair_record_path).unwrap();
     assert!(r.enabled);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -338,31 +338,39 @@ impl Cli {
                     .canonicalize()
                     .context("resolving workspace path")?;
                 let name = name.unwrap_or_else(|| "claude".into());
-                let (provider, base_url) = resolve_pair_provider(provider, base_url);
-                anyhow::ensure!(
-                    provider.as_deref() != Some("ollama") || model.is_some(),
-                    "--provider ollama needs --model <name> (e.g. --model qwen3-coder:30b); \
-                     a local endpoint has no CLI default"
-                );
+                let (provider, base_url) = resolve_pair_provider(provider, base_url)?;
                 let record_path = crate::session::pair_record_path(&workspace);
                 if let Some(dir) = record_path.parent() {
                     std::fs::create_dir_all(dir)?;
                 }
                 if off {
+                    // Deactivation preserves the recorded backend (and takes
+                    // no flag validation: `--provider ollama --off` must
+                    // simply turn the seat off). Erasing provider/base_url
+                    // here made the documented off/on recovery silently
+                    // convert a local seat into a cloud claude seat.
+                    let current = crate::session::read_pair_record(&record_path);
                     crate::session::write_pair_record(
                         &record_path,
                         &crate::session::PairRecord {
-                            model,
+                            model: model.or_else(|| current.as_ref().and_then(|r| r.model.clone())),
                             name,
                             enabled: false,
                             task: None,
-                            provider: None,
-                            base_url: None,
+                            provider: provider
+                                .or_else(|| current.as_ref().and_then(|r| r.provider.clone())),
+                            base_url: base_url
+                                .or_else(|| current.as_ref().and_then(|r| r.base_url.clone())),
                         },
                     )?;
                     println!("navigator deactivated for {}", workspace.display());
                     return Ok(());
                 }
+                anyhow::ensure!(
+                    provider.as_deref() != Some("ollama") || model.is_some(),
+                    "--provider ollama needs --model <name> (e.g. --model qwen3-coder:30b); \
+                     a local endpoint has no CLI default"
+                );
                 if repl {
                     let socket = crate::session::collab_socket_path(&workspace);
                     crate::collab::ensure_relay(&socket)?;
@@ -432,13 +440,27 @@ impl Cli {
 fn resolve_pair_provider(
     provider: Option<String>,
     base_url: Option<String>,
-) -> (Option<String>, Option<String>) {
+) -> Result<(Option<String>, Option<String>)> {
     let provider = provider.or_else(|| base_url.is_some().then(|| String::from("ollama")));
+    // Validate at activation time, when the user is watching: a malformed
+    // endpoint otherwise surfaces hours later as an opaque failure on the
+    // first turn. A trailing slash would build `...//v1/messages`, which
+    // routers 301 and ureq follows by downgrading POST to GET.
+    let base_url = base_url
+        .map(|u| {
+            let u = u.trim_end_matches('/').to_string();
+            anyhow::ensure!(
+                u.starts_with("http://") || u.starts_with("https://"),
+                "--base-url must start with http:// or https:// (got {u})"
+            );
+            Ok(u)
+        })
+        .transpose()?;
     let base_url = match provider.as_deref() {
         Some("ollama") => base_url.or_else(|| Some(String::from("http://localhost:11434"))),
         _ => base_url,
     };
-    (provider, base_url)
+    Ok((provider, base_url))
 }
 
 fn setup_terminal(font: &str, size: u32, yes: bool) -> Result<()> {
@@ -1256,17 +1278,32 @@ mod tests {
     /// activations record neither.
     #[test]
     fn base_url_implies_ollama() {
-        let (p, b) = resolve_pair_provider(None, Some(String::from("http://x:1234")));
+        let (p, b) = resolve_pair_provider(None, Some(String::from("http://x:1234"))).unwrap();
         assert_eq!(p.as_deref(), Some("ollama"));
         assert_eq!(b.as_deref(), Some("http://x:1234"));
 
-        let (p, b) = resolve_pair_provider(Some(String::from("ollama")), None);
+        let (p, b) = resolve_pair_provider(Some(String::from("ollama")), None).unwrap();
         assert_eq!(p.as_deref(), Some("ollama"));
         assert_eq!(b.as_deref(), Some("http://localhost:11434"));
 
-        let (p, b) = resolve_pair_provider(None, None);
+        let (p, b) = resolve_pair_provider(None, None).unwrap();
         assert_eq!(p, None);
         assert_eq!(b, None);
+    }
+
+    /// Validation happens at activation, when the user is watching: a
+    /// trailing slash built `...//v1/messages` (a 301 that ureq follows by
+    /// downgrading POST to GET), and a missing scheme only exploded hours
+    /// later on the first turn.
+    #[test]
+    fn base_url_is_normalised_and_validated_at_activation() {
+        let (_, b) =
+            resolve_pair_provider(None, Some(String::from("http://localhost:11434/"))).unwrap();
+        assert_eq!(b.as_deref(), Some("http://localhost:11434"));
+        assert!(
+            resolve_pair_provider(None, Some(String::from("localhost:11434"))).is_err(),
+            "a schemeless endpoint must be refused up front"
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -349,11 +349,28 @@ impl Cli {
                 // silently converted a disabled ollama record into a cloud
                 // claude seat.
                 let current = crate::session::read_pair_record(&record_path);
-                let model = model.or_else(|| current.as_ref().and_then(|r| r.model.clone()));
-                let base_url =
-                    base_url.or_else(|| current.as_ref().and_then(|r| r.base_url.clone()));
-                let provider =
-                    provider.or_else(|| current.as_ref().and_then(|r| r.provider.clone()));
+                let recorded = current.as_ref().and_then(|r| r.provider.clone());
+                // An explicit provider SWITCH starts that backend fresh:
+                // inheriting the other backend's endpoint or model would
+                // mis-configure the new seat (a claude record persists
+                // provider None, so compare normalised names).
+                let normal = |p: &Option<String>| {
+                    p.as_deref()
+                        .map(str::to_owned)
+                        .unwrap_or_else(|| String::from("claude"))
+                };
+                let inherit = provider.is_none() || normal(&provider) == normal(&recorded);
+                let model = model.or_else(|| {
+                    inherit
+                        .then(|| current.as_ref().and_then(|r| r.model.clone()))
+                        .flatten()
+                });
+                let base_url = base_url.or_else(|| {
+                    inherit
+                        .then(|| current.as_ref().and_then(|r| r.base_url.clone()))
+                        .flatten()
+                });
+                let provider = provider.or(recorded);
                 let (provider, base_url) = resolve_pair_provider(provider, base_url)?;
                 if off {
                     crate::session::write_pair_record(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -338,29 +338,33 @@ impl Cli {
                     .canonicalize()
                     .context("resolving workspace path")?;
                 let name = name.unwrap_or_else(|| "claude".into());
-                let (provider, base_url) = resolve_pair_provider(provider, base_url)?;
                 let record_path = crate::session::pair_record_path(&workspace);
                 if let Some(dir) = record_path.parent() {
                     std::fs::create_dir_all(dir)?;
                 }
+                // The persisted record is the baseline; explicit flags
+                // override it. Resolving bare flags in isolation made
+                // `--provider ollama --off` clobber a custom endpoint with
+                // the default one, and a plain `croft pair` re-activation
+                // silently converted a disabled ollama record into a cloud
+                // claude seat.
+                let current = crate::session::read_pair_record(&record_path);
+                let model = model.or_else(|| current.as_ref().and_then(|r| r.model.clone()));
+                let base_url =
+                    base_url.or_else(|| current.as_ref().and_then(|r| r.base_url.clone()));
+                let provider =
+                    provider.or_else(|| current.as_ref().and_then(|r| r.provider.clone()));
+                let (provider, base_url) = resolve_pair_provider(provider, base_url)?;
                 if off {
-                    // Deactivation preserves the recorded backend (and takes
-                    // no flag validation: `--provider ollama --off` must
-                    // simply turn the seat off). Erasing provider/base_url
-                    // here made the documented off/on recovery silently
-                    // convert a local seat into a cloud claude seat.
-                    let current = crate::session::read_pair_record(&record_path);
                     crate::session::write_pair_record(
                         &record_path,
                         &crate::session::PairRecord {
-                            model: model.or_else(|| current.as_ref().and_then(|r| r.model.clone())),
+                            model,
                             name,
                             enabled: false,
                             task: None,
-                            provider: provider
-                                .or_else(|| current.as_ref().and_then(|r| r.provider.clone())),
-                            base_url: base_url
-                                .or_else(|| current.as_ref().and_then(|r| r.base_url.clone())),
+                            provider,
+                            base_url,
                         },
                     )?;
                     println!("navigator deactivated for {}", workspace.display());
@@ -445,13 +449,21 @@ fn resolve_pair_provider(
     // Validate at activation time, when the user is watching: a malformed
     // endpoint otherwise surfaces hours later as an opaque failure on the
     // first turn. A trailing slash would build `...//v1/messages`, which
-    // routers 301 and ureq follows by downgrading POST to GET.
+    // routers 301 and ureq follows by downgrading POST to GET; a prefix
+    // check alone admitted empty hosts (`https:///path`), whitespace, and
+    // malformed ports, so the URL is properly parsed.
     let base_url = base_url
         .map(|u| {
-            let u = u.trim_end_matches('/').to_string();
+            let u = u.trim().trim_end_matches('/').to_string();
+            let parsed = url::Url::parse(&u)
+                .map_err(|e| anyhow::anyhow!("--base-url is not a valid URL ({e}): {u}"))?;
             anyhow::ensure!(
-                u.starts_with("http://") || u.starts_with("https://"),
-                "--base-url must start with http:// or https:// (got {u})"
+                matches!(parsed.scheme(), "http" | "https"),
+                "--base-url must use http or https (got {u})"
+            );
+            anyhow::ensure!(
+                parsed.host_str().is_some_and(|h| !h.is_empty()),
+                "--base-url needs a host (got {u})"
             );
             Ok(u)
         })
@@ -1303,6 +1315,21 @@ mod tests {
         assert!(
             resolve_pair_provider(None, Some(String::from("localhost:11434"))).is_err(),
             "a schemeless endpoint must be refused up front"
+        );
+        assert!(
+            resolve_pair_provider(None, Some(String::from("https://"))).is_err(),
+            "an empty host must be refused"
+        );
+        // Per the WHATWG parser, extra authority slashes are skipped:
+        // `https:///v1` is host `v1`, odd but well-formed, and accepted.
+        assert!(resolve_pair_provider(None, Some(String::from("https:///v1"))).is_ok());
+        assert!(
+            resolve_pair_provider(None, Some(String::from("http://local host:1"))).is_err(),
+            "whitespace must be refused"
+        );
+        assert!(
+            resolve_pair_provider(None, Some(String::from("http://x:99999999"))).is_err(),
+            "a malformed port must be refused"
         );
     }
 

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -2663,6 +2663,42 @@ mod tests {
         pump.join().unwrap();
     }
 
+    /// A 3xx from the endpoint must NOT be followed: ureq replays the
+    /// x-api-key header to the redirect target, so a loopback endpoint
+    /// answering 302 could bounce the credential to an arbitrary host. The
+    /// redirect surfaces as a failed turn naming the status.
+    #[test]
+    fn a_redirect_is_refused_not_followed() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        let (base_url, server) = serve_http_once(String::from(
+            "HTTP/1.1 302 Found\r\nlocation: http://127.0.0.1:1/v1/messages\r\n\
+             connection: close\r\n\r\n",
+        ));
+        let (turn_tx, turn_rx) = std::sync::mpsc::channel();
+        let mut messages = vec![json!({ "role": "user", "content": "hi" })];
+        state.lock().unwrap().turn_active = true;
+        local::stream_turn(
+            &base_url,
+            "test-model",
+            PAIR_SYSTEM_PROMPT,
+            &mut messages,
+            &state,
+            &turn_tx,
+        );
+        server.join().unwrap();
+        let end = turn_rx.try_recv().expect("turn ended");
+        assert!(end.is_error);
+        assert!(
+            end.text.contains("302"),
+            "the redirect is refused with its status, not followed: {}",
+            end.text
+        );
+        assert!(messages.is_empty());
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
+    }
+
     /// The childless local seat end to end: seat_local connects the guest
     /// seat, the queued turn streams the stub endpoint's fenced edit into
     /// the owner's replica, the turn ends cleanly, and shutdown returns

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -2565,6 +2565,102 @@ mod tests {
             auth_for("http://localhost:11434", None),
             (String::from("croft"), None)
         );
+        // Userinfo must not fool the gate: the destination here is the
+        // remote host, not localhost.
+        assert_eq!(
+            auth_for("http://localhost:pass@evil.example", Some("secret")),
+            (String::from("croft"), None),
+        );
+        assert_eq!(
+            auth_for("http://127.0.0.2:11434", Some("t")),
+            (String::from("t"), Some(String::from("Bearer t"))),
+            "any 127.x address is loopback"
+        );
+    }
+
+    /// The wall-clock ceiling is enforced per CHUNK: a stream of non-newline
+    /// bytes never completes a line, so a per-line check would have let a
+    /// trickling endpoint hold the seat busy indefinitely.
+    #[test]
+    fn a_trickling_stream_is_cut_at_the_deadline() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let stop_trickle = Arc::new(AtomicBool::new(false));
+        let server = {
+            let stop_trickle = Arc::clone(&stop_trickle);
+            std::thread::spawn(move || {
+                let (mut sock, _) = listener.accept().unwrap();
+                let mut req = [0u8; 4096];
+                let _ = sock.read(&mut req);
+                let _ =
+                    sock.write_all(b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\r\n");
+                // Non-newline bytes, forever (until the test releases us).
+                while !stop_trickle.load(Ordering::Relaxed) {
+                    if sock.write_all(b".").is_err() {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+            })
+        };
+        let (turn_tx, turn_rx) = std::sync::mpsc::channel();
+        let mut messages = vec![json!({ "role": "user", "content": "hi" })];
+        state.lock().unwrap().turn_active = true;
+        let started = Instant::now();
+        local::stream_turn_until(
+            &base_url,
+            "test-model",
+            PAIR_SYSTEM_PROMPT,
+            &mut messages,
+            &state,
+            &turn_tx,
+            Instant::now() + Duration::from_millis(300),
+        );
+        let elapsed = started.elapsed();
+        stop_trickle.store(true, Ordering::Relaxed);
+        let _ = server.join();
+        let end = turn_rx.try_recv().expect("turn ended");
+        assert!(end.is_error, "a deadline cut is a failure: {}", end.text);
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "the ceiling must interrupt the trickle promptly, took {elapsed:?}"
+        );
+        assert!(messages.is_empty(), "the conversation stays balanced");
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
+    }
+
+    /// Malformed SSE data mid-stream silently dropped a chunk of the reply
+    /// and still reported success; a broken endpoint must fail the turn.
+    #[test]
+    fn malformed_sse_data_fails_the_turn() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        let (base_url, server) = serve_http_once(String::from(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
+             connection: close\r\n\r\ndata: {not json\n\n\
+             event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+        ));
+        let (turn_tx, turn_rx) = std::sync::mpsc::channel();
+        let mut messages = vec![json!({ "role": "user", "content": "hi" })];
+        state.lock().unwrap().turn_active = true;
+        local::stream_turn(
+            &base_url,
+            "test-model",
+            PAIR_SYSTEM_PROMPT,
+            &mut messages,
+            &state,
+            &turn_tx,
+        );
+        server.join().unwrap();
+        let end = turn_rx.try_recv().expect("turn ended");
+        assert!(end.is_error);
+        assert!(end.text.contains("malformed"), "{}", end.text);
+        assert!(messages.is_empty());
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
     }
 
     /// The childless local seat end to end: seat_local connects the guest

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -1428,7 +1428,16 @@ fn open_region(st: &mut PairState, file: &str, start: (usize, usize), end: (usiz
     let (s, e) = (s.min(doc.len()), e.min(doc.len()));
     if s > e {
         st.discarding = true;
-        eprintln!("[pair] fence range is inverted; edit dropped");
+        // The OUTPUT channel, never stderr: the resident navigator runs
+        // in-process, so an eprintln! lands on the alternate screen and
+        // corrupts the render (the pdftoppm/DAP capture class). The
+        // whole-line header form makes an inverted range a one-token slip
+        // for a weak local model.
+        crate::output::push(
+            "Navigator",
+            crate::output::OutputLevel::Warn,
+            "fence range is inverted; edit dropped",
+        );
         return;
     }
     let original = doc[s..e].to_string();
@@ -2264,6 +2273,52 @@ mod tests {
         assert!(
             st.pending_caret.is_none(),
             "the edit's caret supersedes the pending park"
+        );
+    }
+
+    /// A PARSEABLE whole-line header with an inverted range (`5-3`) drops
+    /// the edit through the OUTPUT channel, never stderr: the resident
+    /// navigator runs in-process, so an eprintln! would land on the
+    /// alternate screen and corrupt the render. The inverted header is a
+    /// one-token slip for the weak local models the whole-line form serves.
+    #[test]
+    fn an_inverted_fence_range_drops_the_edit_via_output_not_stderr() {
+        let harness = OwnerHarness::start("l0\nl1\nl2\nl3\nl4\nl5");
+        let session = connect_session(&harness.socket, "pilot").unwrap();
+        let state = Mutex::new(PairState::new(session, None));
+        state
+            .lock()
+            .unwrap()
+            .begin_turn("demo.txt", "l0\nl1\nl2\nl3\nl4\nl5", false);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let mut st = state.lock().unwrap();
+            let _ = st.session.poll(|_| None);
+            if st.session.is_live("demo.txt") {
+                break;
+            }
+            drop(st);
+            assert!(Instant::now() < deadline, "demo.txt never went live");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let baseline = crate::output::snapshot("Navigator")
+            .unwrap_or_default()
+            .len();
+        let mut st = state.lock().unwrap();
+        open_region(&mut st, "demo.txt", (4, 0), (2, usize::MAX));
+        assert!(st.discarding, "the inverted edit's body must be discarded");
+        assert_eq!(
+            st.session.doc_text("demo.txt").as_deref(),
+            Some("l0\nl1\nl2\nl3\nl4\nl5"),
+            "nothing may be applied"
+        );
+        let lines = crate::output::snapshot("Navigator").unwrap_or_default();
+        assert!(
+            lines
+                .iter()
+                .skip(baseline)
+                .any(|l| l.text.contains("inverted")),
+            "the drop is reported on the OUTPUT channel"
         );
     }
 

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -2308,7 +2308,7 @@ mod tests {
         open_region(&mut st, "demo.txt", (4, 0), (2, usize::MAX));
         assert!(st.discarding, "the inverted edit's body must be discarded");
         assert_eq!(
-            st.session.doc_text("demo.txt").as_deref(),
+            st.session.doc_text("demo.txt"),
             Some("l0\nl1\nl2\nl3\nl4\nl5"),
             "nothing may be applied"
         );

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -2678,6 +2678,56 @@ mod tests {
         pump.join().unwrap();
     }
 
+    /// A deadline cut must also RELEASE the connection. Returning on time
+    /// while a detached reader stayed blocked in `read` kept the socket and
+    /// a thread alive for up to the 300s socket timeout per failed turn, so
+    /// repeated failures accumulated both. The server observing EOF right
+    /// after the cut is the proof the transport let go.
+    #[test]
+    fn a_deadline_cut_releases_the_connection() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let (eof_tx, eof_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut req = [0u8; 4096];
+            let _ = sock.read(&mut req);
+            let _ = sock.write_all(b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\r\n");
+            // Silent body: block until the CLIENT hangs up. EOF or a reset
+            // is the release; draining any leftover request bytes first.
+            let mut probe = [0u8; 64];
+            loop {
+                match sock.read(&mut probe) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+            }
+            let _ = eof_tx.send(());
+        });
+        let (turn_tx, turn_rx) = std::sync::mpsc::channel();
+        let mut messages = vec![json!({ "role": "user", "content": "hi" })];
+        state.lock().unwrap().turn_active = true;
+        local::stream_turn_until(
+            &base_url,
+            "test-model",
+            PAIR_SYSTEM_PROMPT,
+            &mut messages,
+            &state,
+            &turn_tx,
+            Instant::now() + Duration::from_millis(300),
+        );
+        let end = turn_rx.try_recv().expect("turn ended");
+        assert!(end.is_error, "a deadline cut is a failure: {}", end.text);
+        eof_rx.recv_timeout(Duration::from_secs(2)).expect(
+            "the deadline cut must close the connection, not park it until the socket timeout",
+        );
+        assert!(messages.is_empty(), "the conversation stays balanced");
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
+    }
+
     /// Malformed SSE data mid-stream silently dropped a chunk of the reply
     /// and still reported success; a broken endpoint must fail the turn.
     #[test]

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -2074,6 +2074,25 @@ mod tests {
     /// request, and streams `deltas` as `content_block_delta`/`text_delta`
     /// events followed by `message_stop`, closing to end the stream.
     fn serve_sse_once(deltas: Vec<&'static str>) -> (String, std::thread::JoinHandle<()>) {
+        let mut body = String::new();
+        for d in deltas {
+            let ev = json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": { "type": "text_delta", "text": d },
+            });
+            body.push_str(&format!("event: content_block_delta\ndata: {ev}\n\n"));
+        }
+        body.push_str("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
+        serve_http_once(format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
+             connection: close\r\n\r\n{body}"
+        ))
+    }
+
+    /// One-shot HTTP stub answering `resp` verbatim after draining the whole
+    /// request (headers + Content-Length body), per the SSE-stub trap.
+    fn serve_http_once(resp: String) -> (String, std::thread::JoinHandle<()>) {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let base_url = format!("http://{}", listener.local_addr().unwrap());
         let server = std::thread::spawn(move || {
@@ -2101,20 +2120,6 @@ mod tests {
                     }
                 }
             }
-            let mut body = String::new();
-            for d in deltas {
-                let ev = json!({
-                    "type": "content_block_delta",
-                    "index": 0,
-                    "delta": { "type": "text_delta", "text": d },
-                });
-                body.push_str(&format!("event: content_block_delta\ndata: {ev}\n\n"));
-            }
-            body.push_str("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n");
-            let resp = format!(
-                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
-                 connection: close\r\n\r\n{body}"
-            );
             let _ = sock.write_all(resp.as_bytes());
         });
         (base_url, server)
@@ -2345,9 +2350,166 @@ mod tests {
             end.text
         );
         assert!(!state.lock().unwrap().turn_active());
-        assert_eq!(messages.len(), 1, "no assistant message on a failed turn");
+        assert!(
+            messages.is_empty(),
+            "the unanswered user message is popped so the next ask starts clean"
+        );
         stop.store(true, Ordering::Relaxed);
         pump.join().unwrap();
+    }
+
+    /// A stream that dies before `message_stop` is a FAILED turn: the old
+    /// code reported success ("claude finished its turn") while the partial
+    /// edit had been reverted and nothing happened - and it appended the
+    /// partial text as an assistant message, corrupting the conversation.
+    #[test]
+    fn a_mid_stream_drop_reports_failure_and_balances_the_conversation() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        let ev = json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": { "type": "text_delta", "text": "half a rep" },
+        });
+        let (base_url, server) = serve_http_once(format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
+             connection: close\r\n\r\nevent: content_block_delta\ndata: {ev}\n\n"
+        ));
+        let (turn_tx, turn_rx) = std::sync::mpsc::channel();
+        let mut messages = vec![json!({ "role": "user", "content": "hi" })];
+        state.lock().unwrap().turn_active = true;
+        local::stream_turn(
+            &base_url,
+            "test-model",
+            PAIR_SYSTEM_PROMPT,
+            &mut messages,
+            &state,
+            &turn_tx,
+        );
+        server.join().unwrap();
+        let end = turn_rx.try_recv().expect("turn ended");
+        assert!(
+            end.is_error,
+            "an unclean stream end is a failure: {}",
+            end.text
+        );
+        assert!(
+            messages.is_empty(),
+            "the conversation stays balanced for the next ask"
+        );
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
+    }
+
+    /// The HTTP error body carries the fix ("model 'x' not found, try
+    /// pulling it first"); throwing it away left an opaque status code.
+    #[test]
+    fn an_http_error_body_reaches_the_surfaced_failure() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        let (base_url, server) = serve_http_once(String::from(
+            "HTTP/1.1 404 Not Found\r\ncontent-type: application/json\r\n\
+             connection: close\r\n\r\n{\"error\":\"model 'qwn3' not found, try pulling it\"}",
+        ));
+        let (turn_tx, turn_rx) = std::sync::mpsc::channel();
+        let mut messages = vec![json!({ "role": "user", "content": "hi" })];
+        state.lock().unwrap().turn_active = true;
+        local::stream_turn(
+            &base_url,
+            "qwn3",
+            PAIR_SYSTEM_PROMPT,
+            &mut messages,
+            &state,
+            &turn_tx,
+        );
+        server.join().unwrap();
+        let end = turn_rx.try_recv().expect("turn ended");
+        assert!(end.is_error);
+        assert!(
+            end.text.contains("not found, try pulling it"),
+            "the body's own words must survive: {}",
+            end.text
+        );
+        assert!(messages.is_empty());
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
+    }
+
+    /// `stop_reason: max_tokens` means the reply (and any fence in it) was
+    /// cut off; reporting success would pretend the half-edit was the turn.
+    #[test]
+    fn a_token_limit_truncation_is_a_failed_turn() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        let delta = json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": { "type": "text_delta", "text": "prose" },
+        });
+        let md = json!({
+            "type": "message_delta",
+            "delta": { "stop_reason": "max_tokens" },
+        });
+        let (base_url, server) = serve_http_once(format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\
+             connection: close\r\n\r\n\
+             event: content_block_delta\ndata: {delta}\n\n\
+             event: message_delta\ndata: {md}\n\n\
+             event: message_stop\ndata: {{\"type\":\"message_stop\"}}\n\n"
+        ));
+        let (turn_tx, turn_rx) = std::sync::mpsc::channel();
+        let mut messages = vec![json!({ "role": "user", "content": "hi" })];
+        state.lock().unwrap().turn_active = true;
+        local::stream_turn(
+            &base_url,
+            "test-model",
+            PAIR_SYSTEM_PROMPT,
+            &mut messages,
+            &state,
+            &turn_tx,
+        );
+        server.join().unwrap();
+        let end = turn_rx.try_recv().expect("turn ended");
+        assert!(end.is_error, "truncation must not read as success");
+        assert!(end.text.contains("truncated"), "{}", end.text);
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
+    }
+
+    /// The environment credential only ever travels to https or loopback
+    /// destinations; a cleartext remote hop gets the harmless placeholder.
+    #[test]
+    fn the_credential_never_rides_cleartext_to_a_remote_host() {
+        use local::auth_for;
+        assert_eq!(
+            auth_for("http://box:8080", Some("secret")),
+            (String::from("croft"), None),
+        );
+        assert_eq!(
+            auth_for("http://localhost.evil.com:80", Some("secret")),
+            (String::from("croft"), None),
+        );
+        let bearer = Some(String::from("Bearer t"));
+        assert_eq!(
+            auth_for("http://localhost:11434", Some("t")),
+            (String::from("t"), bearer.clone()),
+        );
+        assert_eq!(
+            auth_for("http://127.0.0.1:11434", Some("t")),
+            (String::from("t"), bearer.clone()),
+        );
+        assert_eq!(
+            auth_for("http://[::1]:11434", Some("t")),
+            (String::from("t"), bearer.clone()),
+        );
+        assert_eq!(
+            auth_for("https://gw.example.com", Some("t")),
+            (String::from("t"), bearer),
+        );
+        assert_eq!(
+            auth_for("http://localhost:11434", None),
+            (String::from("croft"), None)
+        );
     }
 
     /// The childless local seat end to end: seat_local connects the guest

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -2632,6 +2632,52 @@ mod tests {
         pump.join().unwrap();
     }
 
+    /// The deadline used to be polled only BETWEEN reads: a peer that sent
+    /// headers and then held the body open without a single byte parked the
+    /// loop inside the blocking `read` (up to the 300s socket timeout) past
+    /// the ceiling. Each wait is bounded by the remaining turn time instead.
+    #[test]
+    fn a_silent_stream_body_is_cut_at_the_deadline() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        // The thread ends on its own after the silence window; dropping the
+        // handle detaches it.
+        std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut req = [0u8; 4096];
+            let _ = sock.read(&mut req);
+            let _ = sock.write_all(b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\r\n");
+            // Not one body byte: hold the connection open in silence, long
+            // enough that only the deadline can explain a prompt return.
+            std::thread::sleep(Duration::from_secs(4));
+        });
+        let (turn_tx, turn_rx) = std::sync::mpsc::channel();
+        let mut messages = vec![json!({ "role": "user", "content": "hi" })];
+        state.lock().unwrap().turn_active = true;
+        let started = Instant::now();
+        local::stream_turn_until(
+            &base_url,
+            "test-model",
+            PAIR_SYSTEM_PROMPT,
+            &mut messages,
+            &state,
+            &turn_tx,
+            Instant::now() + Duration::from_millis(300),
+        );
+        let elapsed = started.elapsed();
+        let end = turn_rx.try_recv().expect("turn ended");
+        assert!(end.is_error, "a deadline cut is a failure: {}", end.text);
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "the ceiling must interrupt a silent body promptly, took {elapsed:?}"
+        );
+        assert!(messages.is_empty(), "the conversation stays balanced");
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
+    }
+
     /// Malformed SSE data mid-stream silently dropped a chunk of the reply
     /// and still reported success; a broken endpoint must fail the turn.
     #[test]

--- a/src/pair/local.rs
+++ b/src/pair/local.rs
@@ -100,33 +100,50 @@ pub(crate) fn stream_turn_until(
         "system": system,
         "messages": messages,
     });
-    let agent = ureq::AgentBuilder::new()
-        .timeout_connect(Duration::from_secs(5))
-        // Per-read, not per-request: a cold model may take minutes to load
-        // before its first token, but the whole stream may run far longer.
-        .timeout_read(Duration::from_secs(300))
-        // Never follow redirects: ureq replays the x-api-key header to the
-        // redirect target, so a loopback endpoint answering 302 could bounce
-        // the credential to an arbitrary host (and a 301 would downgrade
-        // the POST to GET anyway). A redirect surfaces as a status error.
-        .redirects(0)
-        .build();
+    // ureq 3 here, not the tree-wide ureq 2: version 3's phased timeouts
+    // check the remaining budget before EVERY socket operation, so the
+    // per-request global timeout below enforces the turn deadline at the
+    // socket layer. A read can neither outlive the deadline nor keep the
+    // socket alive after it: the cut drops the response, which closes the
+    // connection. Version 2's only knob was a fixed per-read timeout, which
+    // parked a blocked read (plus a helper thread and the socket) for up to
+    // that timeout past the deadline on a peer that just went silent.
+    let agent = ureq3::Agent::config_builder()
+        .timeout_connect(Some(Duration::from_secs(5)))
+        // Never follow redirects: the x-api-key header would be replayed to
+        // the redirect target, so a loopback endpoint answering 302 could
+        // bounce the credential to an arbitrary host (and a 301 would
+        // downgrade the POST to GET anyway). With 0 the 3xx comes back as a
+        // plain response and is refused below.
+        .max_redirects(0)
+        // Non-2xx arrives as a response, not an error: the error BODY
+        // carries the fix ("model 'x' not found, try pulling it first").
+        .http_status_as_error(false)
+        .build()
+        .new_agent();
     let token = std::env::var("ANTHROPIC_AUTH_TOKEN").ok();
     let (api_key, bearer) = auth_for(base_url, token.as_deref());
     let mut post = agent
-        .post(&format!("{base_url}/v1/messages"))
-        .set("content-type", "application/json")
-        .set("anthropic-version", "2023-06-01")
-        .set("x-api-key", &api_key);
+        .post(format!("{base_url}/v1/messages"))
+        .config()
+        // The whole exchange (headers, cold-model wait, every body read)
+        // shares the turn's remaining wall-clock budget.
+        .timeout_global(Some(
+            deadline.saturating_duration_since(std::time::Instant::now()),
+        ))
+        .build()
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .header("x-api-key", &api_key);
     if let Some(bearer) = &bearer {
-        post = post.set("authorization", bearer);
+        post = post.header("authorization", bearer);
     }
-    let resp = match post.send_string(&req.to_string()) {
+    let resp = match post.send(req.to_string()) {
         Ok(r) => r,
         Err(e) => {
             // The endpoint never answered the turn: pop the user message so
             // the conversation stays balanced. Leaving it made the NEXT turn
-            // send [user, user] - a hard 400 on strict gateways for the rest
+            // send [user, user], a hard 400 on strict gateways for the rest
             // of the seat's life, or a silent re-submit of the unanswered
             // ask on permissive local servers.
             messages.pop();
@@ -134,23 +151,37 @@ pub(crate) fn stream_turn_until(
                 state,
                 turn_tx,
                 true,
-                format!("local endpoint {base_url}: {}", error_detail(e)),
+                format!("local endpoint {base_url}: {}", error_detail(&e)),
             );
             return;
         }
     };
 
+    let status = resp.status().as_u16();
     // With redirects disabled a 3xx arrives as a plain response; name it
     // instead of reading an empty stream (following it would have replayed
     // the credential header to wherever Location pointed).
-    if resp.status() >= 300 {
-        let status = resp.status();
+    if (300..400).contains(&status) {
         messages.pop();
         end_turn(
             state,
             turn_tx,
             true,
             format!("local endpoint {base_url}: redirect refused (status {status})"),
+        );
+        return;
+    }
+    if status >= 400 {
+        let body = resp.into_body().read_to_string().unwrap_or_default();
+        messages.pop();
+        end_turn(
+            state,
+            turn_tx,
+            true,
+            format!(
+                "local endpoint {base_url}: {}",
+                status_detail(status, &body)
+            ),
         );
         return;
     }
@@ -164,40 +195,18 @@ pub(crate) fn stream_turn_until(
     let mut clean_end = false;
     let mut truncated = false;
     let mut stream_error: Option<String> = None;
-    // Total wall-clock ceiling: the 300s socket timeout is per READ, so a
-    // server trickling bytes could otherwise hold the seat busy forever.
-    // The deadline is enforced per CHUNK, not per line - `lines()` blocks
-    // until a newline arrives, so a stream of non-newline bytes would have
-    // dodged a per-line check indefinitely. And because the blocking `read`
-    // itself cannot be interrupted, a helper thread owns the socket and
-    // forwards chunks over a channel: the loop waits at most the REMAINING
-    // turn time for each one, so a peer that holds the body open in silence
-    // cannot park the turn inside `read` past the ceiling. After a cut the
-    // helper lingers until its read returns (at worst the socket timeout),
-    // notices the receiver is gone, and exits.
-    let mut reader = resp.into_reader();
+    // Total wall-clock ceiling: the transport's global timeout above bounds
+    // every socket read by the remaining budget, so a silent or trickling
+    // peer is cut mid-read at the deadline (and dropping the reader then
+    // closes the socket). The deadline is enforced per CHUNK, not per line;
+    // `lines()` blocks until a newline arrives, so a stream of non-newline
+    // bytes would have dodged a per-line check indefinitely.
+    let mut reader = resp.into_body().into_reader();
     let mut pending: Vec<u8> = Vec::new();
-    let (chunk_tx, chunk_rx) = std::sync::mpsc::channel::<std::io::Result<Vec<u8>>>();
-    std::thread::spawn(move || {
-        let mut chunk = [0u8; 4096];
-        loop {
-            match std::io::Read::read(&mut reader, &mut chunk) {
-                Ok(0) => break, // hung up; the dropped sender says so
-                Ok(n) => {
-                    if chunk_tx.send(Ok(chunk[..n].to_vec())).is_err() {
-                        break;
-                    }
-                }
-                Err(e) => {
-                    let _ = chunk_tx.send(Err(e));
-                    break;
-                }
-            }
-        }
-    });
+    let mut chunk = [0u8; 4096];
     'stream: loop {
-        // Checked even when chunks are queued: a peer flooding bytes faster
-        // than they drain must not starve the deadline.
+        // Checked even while data flows: a peer flooding bytes faster than
+        // they drain must not starve the deadline.
         if std::time::Instant::now() > deadline {
             stream_error = Some(String::from("turn exceeded the 10 minute ceiling"));
             break;
@@ -208,17 +217,16 @@ pub(crate) fn stream_turn_until(
             stream_error = Some(String::from("endpoint sent an over-long SSE line"));
             break;
         }
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        let bytes = match chunk_rx.recv_timeout(remaining) {
-            Ok(Ok(b)) => b,
-            // Hung up (EOF or read error); finish() reverts open fences.
-            Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+        let n = match std::io::Read::read(&mut reader, &mut chunk) {
+            Ok(0) => break, // hung up; finish() reverts open fences
+            Ok(n) => n,
+            Err(e) if is_timeout(&e) => {
                 stream_error = Some(String::from("turn exceeded the 10 minute ceiling"));
                 break;
             }
+            Err(_) => break, // hung up; finish() reverts open fences
         };
-        pending.extend_from_slice(&bytes);
+        pending.extend_from_slice(&chunk[..n]);
         while let Some(pos) = pending.iter().position(|&b| b == b'\n') {
             let raw: Vec<u8> = pending.drain(..=pos).collect();
             let line = String::from_utf8_lossy(&raw[..raw.len() - 1]);
@@ -298,23 +306,39 @@ pub(crate) fn stream_turn_until(
 /// Total wall-clock ceiling for one turn (the socket timeout is per read).
 const TURN_DEADLINE: Duration = Duration::from_secs(600);
 
-/// The failure text for a request error, with any HTTP error body included:
-/// the body carries the fix ("model 'x' not found, try pulling it first"),
-/// and ureq's Display is just the status code.
-fn error_detail(e: ureq::Error) -> String {
+/// The failure text for a transport error. HTTP statuses never land here
+/// (`http_status_as_error(false)` returns them as responses, handled by
+/// [`status_detail`]); a deadline hit before the headers arrived reads
+/// better as the ceiling than as ureq's "timeout: global".
+fn error_detail(e: &ureq3::Error) -> String {
     match e {
-        ureq::Error::Status(code, resp) => {
-            let body = resp.into_string().unwrap_or_default();
-            let body = body.trim();
-            if body.is_empty() {
-                format!("status {code}")
-            } else {
-                let short: String = body.chars().take(200).collect();
-                format!("status {code}: {short}")
-            }
-        }
+        ureq3::Error::Timeout(_) => String::from("turn exceeded the 10 minute ceiling"),
         other => other.to_string(),
     }
+}
+
+/// The failure text for an HTTP error status, with the error body included:
+/// the body carries the fix ("model 'x' not found, try pulling it first").
+fn status_detail(status: u16, body: &str) -> String {
+    let body = body.trim();
+    if body.is_empty() {
+        format!("status {status}")
+    } else {
+        let short: String = body.chars().take(200).collect();
+        format!("status {status}: {short}")
+    }
+}
+
+/// Whether a body-read error is the transport enforcing the turn deadline
+/// (the global timeout travels inside `io::Error::other`).
+fn is_timeout(e: &std::io::Error) -> bool {
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+    ) || e
+        .get_ref()
+        .and_then(|inner| inner.downcast_ref::<ureq3::Error>())
+        .is_some_and(|u| matches!(u, ureq3::Error::Timeout(_)))
 }
 
 /// The local twin of the claude reader's `result` handling: reset the

--- a/src/pair/local.rs
+++ b/src/pair/local.rs
@@ -105,6 +105,11 @@ pub(crate) fn stream_turn_until(
         // Per-read, not per-request: a cold model may take minutes to load
         // before its first token, but the whole stream may run far longer.
         .timeout_read(Duration::from_secs(300))
+        // Never follow redirects: ureq replays the x-api-key header to the
+        // redirect target, so a loopback endpoint answering 302 could bounce
+        // the credential to an arbitrary host (and a 301 would downgrade
+        // the POST to GET anyway). A redirect surfaces as a status error.
+        .redirects(0)
         .build();
     let token = std::env::var("ANTHROPIC_AUTH_TOKEN").ok();
     let (api_key, bearer) = auth_for(base_url, token.as_deref());
@@ -134,6 +139,21 @@ pub(crate) fn stream_turn_until(
             return;
         }
     };
+
+    // With redirects disabled a 3xx arrives as a plain response; name it
+    // instead of reading an empty stream (following it would have replayed
+    // the credential header to wherever Location pointed).
+    if resp.status() >= 300 {
+        let status = resp.status();
+        messages.pop();
+        end_turn(
+            state,
+            turn_tx,
+            true,
+            format!("local endpoint {base_url}: redirect refused (status {status})"),
+        );
+        return;
+    }
 
     let mut fence = FenceMachine::new();
     let mut assistant = String::new();

--- a/src/pair/local.rs
+++ b/src/pair/local.rs
@@ -7,7 +7,6 @@
 //! shared pair machinery; only the transport differs. The endpoint is
 //! stateless, so the caller owns the conversation as a message list.
 
-use std::io::BufRead;
 use std::sync::Mutex;
 use std::sync::mpsc::Sender;
 use std::time::Duration;
@@ -29,25 +28,31 @@ const MAX_TOKENS: u64 = 8192;
 /// instead, so the token cannot be sniffed off the wire. Environment-only
 /// on purpose: a token must never land in `pair.json`.
 pub(crate) fn auth_for(base_url: &str, token: Option<&str>) -> (String, Option<String>) {
-    let allowed = base_url.starts_with("https://")
-        || base_url
-            .strip_prefix("http://")
-            .is_some_and(|rest| loopback_host(rest.split('/').next().unwrap_or("")));
     match token {
-        Some(t) if allowed => (t.to_string(), Some(format!("Bearer {t}"))),
+        Some(t) if credential_allowed(base_url) => (t.to_string(), Some(format!("Bearer {t}"))),
         _ => (String::from("croft"), None),
     }
 }
 
-/// Whether `host_port` (authority without scheme or path) is loopback.
-fn loopback_host(host_port: &str) -> bool {
-    if let Some(rest) = host_port.strip_prefix('[') {
-        return rest.split(']').next() == Some("::1");
+/// Whether the credential may travel to `base_url`: https anywhere, http
+/// only to a loopback host. A real URL parse, not a string scan - the
+/// authority's userinfo made `http://localhost:pass@evil.example` read as
+/// loopback under a colon-split check while the actual destination was the
+/// remote host.
+fn credential_allowed(base_url: &str) -> bool {
+    let Ok(u) = url::Url::parse(base_url) else {
+        return false;
+    };
+    match u.scheme() {
+        "https" => true,
+        "http" => match u.host() {
+            Some(url::Host::Domain(d)) => d == "localhost",
+            Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+            Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+            None => false,
+        },
+        _ => false,
     }
-    matches!(
-        host_port.split(':').next().unwrap_or(""),
-        "localhost" | "127.0.0.1"
-    )
 }
 
 /// POST one streaming `/v1/messages` turn and drive its text deltas through
@@ -64,6 +69,29 @@ pub(crate) fn stream_turn(
     messages: &mut Vec<Value>,
     state: &Mutex<PairState>,
     turn_tx: &Sender<TurnEnd>,
+) {
+    stream_turn_until(
+        base_url,
+        model,
+        system,
+        messages,
+        state,
+        turn_tx,
+        std::time::Instant::now() + TURN_DEADLINE,
+    );
+}
+
+/// [`stream_turn`] with an explicit wall-clock deadline, so tests can prove
+/// the ceiling interrupts a trickling stream without waiting ten minutes.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn stream_turn_until(
+    base_url: &str,
+    model: &str,
+    system: &str,
+    messages: &mut Vec<Value>,
+    state: &Mutex<PairState>,
+    turn_tx: &Sender<TurnEnd>,
+    deadline: std::time::Instant,
 ) {
     let req = json!({
         "model": model,
@@ -118,49 +146,70 @@ pub(crate) fn stream_turn(
     let mut stream_error: Option<String> = None;
     // Total wall-clock ceiling: the 300s socket timeout is per READ, so a
     // server trickling bytes could otherwise hold the seat busy forever.
-    let deadline = std::time::Instant::now() + TURN_DEADLINE;
-    for line in std::io::BufReader::new(resp.into_reader()).lines() {
+    // The deadline is enforced per CHUNK, not per line - `lines()` blocks
+    // until a newline arrives, so a stream of non-newline bytes would have
+    // dodged a per-line check indefinitely.
+    let mut reader = resp.into_reader();
+    let mut pending: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; 4096];
+    'stream: loop {
         if std::time::Instant::now() > deadline {
             stream_error = Some(String::from("turn exceeded the 10 minute ceiling"));
             break;
         }
-        let Ok(line) = line else {
-            break; // endpoint hung up mid-stream; finish() reverts open fences
-        };
-        let Some(data) = line.strip_prefix("data: ") else {
-            continue;
-        };
-        if data.trim() == "[DONE]" {
-            clean_end = true;
+        // A single SSE line has no business being megabytes long; a cap
+        // keeps a hostile or broken endpoint from ballooning memory.
+        if pending.len() > 1 << 20 {
+            stream_error = Some(String::from("endpoint sent an over-long SSE line"));
             break;
         }
-        let Ok(v) = serde_json::from_str::<Value>(data) else {
-            continue;
+        let n = match std::io::Read::read(&mut reader, &mut chunk) {
+            Ok(0) | Err(_) => break, // hung up; finish() reverts open fences
+            Ok(n) => n,
         };
-        match v["type"].as_str().unwrap_or("") {
-            "content_block_delta" => {
-                if v["delta"]["type"] == "text_delta"
-                    && let Some(text) = v["delta"]["text"].as_str()
-                {
-                    assistant.push_str(text);
-                    for event in fence.push(text) {
-                        apply_fence_event(state, event);
+        pending.extend_from_slice(&chunk[..n]);
+        while let Some(pos) = pending.iter().position(|&b| b == b'\n') {
+            let raw: Vec<u8> = pending.drain(..=pos).collect();
+            let line = String::from_utf8_lossy(&raw[..raw.len() - 1]);
+            let line = line.trim_end_matches('\r');
+            let Some(data) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            if data.trim() == "[DONE]" {
+                clean_end = true;
+                break 'stream;
+            }
+            let Ok(v) = serde_json::from_str::<Value>(data) else {
+                // Skipping silently would drop a chunk of the reply and
+                // still report success; the endpoint is broken, say so.
+                stream_error = Some(String::from("endpoint sent malformed SSE data"));
+                break 'stream;
+            };
+            match v["type"].as_str().unwrap_or("") {
+                "content_block_delta" => {
+                    if v["delta"]["type"] == "text_delta"
+                        && let Some(text) = v["delta"]["text"].as_str()
+                    {
+                        assistant.push_str(text);
+                        for event in fence.push(text) {
+                            apply_fence_event(state, event);
+                        }
                     }
                 }
+                "message_delta" if v["delta"]["stop_reason"] == "max_tokens" => {
+                    truncated = true;
+                }
+                "message_stop" => {
+                    clean_end = true;
+                    break 'stream;
+                }
+                "error" => {
+                    let msg = v["error"]["message"].as_str().unwrap_or("stream error");
+                    stream_error = Some(msg.to_string());
+                    break 'stream;
+                }
+                _ => {}
             }
-            "message_delta" if v["delta"]["stop_reason"] == "max_tokens" => {
-                truncated = true;
-            }
-            "message_stop" => {
-                clean_end = true;
-                break;
-            }
-            "error" => {
-                let msg = v["error"]["message"].as_str().unwrap_or("stream error");
-                stream_error = Some(msg.to_string());
-                break;
-            }
-            _ => {}
         }
     }
     for event in fence.finish() {

--- a/src/pair/local.rs
+++ b/src/pair/local.rs
@@ -168,11 +168,36 @@ pub(crate) fn stream_turn_until(
     // server trickling bytes could otherwise hold the seat busy forever.
     // The deadline is enforced per CHUNK, not per line - `lines()` blocks
     // until a newline arrives, so a stream of non-newline bytes would have
-    // dodged a per-line check indefinitely.
+    // dodged a per-line check indefinitely. And because the blocking `read`
+    // itself cannot be interrupted, a helper thread owns the socket and
+    // forwards chunks over a channel: the loop waits at most the REMAINING
+    // turn time for each one, so a peer that holds the body open in silence
+    // cannot park the turn inside `read` past the ceiling. After a cut the
+    // helper lingers until its read returns (at worst the socket timeout),
+    // notices the receiver is gone, and exits.
     let mut reader = resp.into_reader();
     let mut pending: Vec<u8> = Vec::new();
-    let mut chunk = [0u8; 4096];
+    let (chunk_tx, chunk_rx) = std::sync::mpsc::channel::<std::io::Result<Vec<u8>>>();
+    std::thread::spawn(move || {
+        let mut chunk = [0u8; 4096];
+        loop {
+            match std::io::Read::read(&mut reader, &mut chunk) {
+                Ok(0) => break, // hung up; the dropped sender says so
+                Ok(n) => {
+                    if chunk_tx.send(Ok(chunk[..n].to_vec())).is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let _ = chunk_tx.send(Err(e));
+                    break;
+                }
+            }
+        }
+    });
     'stream: loop {
+        // Checked even when chunks are queued: a peer flooding bytes faster
+        // than they drain must not starve the deadline.
         if std::time::Instant::now() > deadline {
             stream_error = Some(String::from("turn exceeded the 10 minute ceiling"));
             break;
@@ -183,11 +208,17 @@ pub(crate) fn stream_turn_until(
             stream_error = Some(String::from("endpoint sent an over-long SSE line"));
             break;
         }
-        let n = match std::io::Read::read(&mut reader, &mut chunk) {
-            Ok(0) | Err(_) => break, // hung up; finish() reverts open fences
-            Ok(n) => n,
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        let bytes = match chunk_rx.recv_timeout(remaining) {
+            Ok(Ok(b)) => b,
+            // Hung up (EOF or read error); finish() reverts open fences.
+            Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                stream_error = Some(String::from("turn exceeded the 10 minute ceiling"));
+                break;
+            }
         };
-        pending.extend_from_slice(&chunk[..n]);
+        pending.extend_from_slice(&bytes);
         while let Some(pos) = pending.iter().position(|&b| b == b'\n') {
             let raw: Vec<u8> = pending.drain(..=pos).collect();
             let line = String::from_utf8_lossy(&raw[..raw.len() - 1]);

--- a/src/pair/local.rs
+++ b/src/pair/local.rs
@@ -208,7 +208,7 @@ pub(crate) fn stream_turn_until(
         // Checked even while data flows: a peer flooding bytes faster than
         // they drain must not starve the deadline.
         if std::time::Instant::now() > deadline {
-            stream_error = Some(String::from("turn exceeded the 10 minute ceiling"));
+            stream_error = Some(ceiling_msg());
             break;
         }
         // A single SSE line has no business being megabytes long; a cap
@@ -221,7 +221,7 @@ pub(crate) fn stream_turn_until(
             Ok(0) => break, // hung up; finish() reverts open fences
             Ok(n) => n,
             Err(e) if is_timeout(&e) => {
-                stream_error = Some(String::from("turn exceeded the 10 minute ceiling"));
+                stream_error = Some(ceiling_msg());
                 break;
             }
             Err(_) => break, // hung up; finish() reverts open fences
@@ -303,16 +303,29 @@ pub(crate) fn stream_turn_until(
     }
 }
 
-/// Total wall-clock ceiling for one turn (the socket timeout is per read).
+/// Total wall-clock ceiling for one turn, enforced by the transport's
+/// global timeout.
 const TURN_DEADLINE: Duration = Duration::from_secs(600);
+
+/// The ceiling failure text, derived from [`TURN_DEADLINE`] so the message
+/// can never drift from the enforced value. (A test-supplied shorter
+/// deadline reuses it; those tests assert the outcome, not the wording.)
+fn ceiling_msg() -> String {
+    format!(
+        "turn exceeded the {} minute ceiling",
+        TURN_DEADLINE.as_secs() / 60
+    )
+}
 
 /// The failure text for a transport error. HTTP statuses never land here
 /// (`http_status_as_error(false)` returns them as responses, handled by
-/// [`status_detail`]); a deadline hit before the headers arrived reads
-/// better as the ceiling than as ureq's "timeout: global".
+/// [`status_detail`]). Only the GLOBAL timeout is the turn ceiling; the 5
+/// second connect timeout also arrives as `Error::Timeout` and must keep
+/// its own name ("timeout: connect") instead of claiming ten minutes
+/// passed after five seconds.
 fn error_detail(e: &ureq3::Error) -> String {
     match e {
-        ureq3::Error::Timeout(_) => String::from("turn exceeded the 10 minute ceiling"),
+        ureq3::Error::Timeout(ureq3::Timeout::Global | ureq3::Timeout::PerCall) => ceiling_msg(),
         other => other.to_string(),
     }
 }
@@ -330,7 +343,9 @@ fn status_detail(status: u16, body: &str) -> String {
 }
 
 /// Whether a body-read error is the transport enforcing the turn deadline
-/// (the global timeout travels inside `io::Error::other`).
+/// (the global timeout travels inside `io::Error::other`). Only the global
+/// and per-call reasons count: no other timeout is configured for the body
+/// phase, and a raw socket-timeout kind can only mean the same budget.
 fn is_timeout(e: &std::io::Error) -> bool {
     matches!(
         e.kind(),
@@ -338,7 +353,12 @@ fn is_timeout(e: &std::io::Error) -> bool {
     ) || e
         .get_ref()
         .and_then(|inner| inner.downcast_ref::<ureq3::Error>())
-        .is_some_and(|u| matches!(u, ureq3::Error::Timeout(_)))
+        .is_some_and(|u| {
+            matches!(
+                u,
+                ureq3::Error::Timeout(ureq3::Timeout::Global | ureq3::Timeout::PerCall)
+            )
+        })
 }
 
 /// The local twin of the claude reader's `result` handling: reset the
@@ -356,4 +376,30 @@ fn end_turn(state: &Mutex<PairState>, turn_tx: &Sender<TurnEnd>, is_error: bool,
         cancelled,
         text,
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Only the GLOBAL timeout is the turn ceiling. The 5 second connect
+    /// timeout also surfaces as `Error::Timeout`; reporting it as "exceeded
+    /// the 10 minute ceiling" after 5 seconds misnames the failure.
+    #[test]
+    fn a_connect_timeout_is_not_reported_as_the_turn_ceiling() {
+        let connect = error_detail(&ureq3::Error::Timeout(ureq3::Timeout::Connect));
+        assert!(
+            !connect.contains("ceiling"),
+            "a connect timeout is not the turn ceiling: {connect}"
+        );
+        let global = error_detail(&ureq3::Error::Timeout(ureq3::Timeout::Global));
+        assert!(
+            global.contains("ceiling"),
+            "the global timeout IS the ceiling: {global}"
+        );
+        assert!(
+            global.contains("10 minute"),
+            "the ceiling text names the enforced duration: {global}"
+        );
+    }
 }

--- a/src/pair/local.rs
+++ b/src/pair/local.rs
@@ -148,10 +148,8 @@ pub(crate) fn stream_turn(
                     }
                 }
             }
-            "message_delta" => {
-                if v["delta"]["stop_reason"] == "max_tokens" {
-                    truncated = true;
-                }
+            "message_delta" if v["delta"]["stop_reason"] == "max_tokens" => {
+                truncated = true;
             }
             "message_stop" => {
                 clean_end = true;

--- a/src/pair/local.rs
+++ b/src/pair/local.rs
@@ -20,10 +20,34 @@ use super::{FenceMachine, PairState, TurnEnd, apply_fence_event};
 /// reject nothing under their context limit.
 const MAX_TOKENS: u64 = 8192;
 
-/// Bearer for keyed Anthropic-compatible gateways; local servers ignore it.
-/// Environment-only on purpose: a token must never land in `pair.json`.
-fn api_key() -> String {
-    std::env::var("ANTHROPIC_AUTH_TOKEN").unwrap_or_else(|_| String::from("croft"))
+/// The auth headers for `base_url`: `(x-api-key value, Authorization
+/// value)`. Keyed Anthropic-compatible gateways read the environment token
+/// as `Authorization: Bearer` (Anthropic's own `ANTHROPIC_AUTH_TOKEN`
+/// convention); it is also mirrored into `x-api-key` for gateways of the
+/// other style. The credential only ever travels over https or to a
+/// loopback host - a cleartext remote hop gets the harmless placeholder
+/// instead, so the token cannot be sniffed off the wire. Environment-only
+/// on purpose: a token must never land in `pair.json`.
+pub(crate) fn auth_for(base_url: &str, token: Option<&str>) -> (String, Option<String>) {
+    let allowed = base_url.starts_with("https://")
+        || base_url
+            .strip_prefix("http://")
+            .is_some_and(|rest| loopback_host(rest.split('/').next().unwrap_or("")));
+    match token {
+        Some(t) if allowed => (t.to_string(), Some(format!("Bearer {t}"))),
+        _ => (String::from("croft"), None),
+    }
+}
+
+/// Whether `host_port` (authority without scheme or path) is loopback.
+fn loopback_host(host_port: &str) -> bool {
+    if let Some(rest) = host_port.strip_prefix('[') {
+        return rest.split(']').next() == Some("::1");
+    }
+    matches!(
+        host_port.split(':').next().unwrap_or(""),
+        "localhost" | "127.0.0.1"
+    )
 }
 
 /// POST one streaming `/v1/messages` turn and drive its text deltas through
@@ -54,19 +78,30 @@ pub(crate) fn stream_turn(
         // before its first token, but the whole stream may run far longer.
         .timeout_read(Duration::from_secs(300))
         .build();
-    let resp = agent
+    let token = std::env::var("ANTHROPIC_AUTH_TOKEN").ok();
+    let (api_key, bearer) = auth_for(base_url, token.as_deref());
+    let mut post = agent
         .post(&format!("{base_url}/v1/messages"))
         .set("content-type", "application/json")
-        .set("x-api-key", &api_key())
-        .send_string(&req.to_string());
-    let resp = match resp {
+        .set("anthropic-version", "2023-06-01")
+        .set("x-api-key", &api_key);
+    if let Some(bearer) = &bearer {
+        post = post.set("authorization", bearer);
+    }
+    let resp = match post.send_string(&req.to_string()) {
         Ok(r) => r,
         Err(e) => {
+            // The endpoint never answered the turn: pop the user message so
+            // the conversation stays balanced. Leaving it made the NEXT turn
+            // send [user, user] - a hard 400 on strict gateways for the rest
+            // of the seat's life, or a silent re-submit of the unanswered
+            // ask on permissive local servers.
+            messages.pop();
             end_turn(
                 state,
                 turn_tx,
                 true,
-                format!("local endpoint {base_url}: {e}"),
+                format!("local endpoint {base_url}: {}", error_detail(e)),
             );
             return;
         }
@@ -74,31 +109,114 @@ pub(crate) fn stream_turn(
 
     let mut fence = FenceMachine::new();
     let mut assistant = String::new();
+    // Outcome honesty: the turn only succeeded if the stream ENDED cleanly
+    // (message_stop / [DONE]) with untruncated text. A mid-stream drop, the
+    // read timeout, an SSE error frame, or a token-limit cut all used to be
+    // reported as a finished turn while the partial edit had been reverted.
+    let mut clean_end = false;
+    let mut truncated = false;
+    let mut stream_error: Option<String> = None;
+    // Total wall-clock ceiling: the 300s socket timeout is per READ, so a
+    // server trickling bytes could otherwise hold the seat busy forever.
+    let deadline = std::time::Instant::now() + TURN_DEADLINE;
     for line in std::io::BufReader::new(resp.into_reader()).lines() {
+        if std::time::Instant::now() > deadline {
+            stream_error = Some(String::from("turn exceeded the 10 minute ceiling"));
+            break;
+        }
         let Ok(line) = line else {
             break; // endpoint hung up mid-stream; finish() reverts open fences
         };
         let Some(data) = line.strip_prefix("data: ") else {
             continue;
         };
+        if data.trim() == "[DONE]" {
+            clean_end = true;
+            break;
+        }
         let Ok(v) = serde_json::from_str::<Value>(data) else {
             continue;
         };
-        if v["type"] == "content_block_delta"
-            && v["delta"]["type"] == "text_delta"
-            && let Some(text) = v["delta"]["text"].as_str()
-        {
-            assistant.push_str(text);
-            for event in fence.push(text) {
-                apply_fence_event(state, event);
+        match v["type"].as_str().unwrap_or("") {
+            "content_block_delta" => {
+                if v["delta"]["type"] == "text_delta"
+                    && let Some(text) = v["delta"]["text"].as_str()
+                {
+                    assistant.push_str(text);
+                    for event in fence.push(text) {
+                        apply_fence_event(state, event);
+                    }
+                }
             }
+            "message_delta" => {
+                if v["delta"]["stop_reason"] == "max_tokens" {
+                    truncated = true;
+                }
+            }
+            "message_stop" => {
+                clean_end = true;
+                break;
+            }
+            "error" => {
+                let msg = v["error"]["message"].as_str().unwrap_or("stream error");
+                stream_error = Some(msg.to_string());
+                break;
+            }
+            _ => {}
         }
     }
     for event in fence.finish() {
         apply_fence_event(state, event);
     }
-    messages.push(json!({ "role": "assistant", "content": assistant }));
-    end_turn(state, turn_tx, false, assistant);
+    let failure = if let Some(err) = stream_error {
+        Some(err)
+    } else if truncated {
+        Some(format!("reply truncated at the {MAX_TOKENS}-token limit"))
+    } else if !clean_end {
+        Some(String::from("stream ended before message_stop"))
+    } else if assistant.is_empty() {
+        // An empty assistant message is itself a 400 on the next turn.
+        Some(String::from("endpoint streamed no text"))
+    } else {
+        None
+    };
+    match failure {
+        Some(reason) => {
+            messages.pop(); // balanced: the next ask starts a clean exchange
+            end_turn(
+                state,
+                turn_tx,
+                true,
+                format!("local endpoint {base_url}: {reason}"),
+            );
+        }
+        None => {
+            messages.push(json!({ "role": "assistant", "content": assistant }));
+            end_turn(state, turn_tx, false, assistant);
+        }
+    }
+}
+
+/// Total wall-clock ceiling for one turn (the socket timeout is per read).
+const TURN_DEADLINE: Duration = Duration::from_secs(600);
+
+/// The failure text for a request error, with any HTTP error body included:
+/// the body carries the fix ("model 'x' not found, try pulling it first"),
+/// and ureq's Display is just the status code.
+fn error_detail(e: ureq::Error) -> String {
+    match e {
+        ureq::Error::Status(code, resp) => {
+            let body = resp.into_string().unwrap_or_default();
+            let body = body.trim();
+            if body.is_empty() {
+                format!("status {code}")
+            } else {
+                let short: String = body.chars().take(200).collect();
+                format!("status {code}: {short}")
+            }
+        }
+        other => other.to_string(),
+    }
 }
 
 /// The local twin of the claude reader's `result` handling: reset the

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -74,6 +74,6 @@ pub const RELEASE_NOTES: &[ReleaseNote] = &[
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "The gateway token travels as a proper Bearer header and only over https or to localhost, a stalled endpoint can no longer hold the seat busy past ten minutes, and an inverted edit fence reports to OUTPUT instead of corrupting the screen.",
+        summary: "The gateway token travels as a proper Bearer header and only over https or to loopback hosts, a stalled endpoint can no longer hold the seat busy past ten minutes, and an inverted edit fence reports to OUTPUT instead of corrupting the screen.",
     },
 ];

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -74,6 +74,6 @@ pub const RELEASE_NOTES: &[ReleaseNote] = &[
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "The gateway token travels as a proper Bearer header and only over https or to loopback hosts, a stalled endpoint can no longer hold the seat busy past ten minutes, and an inverted edit fence reports to OUTPUT instead of corrupting the screen.",
+        summary: "The gateway token travels as a proper Bearer header and only over https or to loopback hosts, a stalled endpoint can no longer hold the seat busy past ten minutes (the deadline now cuts at the socket itself, so failed turns leak no threads or connections), and an inverted edit fence reports to OUTPUT instead of corrupting the screen.",
     },
 ];

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -62,18 +62,18 @@ pub struct ReleaseNote {
 pub const RELEASE_NOTES: &[ReleaseNote] = &[
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "Navigator comment boxes taller than the window are fully readable: non-wrap scrolling steps into and past a box, the scrollbar is live and accurate with boxes on screen, and a long reply windows around the caret instead of going blind.",
+        summary: "A failed local-model turn no longer poisons the conversation: the unanswered ask is dropped so the next one starts clean, and every failure mode (mid-stream drop, timeout, token-limit truncation, stream errors) is reported honestly instead of as a finished turn.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "F4 reaches every comment, including the navigator's answer anchored on the same line as the note you replied to.",
+        summary: "Toggling the navigator off and on keeps its backend: a local ollama seat no longer silently becomes a cloud claude seat, and croft pair --provider ollama --off simply deactivates.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "Proactive navigator looks stop over-firing: list bullets, block quotes, paragraph splits, and single struct fields or enum variants no longer summon an unsolicited comment turn.",
+        summary: "Local endpoint problems name their cause: HTTP error bodies (like ollama's 'model not found, try pulling it') reach the status line, and a malformed --base-url is refused at activation instead of failing hours later.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "A failed reply no longer duplicates your text in the box, commentary anchors only in its own file, and changing the workspace root drops the old workspace's collaborator carets.",
+        summary: "The gateway token travels as a proper Bearer header and only over https or to localhost, a stalled endpoint can no longer hold the seat busy past ten minutes, and an inverted edit fence reports to OUTPUT instead of corrupting the screen.",
     },
 ];

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -52,8 +52,12 @@ fn probe_subcommands_answer_instantly_even_with_a_stripped_path() {
             .env("SHELL", &slow_shell)
             .assert()
             .success();
+        // The discriminant is the 10s sleeping shell: a probe that runs the
+        // PATH repair blocks on it, one that early-outs answers in well
+        // under a second. 5s tolerates a loaded box without ever passing
+        // the failure mode.
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(2),
+            start.elapsed() < std::time::Duration::from_secs(5),
             "{sub} --probe took {:?} with a stripped PATH",
             start.elapsed()
         );
@@ -67,4 +71,79 @@ fn nonexistent_path_fails_cleanly() {
         .arg("/nonexistent/path/that/does/not/exist/abc123")
         .assert()
         .failure();
+}
+
+/// The persisted pair record is the baseline for every `croft pair`
+/// invocation: `--off` (with or without provider flags) and a plain
+/// re-activation must both keep a custom ollama endpoint. Resolving bare
+/// flags in isolation used to clobber the custom URL with the default and
+/// silently converted a disabled ollama record into a cloud claude seat.
+#[test]
+fn pair_off_and_reactivation_keep_the_recorded_backend() {
+    // A SHORT home: the activation path binds a relay socket under
+    // $HOME/.cache/croft/sessions, and the default tempdir base pushes the
+    // path past the AF_UNIX 104-byte limit.
+    let home = tempfile::Builder::new()
+        .prefix("h")
+        .tempdir_in("/tmp")
+        .unwrap();
+    let ws = tempfile::tempdir().unwrap();
+    let run = |args: &[&str]| {
+        Command::cargo_bin("croft")
+            .unwrap()
+            .args(args)
+            .arg("--workspace")
+            .arg(ws.path())
+            .env("HOME", home.path())
+            .assert()
+            .success();
+    };
+    run(&[
+        "pair",
+        "--provider",
+        "ollama",
+        "--model",
+        "qwen3-coder:30b",
+        "--base-url",
+        "http://localhost:9999",
+    ]);
+    let record_path = || {
+        let dir = home.path().join(".cache/croft/sessions");
+        std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .find(|p| p.to_string_lossy().ends_with(".pair.json"))
+            .expect("a pair record exists")
+    };
+    let read = || std::fs::read_to_string(record_path()).unwrap();
+    assert!(read().contains("http://localhost:9999"));
+    // Deactivate with provider flags but no URL: the custom URL survives.
+    run(&["pair", "--provider", "ollama", "--off"]);
+    let r = read();
+    assert!(r.contains("\"enabled\":false"), "{r}");
+    assert!(
+        r.contains("http://localhost:9999"),
+        "the default endpoint must not clobber the custom one: {r}"
+    );
+    // Plain re-activation: the whole recorded backend comes back.
+    run(&["pair"]);
+    let r = read();
+    assert!(r.contains("\"enabled\":true"), "{r}");
+    assert!(r.contains("\"provider\":\"ollama\""), "{r}");
+    assert!(r.contains("http://localhost:9999"), "{r}");
+    assert!(r.contains("qwen3-coder:30b"), "{r}");
+    // Activation detached a relay for the workspace; reap it so test runs
+    // do not accumulate idle processes.
+    let sessions = home.path().join(".cache/croft/sessions");
+    if let Ok(entries) = std::fs::read_dir(&sessions) {
+        for e in entries.filter_map(|e| e.ok()) {
+            let p = e.path();
+            if p.to_string_lossy().ends_with(".collab.sock") {
+                let _ = std::process::Command::new("pkill")
+                    .args(["-f", &p.to_string_lossy()])
+                    .status();
+            }
+        }
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -133,6 +133,16 @@ fn pair_off_and_reactivation_keep_the_recorded_backend() {
     assert!(r.contains("\"provider\":\"ollama\""), "{r}");
     assert!(r.contains("http://localhost:9999"), "{r}");
     assert!(r.contains("qwen3-coder:30b"), "{r}");
+    // An explicit provider SWITCH starts fresh: the other backend's
+    // endpoint and model must not ride along into the claude record.
+    run(&["pair", "--provider", "claude"]);
+    let r = read();
+    assert!(r.contains("\"provider\":\"claude\""), "{r}");
+    assert!(
+        !r.contains("http://localhost:9999"),
+        "the ollama endpoint must not survive a provider switch: {r}"
+    );
+    assert!(!r.contains("qwen3-coder:30b"), "{r}");
     // Activation detached a relay for the workspace; reap it so test runs
     // do not accumulate idle processes.
     let sessions = home.path().join(".cache/croft/sessions");


### PR DESCRIPTION
An adversarial review of the twelve-commit local-model navigator span (0.1.636, judged against current HEAD) produced ten findings; nine are fixed here RED-test-first and one is settled as a documentation correction.

- Conversation integrity: a failed local turn used to leave its unanswered user message in the conversation, so the next ask sent [user, user] — a permanent 400 on strict gateways, a silent double-submit on permissive ones — and a zero-delta success appended an empty assistant message (also a 400). Failed turns now pop the ask so the seat genuinely survives with a clean retry.
- Outcome honesty: mid-stream drops, the read timeout, SSE error frames, non-SSE 200s, and token-limit truncation were all reported as a finished turn; each is now a named failure, and the turn has a ten-minute wall-clock ceiling so a trickling endpoint cannot hold the seat busy forever.
- Diagnosability: HTTP error bodies (ollama's "model not found, try pulling it") now reach the status line instead of an opaque status code, and --base-url is normalised (trailing slash) and validated (scheme) at activation.
- Credential safety: ANTHROPIC_AUTH_TOKEN travels as Authorization: Bearer (Anthropic's convention for that variable, mirrored into x-api-key) with anthropic-version, and only over https or to a loopback host — a cleartext remote hop gets a placeholder.
- Provider persistence: the palette toggle and croft pair --off preserved neither provider nor base_url, silently reseating a local-only ollama navigator on the cloud claude CLI; both now carry the recorded backend forward, and --provider ollama --off deactivates instead of demanding --model.
- Screen safety: a parseable-but-inverted whole-line fence range reported via eprintln! from the in-process navigator, corrupting the alternate screen; it now reports through the OUTPUT channel.
- The tenth finding (a memory claim that the 213KB claude-CLI prefill behavior is "settled by test" when no such test survives) is corrected in the project memory: the claim stands as design prose from the live spike, pinned by nothing hermetic.

Full suite: 2784 + 5 CLI tests, 0 failed, clippy zero warnings. Ships as 0.1.658.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed local-model requests failing silently or leaving incomplete conversations.
  * Improved endpoint validation and error reporting with relevant response details.
  * Added safer authentication, redirect refusal, streaming interruption, empty-response, and timeout handling.
  * Preserved navigator settings when toggling it off and on or deactivating it.
  * Prevented stale local-model settings when switching providers.
  * Displayed edit-range warnings in Navigator output.
* **Documentation**
  * Clarified local-model authentication, transport security, and saved pair configuration.
* **Chores**
  * Updated the package version to 0.1.658.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->