### PR TITLE
fix(pair): navigator lifecycle hardening (note anchors, host lock liveness, draft loss, child reaping)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.658"
+version = "0.1.659"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.658"
+version = "0.1.659"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/MULTIPLAYER.md
+++ b/docs/MULTIPLAYER.md
@@ -561,11 +561,18 @@ interaction into turn-based driver/navigator pairing:
   `◆ <name> seated` badge; the orange streaming badge takes over whenever
   it types. If the claude child dies (or fails to seat), the host surfaces
   it and unseats, and does NOT respawn it every second — the latch clears
-  only when the record is deactivated, so a `croft pair --off` / `croft
-  pair` (or palette off/on) re-activates. Teardown on unseat runs on a
+  when the record is deactivated OR rewritten, so `croft pair --off` /
+  `croft pair`, a palette off/on, or simply re-running `croft pair` after
+  fixing the backend all re-activate. A window whose spawn failed also
+  releases the single-host lock (and its same-tick owner self-appointment),
+  so another croft window in the workspace can host instead; the losing
+  window announces the refusal once and keeps polling silently for
+  takeover. Teardown on unseat runs on a
   detached thread so the 2s grace-kill never freezes the UI, and the exit
   paths (drop-to-local, self-update exec) reap the child synchronously
-  first. The claude binary resolves to an absolute path when off `PATH`, so
+  first, then join every teardown a recent unseat detached — a thread that
+  died with the process used to leave the claude child running. The claude
+  binary resolves to an absolute path when off `PATH`, so
   a stripped GUI-launch environment can still seat it.
 
 ### Local models (0.1.636)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2722,19 +2722,34 @@ pub struct App {
     /// Notes the navigator left since its turn started, so the TurnDone
     /// status can surface them instead of overwriting the NoteAdded status.
     pair_notes_this_turn: usize,
-    /// The file the turn's notes landed in (for the TurnDone hint; F4 only
-    /// cycles the active file, so naming it tells the user where to look).
+    /// The file the turn's notes LAST landed in (anchors the turn's prose
+    /// when the invocation origin is unknown).
     pair_last_noted_file: Option<String>,
+    /// Every file the turn's notes landed in: the TurnDone hint names the
+    /// file only when there is exactly one ("3 comments in b.rs" was a lie
+    /// when two of them sat in a.rs).
+    pair_noted_files: std::collections::BTreeSet<String>,
     /// Held while this croft is the self-appointed navigator owner: exactly
     /// one plain croft per workspace may host the pilot (and claim collab
     /// owner site 1). Released by the OS on exit, so a crashed host hands off.
     pair_host_lock: Option<crate::session::PairHostLock>,
     /// Set when the pilot died or failed to seat: suppresses the 1s re-seat
     /// so a broken claude (unauthenticated, missing, crashing) is not
-    /// respawned forever. Cleared when the record is deactivated, so an
-    /// explicit off/on (or toggle) re-activates. Matches the LSP precedent:
-    /// no auto-respawn within a session; a fresh croft retries.
+    /// respawned forever. Cleared when the record is deactivated OR
+    /// rewritten (any `croft pair` run re-arms seating, as the CLI
+    /// promises), so an explicit off/on (or toggle) re-activates. Matches
+    /// the LSP precedent: no auto-respawn within a session; a fresh croft
+    /// retries.
     navigator_down: bool,
+    /// The pair record's mtime at the last 1s check: a changed mtime means
+    /// someone ran `croft pair` (even enabled→enabled, where no other
+    /// transition is observable) and clears [`navigator_down`].
+    last_pair_record_mtime: Option<std::time::SystemTime>,
+    /// Whether the "hosted by another croft window" refusal has already
+    /// been announced: the losing window keeps polling for takeover every
+    /// second, and re-announcing each poll clobbered its status line
+    /// forever (and forced a 1 Hz repaint).
+    pair_lock_denied: bool,
     /// Proactive navigator looks (docs/MULTIPLAYER.md): a completed new
     /// construct plus a typing pause hands the seated navigator a
     /// comment-only turn on its own. Opt-out via
@@ -3616,6 +3631,9 @@ impl App {
             pair_last_noted_file: None,
             pair_host_lock: None,
             navigator_down: false,
+            last_pair_record_mtime: None,
+            pair_lock_denied: false,
+            pair_noted_files: std::collections::BTreeSet::new(),
             proactive_navigator_enabled: !loaded_prefs.disable_proactive_navigator,
             proactive_scanned: std::collections::HashMap::new(),
             #[cfg(test)]
@@ -15671,15 +15689,21 @@ impl App {
                 range,
                 selection,
             } => {
-                self.close_input_prompt();
+                // The prompt closes only on a SENT ask: a failure (navigator
+                // gone or gone busy while the user typed) keeps the box open
+                // with the draft intact for a retry, like a failed comment
+                // reply keeps its draft.
                 let Some(host) = &self.pair_host else {
                     self.status = String::from("Navigator is not active");
                     return;
                 };
                 let content = self.editor.lines.join("\n");
-                match host.send_ask_turn(&file, range, &selection, &value, &content) {
+                let name = host.name().to_string();
+                let result = host.send_ask_turn(&file, range, &selection, &value, &content);
+                match result {
                     Ok(()) => {
-                        self.status = format!("Asked {} about {file}:{}", host.name(), range.0 + 1);
+                        self.close_input_prompt();
+                        self.status = format!("Asked {name} about {file}:{}", range.0 + 1);
                         // Anchor the turn's prose commentary where it was asked.
                         self.pair_turn_origin = Some((file, range.0));
                     }
@@ -15885,12 +15909,27 @@ impl App {
             return false;
         }
         self.last_pair_check = Some(std::time::Instant::now());
+        // A rewritten record re-arms seating: after a failed seat the user
+        // re-runs `croft pair`, and the CLI promises "a running croft seats
+        // it within a second" — but an enabled→enabled rewrite has no other
+        // observable transition. The mtime is the signal (the contents may
+        // be byte-identical).
+        let mtime = std::fs::metadata(&self.pair_record_path)
+            .ok()
+            .and_then(|m| m.modified().ok());
+        if self.last_pair_record_mtime != mtime {
+            if self.last_pair_record_mtime.is_some() {
+                self.navigator_down = false;
+            }
+            self.last_pair_record_mtime = mtime;
+        }
         let record = crate::session::read_pair_record(&self.pair_record_path);
         let want = record.as_ref().is_some_and(|r| r.enabled);
         if !want {
             // Deactivation clears the death latch, so `croft pair --off`
             // then `croft pair` (or a palette off/on) re-activates.
             self.navigator_down = false;
+            self.pair_lock_denied = false;
             if let Some(host) = self.pair_host.take() {
                 // Drop tears the seat down; its parked caret goes with it.
                 let sites = host.caret_sites();
@@ -15898,6 +15937,11 @@ impl App {
                 self.navigator_notes.clear();
                 self.pair_commentary_buf.clear();
                 self.pair_turn_origin = None;
+                // The turn counters die with the seat: leaking them made
+                // the NEXT seat's first TurnDone report a dead seat's notes.
+                self.pair_notes_this_turn = 0;
+                self.pair_last_noted_file = None;
+                self.pair_noted_files.clear();
                 self.editor.comment_focus = None;
                 self.status = String::from("Navigator unseated");
                 return true;
@@ -15920,6 +15964,7 @@ impl App {
             return false;
         }
         let record = record.expect("want implies a record");
+        let mut self_appointed_now = false;
         if self.collab_config.is_none() {
             // Only one croft may self-appoint owner per workspace: two owners
             // would both claim site id 1 and corrupt the shared buffer. Claim
@@ -15927,8 +15972,18 @@ impl App {
             // host (keep checking — take over when that croft exits).
             if self.pair_host_lock.is_none() {
                 match crate::session::try_acquire_pair_host_lock(&self.pair_host_lock_path) {
-                    Some(lock) => self.pair_host_lock = Some(lock),
+                    Some(lock) => {
+                        self.pair_host_lock = Some(lock);
+                        self.pair_lock_denied = false;
+                    }
                     None => {
+                        // Announced ONCE: the takeover poll keeps running
+                        // every second, and re-announcing clobbered the
+                        // window's status line forever at a 1 Hz repaint.
+                        if self.pair_lock_denied {
+                            return false;
+                        }
+                        self.pair_lock_denied = true;
                         self.status = format!(
                             "Navigator '{}' is hosted by another croft window in this workspace",
                             record.name
@@ -15943,6 +15998,7 @@ impl App {
             }
             self.collab_config = Some((self.pair_socket.clone(), crate::collab::CollabRole::Owner));
             self.last_collab_connect = None; // connect this tick, not in 2s
+            self_appointed_now = true;
         }
         let cfg = crate::pair::PairConfig {
             socket: self.pair_socket.clone(),
@@ -15978,6 +16034,16 @@ impl App {
             Err(e) => {
                 self.status = format!("Navigator failed to seat: {e}");
                 self.navigator_down = true; // no 1s retry storm
+                if self_appointed_now {
+                    // A window that cannot host must not block one that can:
+                    // undo the self-appointment made moments ago (nothing
+                    // has connected yet within this same call) and release
+                    // the lock so another croft may claim the seat. A host
+                    // whose PILOT died later keeps both — it is still the
+                    // live collab owner and re-seats on re-activation.
+                    self.collab_config = None;
+                    self.pair_host_lock = None;
+                }
             }
         }
         true
@@ -16010,11 +16076,13 @@ impl App {
                     let snippet: String = body.chars().take(60).collect();
                     self.status = format!("{name} commented on {file}:{}: {snippet}", row + 1);
                     self.pair_notes_this_turn += 1;
+                    self.pair_noted_files.insert(file.clone());
                     self.pair_last_noted_file = Some(file);
                 }
                 crate::pair_host::PairEvent::TurnDone { cancelled, failed } => {
                     let mut notes = std::mem::take(&mut self.pair_notes_this_turn);
-                    let mut file = self.pair_last_noted_file.take();
+                    let mut files = std::mem::take(&mut self.pair_noted_files);
+                    let file = self.pair_last_noted_file.take();
                     let prose = std::mem::take(&mut self.pair_commentary_buf);
                     let origin = self.pair_turn_origin.take();
                     if !cancelled && !prose.trim().is_empty() {
@@ -16051,7 +16119,7 @@ impl App {
                         match (landed, anchor) {
                             (Some(_), Some((f, _))) => {
                                 notes += 1;
-                                file.get_or_insert(f);
+                                files.insert(f);
                             }
                             _ => {
                                 for line in prose.lines().filter(|l| !l.trim().is_empty()) {
@@ -16070,13 +16138,10 @@ impl App {
                         let err: String = err.chars().take(80).collect();
                         format!("{name}: turn failed: {err}")
                     } else if notes > 0 {
-                        let plural = if notes == 1 { "comment" } else { "comments" };
-                        match file {
-                            Some(f) => {
-                                format!("{name} finished: {notes} {plural} in {f} · F4 to review")
-                            }
-                            None => format!("{name} finished: {notes} {plural} · F4 to review"),
-                        }
+                        format!(
+                            "{name} finished: {} · F4 to review",
+                            turn_note_summary(notes, &files)
+                        )
                     } else {
                         format!("{name} finished its turn")
                     };
@@ -16097,6 +16162,10 @@ impl App {
             self.navigator_notes.clear();
             self.pair_commentary_buf.clear();
             self.pair_turn_origin = None;
+            // The turn counters die with the seat (see the unseat twin).
+            self.pair_notes_this_turn = 0;
+            self.pair_last_noted_file = None;
+            self.pair_noted_files.clear();
             self.editor.comment_focus = None;
             self.navigator_down = true; // no auto-respawn; re-activate to retry
             return true;
@@ -16376,6 +16445,13 @@ impl App {
             return false;
         };
         if host.is_busy() || self.editor.comment_focus.is_some() {
+            return false;
+        }
+        // The user is mid-typing in a prompt (the ask box included):
+        // stealing the seat now would make their Enter land on a busy host
+        // and fail. Suppress WITHOUT consuming the scan latch below, so the
+        // look fires once the prompt closes.
+        if self.input_prompt.is_some() {
             return false;
         }
         let Some(edited) = self.editor.last_edit_at else {
@@ -29774,6 +29850,22 @@ fn is_extensions_jump_key(key: KeyEvent) -> bool {
     is_cmd_shift_letter(key, 'x')
 }
 
+/// The TurnDone status fragment for a turn's notes: the file is named only
+/// when every note landed in the SAME file. "3 comments in b.rs" was a lie
+/// when two of them sat in a.rs (F4 only cycles the active file, so the
+/// name tells the user where to look).
+fn turn_note_summary(notes: usize, files: &std::collections::BTreeSet<String>) -> String {
+    let plural = if notes == 1 { "comment" } else { "comments" };
+    match files.len() {
+        0 => format!("{notes} {plural}"),
+        1 => format!(
+            "{notes} {plural} in {}",
+            files.iter().next().expect("len checked")
+        ),
+        n => format!("{notes} {plural} across {n} files"),
+    }
+}
+
 /// Index of the next navigator note to visit from `here` = (row, index of
 /// the currently focused note, or `usize::MAX` when the walk starts from a
 /// bare caret row): the note with the smallest (row, index) strictly greater
@@ -32149,6 +32241,10 @@ pub fn run(
     if let Some(host) = app.pair_host.take() {
         host.shutdown_blocking();
     }
+    // And every teardown a recent unseat DETACHED (toggle off, record
+    // disabled, pilot death): those threads race process exit, and a thread
+    // that dies mid-grace-kill leaves the claude child running.
+    crate::pair_host::join_teardowns();
 
     result?;
     if app.drop_to_local {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15997,6 +15997,11 @@ impl App {
             }
             if let Err(e) = crate::collab::ensure_relay(&self.pair_socket) {
                 self.status = format!("Navigator: relay failed: {e}");
+                // The spawn failure's sibling: this window holds the lock
+                // but cannot host without a relay. Release it so another
+                // window can try; this one retries next second and may
+                // re-acquire.
+                self.pair_host_lock = None;
                 return true;
             }
             self.collab_config = Some((self.pair_socket.clone(), crate::collab::CollabRole::Owner));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2741,10 +2741,12 @@ pub struct App {
     /// the LSP precedent: no auto-respawn within a session; a fresh croft
     /// retries.
     navigator_down: bool,
-    /// The pair record's mtime at the last 1s check: a changed mtime means
-    /// someone ran `croft pair` (even enabled→enabled, where no other
-    /// transition is observable) and clears [`navigator_down`].
-    last_pair_record_mtime: Option<std::time::SystemTime>,
+    /// The pair record's raw bytes at the last 1s check: changed bytes mean
+    /// someone ran `croft pair` (even enabled→enabled — every write stamps
+    /// the record, so no rewrite is byte-identical) and clear
+    /// [`navigator_down`]. Content, not mtime: a same-grain rewrite on a
+    /// coarse-timestamp filesystem keeps its mtime.
+    last_pair_record_raw: Option<Vec<u8>>,
     /// Whether the "hosted by another croft window" refusal has already
     /// been announced: the losing window keeps polling for takeover every
     /// second, and re-announcing each poll clobbered its status line
@@ -3631,7 +3633,7 @@ impl App {
             pair_last_noted_file: None,
             pair_host_lock: None,
             navigator_down: false,
-            last_pair_record_mtime: None,
+            last_pair_record_raw: None,
             pair_lock_denied: false,
             pair_noted_files: std::collections::BTreeSet::new(),
             proactive_navigator_enabled: !loaded_prefs.disable_proactive_navigator,
@@ -15912,18 +15914,19 @@ impl App {
         // A rewritten record re-arms seating: after a failed seat the user
         // re-runs `croft pair`, and the CLI promises "a running croft seats
         // it within a second" — but an enabled→enabled rewrite has no other
-        // observable transition. The mtime is the signal (the contents may
-        // be byte-identical).
-        let mtime = std::fs::metadata(&self.pair_record_path)
-            .ok()
-            .and_then(|m| m.modified().ok());
-        if self.last_pair_record_mtime != mtime {
-            if self.last_pair_record_mtime.is_some() {
+        // observable transition. The record's BYTES are the signal (every
+        // write stamps them, and mtime misses a same-grain rewrite on a
+        // coarse-timestamp filesystem).
+        let raw = std::fs::read(&self.pair_record_path).ok();
+        if self.last_pair_record_raw != raw {
+            if self.last_pair_record_raw.is_some() {
                 self.navigator_down = false;
             }
-            self.last_pair_record_mtime = mtime;
+            self.last_pair_record_raw = raw.clone();
         }
-        let record = crate::session::read_pair_record(&self.pair_record_path);
+        let record: Option<crate::session::PairRecord> = raw
+            .as_deref()
+            .and_then(|bytes| serde_json::from_slice(bytes).ok());
         let want = record.as_ref().is_some_and(|r| r.enabled);
         if !want {
             // Deactivation clears the death latch, so `croft pair --off`

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20120,14 +20120,20 @@ fn a_record_rewrite_re_arms_a_downed_navigator() {
     assert!(app.pair_host.is_none());
 
     // The user fixes the backend and re-runs `croft pair`: the rewritten
-    // record (bumped mtime; contents may be identical) re-arms seating.
+    // record re-arms seating — even when the rewrite lands within the same
+    // mtime grain (coarse-timestamp filesystems): pin the mtime to the old
+    // value so only the CONTENT can carry the signal (every write stamps
+    // the record, so an enabled→enabled rewrite is never byte-identical).
+    let old_mtime = std::fs::metadata(&app.pair_record_path)
+        .unwrap()
+        .modified()
+        .unwrap();
     crate::session::write_pair_record(&app.pair_record_path, &record).unwrap();
     let f = std::fs::File::options()
         .write(true)
         .open(&app.pair_record_path)
         .unwrap();
-    f.set_modified(std::time::SystemTime::now() + Duration::from_secs(2))
-        .unwrap();
+    f.set_modified(old_mtime).unwrap();
     app.pair_spawn_override = Some(Box::new(local_test_spawn));
     app.last_pair_check = None;
     app.maybe_seat_navigator();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19877,15 +19877,17 @@ fn only_one_croft_self_appoints_the_navigator_owner() {
         a.last_pair_check = None;
     };
 
-    // Croft A grabs the single-host lock and self-appoints (the spawn bails,
-    // but the lock is taken first and held).
+    // Croft A grabs the single-host lock, self-appoints, and HOSTS (a
+    // local-provider seat spawns no child): the lock is only kept by a
+    // window that actually holds the seat.
     let mut a = App::new(tmp.path().to_path_buf()).unwrap();
     a.pair_record_path = tmp.path().join("a.pair.json");
     a.pair_socket = socket.clone();
     a.pair_host_lock_path = lock_path.clone();
-    a.pair_spawn_override = Some(Box::new(|_| anyhow::bail!("no real child in test")));
+    a.pair_spawn_override = Some(Box::new(local_test_spawn));
     enable(&mut a);
     a.maybe_seat_navigator();
+    assert!(a.pair_host.is_some(), "A must host: {}", a.status);
     assert!(
         a.pair_host_lock.is_some(),
         "A must hold the single-host lock"
@@ -19906,6 +19908,233 @@ fn only_one_croft_self_appoints_the_navigator_owner() {
         b.status.to_lowercase().contains("another croft"),
         "B must say another croft hosts it, got: {}",
         b.status
+    );
+
+    // The refusal is announced ONCE. B keeps silently polling for takeover,
+    // but re-announcing every second clobbered its status line forever and
+    // dirtied a frame at 1 Hz.
+    b.status = String::from("Saved src/foo.rs");
+    b.last_pair_check = None;
+    let redraw = b.maybe_seat_navigator();
+    assert!(!redraw, "an unchanged refusal must not dirty the frame");
+    assert_eq!(
+        b.status, "Saved src/foo.rs",
+        "the refusal must not clobber the status line again"
+    );
+}
+
+/// A local-provider seat for tests: connects to the workspace relay but
+/// spawns no child process (the endpoint is never contacted until a turn).
+fn local_test_spawn(cfg: &crate::pair::PairConfig) -> anyhow::Result<crate::pair_host::PairHost> {
+    crate::pair_host::PairHost::spawn(crate::pair::PairConfig {
+        socket: cfg.socket.clone(),
+        workspace: cfg.workspace.clone(),
+        name: cfg.name.clone(),
+        model: Some(String::from("test-model")),
+        task: None,
+        provider: crate::pair::Provider::Local {
+            base_url: String::from("http://127.0.0.1:9"),
+        },
+    })
+}
+
+/// A window whose spawn FAILED must not keep the workspace's single-host
+/// lock: it cannot host, so holding the flock only blocks the window that
+/// can. The failed spawner un-appoints itself and releases; the next window
+/// acquires and seats.
+#[test]
+fn a_failed_spawner_releases_the_lock_so_another_window_can_host() {
+    use std::time::{Duration, Instant};
+    let tmp = tempfile::tempdir().unwrap();
+    let socket = tmp.path().join("collab.sock");
+    let lock_path = tmp.path().join("host.lock");
+    {
+        let s = socket.clone();
+        std::thread::spawn(move || {
+            let _ = crate::collab::relay_serve(&s);
+        });
+    }
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !crate::session::is_alive(&socket) {
+        assert!(Instant::now() < deadline, "relay never came up");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let record = crate::session::PairRecord {
+        model: None,
+        name: "nav".into(),
+        enabled: true,
+        task: None,
+        provider: None,
+        base_url: None,
+    };
+
+    let mut a = App::new(tmp.path().to_path_buf()).unwrap();
+    a.pair_record_path = tmp.path().join("a.pair.json");
+    a.pair_socket = socket.clone();
+    a.pair_host_lock_path = lock_path.clone();
+    a.pair_spawn_override = Some(Box::new(|_| anyhow::bail!("claude is broken")));
+    crate::session::write_pair_record(&a.pair_record_path, &record).unwrap();
+    a.last_pair_check = None;
+    a.maybe_seat_navigator();
+    assert!(a.pair_host.is_none());
+    assert!(a.navigator_down, "the failure latches, no 1s retry storm");
+    assert!(
+        a.pair_host_lock.is_none(),
+        "a window that cannot host must release the lock"
+    );
+    assert!(
+        a.collab_config.is_none(),
+        "the same-tick self-appointment is undone with it"
+    );
+
+    let mut b = App::new(tmp.path().to_path_buf()).unwrap();
+    b.pair_record_path = tmp.path().join("b.pair.json");
+    b.pair_socket = socket.clone();
+    b.pair_host_lock_path = lock_path.clone();
+    b.pair_spawn_override = Some(Box::new(local_test_spawn));
+    crate::session::write_pair_record(&b.pair_record_path, &record).unwrap();
+    b.last_pair_check = None;
+    b.maybe_seat_navigator();
+    assert!(
+        b.pair_host.is_some(),
+        "the working window must be able to host: {}",
+        b.status
+    );
+}
+
+/// Unseating the navigator mid-turn must reset the turn's note counters:
+/// they survived into the NEXT seat's first TurnDone, which then reported
+/// a dead seat's notes (inflated count, wrong file).
+#[test]
+fn unseating_the_navigator_resets_the_turn_note_counters() {
+    use std::time::{Duration, Instant};
+    let tmp = tempfile::tempdir().unwrap();
+    let socket = tmp.path().join("collab.sock");
+    {
+        let s = socket.clone();
+        std::thread::spawn(move || {
+            let _ = crate::collab::relay_serve(&s);
+        });
+    }
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !crate::session::is_alive(&socket) {
+        assert!(Instant::now() < deadline, "relay never came up");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let mut record = crate::session::PairRecord {
+        model: None,
+        name: "nav".into(),
+        enabled: true,
+        task: None,
+        provider: None,
+        base_url: None,
+    };
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.pair_record_path = tmp.path().join("x.pair.json");
+    app.pair_socket = socket.clone();
+    app.pair_host_lock_path = tmp.path().join("x.host.lock");
+    app.pair_spawn_override = Some(Box::new(local_test_spawn));
+    crate::session::write_pair_record(&app.pair_record_path, &record).unwrap();
+    app.last_pair_check = None;
+    app.maybe_seat_navigator();
+    assert!(app.pair_host.is_some(), "seated: {}", app.status);
+
+    // Mid-turn state: the navigator commented three times in a.rs.
+    app.pair_notes_this_turn = 3;
+    app.pair_last_noted_file = Some(String::from("a.rs"));
+    app.pair_noted_files.insert(String::from("a.rs"));
+
+    record.enabled = false;
+    crate::session::write_pair_record(&app.pair_record_path, &record).unwrap();
+    app.last_pair_check = None;
+    app.maybe_seat_navigator();
+    assert!(app.pair_host.is_none(), "unseated");
+    assert_eq!(
+        app.pair_notes_this_turn, 0,
+        "a dead seat's note count must not leak into the next seat's TurnDone"
+    );
+    assert!(
+        app.pair_last_noted_file.is_none(),
+        "a dead seat's noted file must not leak either"
+    );
+    assert!(app.pair_noted_files.is_empty());
+}
+
+/// The TurnDone hint names a file only when every note landed in the SAME
+/// file: "3 comments in b.rs" was a lie when two of them sat in a.rs.
+#[test]
+fn turn_note_summary_only_names_a_single_file() {
+    use std::collections::BTreeSet;
+    let one: BTreeSet<String> = [String::from("a.rs")].into();
+    assert_eq!(super::turn_note_summary(1, &one), "1 comment in a.rs");
+    assert_eq!(super::turn_note_summary(3, &one), "3 comments in a.rs");
+    let two: BTreeSet<String> = [String::from("a.rs"), String::from("b.rs")].into();
+    assert_eq!(
+        super::turn_note_summary(3, &two),
+        "3 comments across 2 files"
+    );
+    assert_eq!(super::turn_note_summary(2, &BTreeSet::new()), "2 comments");
+}
+
+/// Re-running `croft pair` after a failed seat must retry: the CLI promises
+/// "a running croft seats it within a second", but an enabled→enabled
+/// rewrite has no transition for the death latch to observe. The record's
+/// mtime is the signal.
+#[test]
+fn a_record_rewrite_re_arms_a_downed_navigator() {
+    use std::time::{Duration, Instant};
+    let tmp = tempfile::tempdir().unwrap();
+    let socket = tmp.path().join("collab.sock");
+    {
+        let s = socket.clone();
+        std::thread::spawn(move || {
+            let _ = crate::collab::relay_serve(&s);
+        });
+    }
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !crate::session::is_alive(&socket) {
+        assert!(Instant::now() < deadline, "relay never came up");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let record = crate::session::PairRecord {
+        model: None,
+        name: "nav".into(),
+        enabled: true,
+        task: None,
+        provider: None,
+        base_url: None,
+    };
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.pair_record_path = tmp.path().join("x.pair.json");
+    app.pair_socket = socket.clone();
+    app.pair_host_lock_path = tmp.path().join("x.host.lock");
+    app.pair_spawn_override = Some(Box::new(|_| anyhow::bail!("claude is broken")));
+    crate::session::write_pair_record(&app.pair_record_path, &record).unwrap();
+    app.last_pair_check = None;
+    app.maybe_seat_navigator();
+    assert!(app.navigator_down, "the first seat fails and latches");
+
+    // Latched: an unchanged record must NOT retry every second.
+    app.last_pair_check = None;
+    app.maybe_seat_navigator();
+    assert!(app.pair_host.is_none());
+
+    // The user fixes the backend and re-runs `croft pair`: the rewritten
+    // record (bumped mtime; contents may be identical) re-arms seating.
+    crate::session::write_pair_record(&app.pair_record_path, &record).unwrap();
+    let f = std::fs::File::options()
+        .write(true)
+        .open(&app.pair_record_path)
+        .unwrap();
+    f.set_modified(std::time::SystemTime::now() + Duration::from_secs(2))
+        .unwrap();
+    app.pair_spawn_override = Some(Box::new(local_test_spawn));
+    app.last_pair_check = None;
+    app.maybe_seat_navigator();
+    assert!(
+        app.pair_host.is_some(),
+        "a rewritten record must re-arm the downed navigator: {}",
+        app.status
     );
 }
 
@@ -20476,9 +20705,21 @@ fn a_completed_construct_plus_pause_triggers_a_proactive_look() {
         "the pref must gate the look"
     );
 
-    // Pref back on: the completed construct fires a comment-only look
-    // anchored at the new function's row.
+    // Pref back on but the user is mid-typing in a prompt (the ask box):
+    // stealing the seat now would make their Enter fail against a busy
+    // host and lose the typed draft. An open prompt suppresses the look
+    // without consuming the scan.
     app.proactive_navigator_enabled = true;
+    app.open_ask_navigator((0, 0), String::new());
+    assert!(app.input_prompt.is_some(), "the ask box must open");
+    assert!(
+        !app.tick_proactive_navigator(),
+        "an open prompt must suppress the proactive look"
+    );
+    app.close_input_prompt();
+
+    // Prompt closed: the completed construct fires a comment-only look
+    // anchored at the new function's row.
     assert!(app.tick_proactive_navigator(), "new fn + pause must fire");
     assert_eq!(
         app.pair_turn_origin,
@@ -20492,6 +20733,41 @@ fn a_completed_construct_plus_pause_triggers_a_proactive_look() {
 
     // The same buffer state never fires twice (latch + busy host).
     assert!(!app.tick_proactive_navigator());
+}
+
+/// A failed ask submit must not eat the typed draft: the navigator can go
+/// away (or busy) between opening the box and Enter, and the instruction
+/// the user typed is unrecoverable once the prompt closes. The failure
+/// keeps the box open for a retry, like a failed comment reply keeps its
+/// draft.
+#[test]
+fn a_failed_ask_submit_keeps_the_typed_draft() {
+    use crate::widgets::input_prompt::{InputPrompt, InputPurpose};
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.input_prompt = Some(
+        InputPrompt::new(
+            InputPurpose::AskNavigator {
+                file: String::from("f.rs"),
+                range: (0, 0),
+                selection: String::new(),
+            },
+            "Ask nav",
+            "",
+        )
+        .with_value("check the loop bounds"),
+    );
+    app.submit_input_prompt();
+    let p = app
+        .input_prompt
+        .as_ref()
+        .expect("the failed submit must keep the prompt open");
+    assert_eq!(p.value, "check the loop bounds", "the draft survives");
+    assert!(
+        app.status.to_lowercase().contains("not active"),
+        "the failure is announced: {}",
+        app.status
+    );
 }
 
 /// Enter in a focused comment box sends the reply turn: the composed

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20076,6 +20076,47 @@ fn turn_note_summary_only_names_a_single_file() {
     assert_eq!(super::turn_note_summary(2, &BTreeSet::new()), "2 comments");
 }
 
+/// Relay startup failure is the spawn failure's sibling: the window has
+/// already acquired the workspace host lock, cannot host without a relay,
+/// and must release the lock on the way out so another window can try.
+/// Holding it made every other window report "hosted by another croft
+/// window" while nobody hosted anything.
+#[test]
+fn a_relay_failure_releases_the_host_lock() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.pair_record_path = tmp.path().join("x.pair.json");
+    // A socket inside a directory that does not exist: the relay can never
+    // bind it, so ensure_relay fails after its aliveness poll.
+    app.pair_socket = tmp.path().join("missing-dir").join("collab.sock");
+    app.pair_host_lock_path = tmp.path().join("x.host.lock");
+    app.pair_spawn_override = Some(Box::new(|_| panic!("must not reach the spawn")));
+    crate::session::write_pair_record(
+        &app.pair_record_path,
+        &crate::session::PairRecord {
+            model: None,
+            name: "nav".into(),
+            enabled: true,
+            task: None,
+            provider: None,
+            base_url: None,
+        },
+    )
+    .unwrap();
+    app.last_pair_check = None;
+    app.maybe_seat_navigator();
+    assert!(app.pair_host.is_none());
+    assert!(
+        app.status.contains("relay failed"),
+        "the failure is announced: {}",
+        app.status
+    );
+    assert!(
+        app.pair_host_lock.is_none(),
+        "a window without a relay cannot host; the lock must be released"
+    );
+}
+
 /// Re-running `croft pair` after a failed seat must retry: the CLI promises
 /// "a running croft seats it within a second", but an enabled→enabled
 /// rewrite has no transition for the death latch to observe. The record's

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -1384,31 +1384,36 @@ fn apply_fence_event(state: &Mutex<PairState>, event: FenceEvent) {
             };
             let offset = note_offset(&lines, row);
             let row_now = position(&lines, offset).0;
-            match st.events.clone() {
+            // The AI is visibly "looking" where it just commented.
+            st.caret_now(&file, row_now, 0);
+            let id = st.take_note_id();
+            let sink = st.events.clone();
+            // Pushed under the SAME lock as the offset computation: pushing
+            // after the REPL's say() left a window where a concurrent
+            // remote edit shifted every note EXCEPT this not-yet-pushed
+            // one, stranding its anchor below the edit.
+            st.notes.push(Note {
+                id,
+                file: file.clone(),
+                offset,
+                body: body.clone(),
+            });
+            match sink {
                 Some(tx) => {
                     let _ = tx.send(crate::pair_host::PairEvent::NoteAdded {
-                        file: file.clone(),
+                        file,
                         row: row_now,
-                        body: body.clone(),
+                        body,
                     });
                 }
                 None => {
                     // REPL driver: no event channel, so print the note or it
-                    // would be silently swallowed.
+                    // would be silently swallowed (say re-locks internally,
+                    // hence the drop).
                     drop(st);
                     say(state, &format!("[note {file}:{}] {body}\n", row_now + 1));
-                    st = state.lock().unwrap();
                 }
             }
-            // The AI is visibly "looking" where it just commented.
-            st.caret_now(&file, row_now, 0);
-            let id = st.take_note_id();
-            st.notes.push(Note {
-                id,
-                file,
-                offset,
-                body,
-            });
         }
         FenceEvent::NoteAbort => {
             state.lock().unwrap().note_in_flight = None;
@@ -1474,6 +1479,15 @@ fn revert_region(st: &mut PairState) {
         let anchor = r.anchor.clamp(start, doc.len());
         let new = format!("{}{}{}", &doc[..start], r.original, &doc[anchor..]);
         st.session.local_change(&r.file, &new);
+        // The inverse of the shifts open_region and EditBody applied: the
+        // revert deletes the streamed bytes and puts the original back, so
+        // notes the edit moved must move back with it.
+        let span = ResolvedSpan {
+            at: start,
+            deleted: anchor - start,
+            inserted: r.original.clone(),
+        };
+        shift_notes(&mut st.notes, &r.file, std::slice::from_ref(&span));
     }
     st.session.send_stream_state(&r.file, false);
 }
@@ -2158,6 +2172,41 @@ mod tests {
             })
         };
         (state, stop, pump)
+    }
+
+    /// An unseat moments before exit must still reap the pilot's child:
+    /// Drop detaches its grace-kill onto a thread, and a thread that dies
+    /// with the process leaves the child running (orphaned, still holding
+    /// its MCP subprocesses). join_teardowns() is the exit path's barrier
+    /// for every detached teardown.
+    #[test]
+    fn join_teardowns_reaps_a_dropped_hosts_child() {
+        if !crate::lsp::manager::is_on_path("python3") {
+            eprintln!("SKIPPED: python3 not on PATH");
+            return;
+        }
+        let harness = OwnerHarness::start("hello world");
+        let marker = format!("croft-teardown-{}", std::process::id());
+        let mut cmd = std::process::Command::new("python3");
+        cmd.arg("-c")
+            .arg("import time; time.sleep(120)")
+            .arg(&marker);
+        let host =
+            crate::pair_host::PairHost::spawn_cmd(&harness.socket, "nav", None, cmd).unwrap();
+        let alive = |m: &str| {
+            std::process::Command::new("pgrep")
+                .args(["-f", m])
+                .output()
+                .map(|o| !o.stdout.is_empty())
+                .unwrap_or(false)
+        };
+        assert!(alive(&marker), "the sleeper child must be running");
+        drop(host);
+        crate::pair_host::join_teardowns();
+        assert!(
+            !alive(&marker),
+            "after join_teardowns the dropped host's child must be reaped"
+        );
     }
 
     /// The persistent AI caret: a park before the file is live resolves as
@@ -3929,6 +3978,48 @@ mod tests {
         shift_notes(&mut notes, "a.rs", &spans);
         assert_eq!(notes[0].offset, 13);
         assert_eq!(notes[1].offset, 10, "other file's note must not move");
+    }
+
+    /// Aborting a streamed edit must also un-shift the notes that edit
+    /// moved: open_region shifts notes for its delete and every EditBody
+    /// shifts them for its insert, so the revert has to apply the inverse
+    /// span. Without it, every cancel or abort left the turn's notes
+    /// permanently drifted from the rows the model anchored them to.
+    #[test]
+    fn an_aborted_edit_un_shifts_the_notes_it_moved() {
+        let harness = OwnerHarness::start("hello world");
+        let (state, stop, pump) = pumped_state(&harness);
+        {
+            let mut st = state.lock().unwrap();
+            st.begin_turn("demo.txt", "hello world", false);
+            let id = st.take_note_id();
+            st.notes.push(Note {
+                id,
+                file: String::from("demo.txt"),
+                offset: 8, // inside "world", below the edited span
+                body: String::from("remark"),
+            });
+        }
+        apply_fence_event(
+            &state,
+            FenceEvent::EditStart {
+                file: String::from("demo.txt"),
+                start: (0, 0),
+                end: (0, 5),
+            },
+        );
+        apply_fence_event(
+            &state,
+            FenceEvent::EditBody(String::from("hi there friend")),
+        );
+        apply_fence_event(&state, FenceEvent::EditAbort);
+        let offset = state.lock().unwrap().notes[0].offset;
+        assert_eq!(
+            offset, 8,
+            "the revert must restore the note anchor the edit had shifted"
+        );
+        stop.store(true, Ordering::Relaxed);
+        pump.join().unwrap();
     }
 
     /// A note row just past EOF clamps to the last line instead of panicking

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -491,6 +491,12 @@ struct StreamRegion {
     start: usize,
     anchor: usize,
     original: String,
+    /// Notes whose anchors sat at or inside the fence's range when it
+    /// opened, as `(note id, offset - start)`: the delete collapses them
+    /// and the streamed inserts drag them along, so the revert can only
+    /// restore them from these recorded deltas (`start` keeps tracking
+    /// remote edits, so `start + delta` stays exact in the restored text).
+    displaced: Vec<(u64, usize)>,
 }
 
 /// One anchored navigator note: a byte offset into `file`'s replica text
@@ -1448,6 +1454,15 @@ fn open_region(st: &mut PairState, file: &str, start: (usize, usize), end: (usiz
     let original = doc[s..e].to_string();
     let new = format!("{}{}", &doc[..s], &doc[e..]);
     st.session.local_change(file, &new);
+    // Anchors at or inside the range are about to be collapsed by the
+    // delete (and then dragged along by the streamed inserts): record
+    // their pre-edit deltas so a revert can put them back exactly.
+    let displaced: Vec<(u64, usize)> = st
+        .notes
+        .iter()
+        .filter(|n| n.file == file && (s..e).contains(&n.offset))
+        .map(|n| (n.id, n.offset - s))
+        .collect();
     // Our own delete moves any note anchored below the cut in this file.
     let span = ResolvedSpan {
         at: s,
@@ -1460,6 +1475,7 @@ fn open_region(st: &mut PairState, file: &str, start: (usize, usize), end: (usiz
         start: s,
         anchor: s,
         original,
+        displaced,
     });
     st.discarding = false;
     st.session.send_stream_state(file, true);
@@ -1488,6 +1504,19 @@ fn revert_region(st: &mut PairState) {
             inserted: r.original.clone(),
         };
         shift_notes(&mut st.notes, &r.file, std::slice::from_ref(&span));
+        // Anchors that sat inside the range cannot be un-shifted (the
+        // delete collapsed them); restore them from the deltas recorded at
+        // open. `start` tracked remote edits all along, so `start + delta`
+        // lands exactly where the anchor sat in the restored slice.
+        for (id, delta) in &r.displaced {
+            if let Some(n) = st
+                .notes
+                .iter_mut()
+                .find(|n| n.id == *id && n.file == r.file)
+            {
+                n.offset = start + delta;
+            }
+        }
     }
     st.session.send_stream_state(&r.file, false);
 }
@@ -3992,13 +4021,19 @@ mod tests {
         {
             let mut st = state.lock().unwrap();
             st.begin_turn("demo.txt", "hello world", false);
-            let id = st.take_note_id();
-            st.notes.push(Note {
-                id,
-                file: String::from("demo.txt"),
-                offset: 8, // inside "world", below the edited span
-                body: String::from("remark"),
-            });
+            // Anchors below, AT, and INSIDE the edited span [0, 5): the
+            // below one is shifted and must shift back; the at/inside ones
+            // are collapsed by the delete and ride the streamed inserts,
+            // so only their recorded pre-edit offsets can restore them.
+            for offset in [8usize, 0, 2] {
+                let id = st.take_note_id();
+                st.notes.push(Note {
+                    id,
+                    file: String::from("demo.txt"),
+                    offset,
+                    body: String::from("remark"),
+                });
+            }
         }
         apply_fence_event(
             &state,
@@ -4013,10 +4048,17 @@ mod tests {
             FenceEvent::EditBody(String::from("hi there friend")),
         );
         apply_fence_event(&state, FenceEvent::EditAbort);
-        let offset = state.lock().unwrap().notes[0].offset;
+        let offsets: Vec<usize> = state
+            .lock()
+            .unwrap()
+            .notes
+            .iter()
+            .map(|n| n.offset)
+            .collect();
         assert_eq!(
-            offset, 8,
-            "the revert must restore the note anchor the edit had shifted"
+            offsets,
+            vec![8, 0, 2],
+            "the revert must restore every note anchor the edit had moved"
         );
         stop.store(true, Ordering::Relaxed);
         pump.join().unwrap();

--- a/src/pair_host.rs
+++ b/src/pair_host.rs
@@ -332,6 +332,23 @@ pub fn join_teardowns() {
     }
 }
 
+/// Pull the FINISHED handles out of the registry, leaving the running ones:
+/// each unseat sweeps its predecessors so repeated unseat/reseat cycles do
+/// not grow the registry without bound. Joining the returned handles is
+/// instant (the threads have exited) but happens outside the lock anyway.
+fn sweep_finished(reg: &mut Vec<std::thread::JoinHandle<()>>) -> Vec<std::thread::JoinHandle<()>> {
+    let mut done = Vec::new();
+    let mut i = 0;
+    while i < reg.len() {
+        if reg[i].is_finished() {
+            done.push(reg.swap_remove(i));
+        } else {
+            i += 1;
+        }
+    }
+    done
+}
+
 impl Drop for PairHost {
     fn drop(&mut self) {
         // Detach the teardown: the grace-kill blocks up to 2s (claude lingers
@@ -343,7 +360,45 @@ impl Drop for PairHost {
         // that happened shortly before exit.
         if let Some(p) = self.pilot.take() {
             let handle = std::thread::spawn(move || p.shutdown());
-            TEARDOWNS.lock().unwrap().push(handle);
+            let done = {
+                let mut reg = TEARDOWNS.lock().unwrap();
+                let done = sweep_finished(&mut reg);
+                reg.push(handle);
+                done
+            };
+            for h in done {
+                let _ = h.join();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sweep_finished;
+
+    /// The registry sweep keeps only RUNNING teardowns: finished ones are
+    /// pulled out (and joined by the caller), so repeated unseat/reseat
+    /// cycles cannot grow the registry without bound.
+    #[test]
+    fn sweep_finished_pulls_only_the_finished_handles() {
+        let (block_tx, block_rx) = std::sync::mpsc::channel::<()>();
+        let finished = std::thread::spawn(|| {});
+        // A finished thread may take a beat to be observably finished.
+        while !finished.is_finished() {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        let running = std::thread::spawn(move || {
+            let _ = block_rx.recv();
+        });
+        let mut reg = vec![finished, running];
+        let done = sweep_finished(&mut reg);
+        assert_eq!(done.len(), 1, "exactly the finished handle is pulled");
+        assert_eq!(reg.len(), 1, "the running teardown stays registered");
+        assert!(!reg[0].is_finished(), "and it is the running one");
+        block_tx.send(()).unwrap();
+        for h in done.into_iter().chain(reg) {
+            h.join().unwrap();
         }
     }
 }

--- a/src/pair_host.rs
+++ b/src/pair_host.rs
@@ -315,6 +315,23 @@ impl PairHost {
     }
 }
 
+/// Teardown threads detached by [`Drop`]: an unseat's grace-kill runs on
+/// its own thread, and a thread that dies with the process leaves the
+/// claude child running (orphaned, still holding its MCP subprocesses).
+/// The exit path joins these so every detached teardown finishes first.
+static TEARDOWNS: std::sync::Mutex<Vec<std::thread::JoinHandle<()>>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Join every teardown thread [`Drop`] detached. Called on the exit path
+/// after the live host's own `shutdown_blocking`; bounded by the pilots'
+/// grace-kill (about two seconds each, and stacked teardowns are rare).
+pub fn join_teardowns() {
+    let handles: Vec<_> = std::mem::take(&mut *TEARDOWNS.lock().unwrap());
+    for h in handles {
+        let _ = h.join();
+    }
+}
+
 impl Drop for PairHost {
     fn drop(&mut self) {
         // Detach the teardown: the grace-kill blocks up to 2s (claude lingers
@@ -322,9 +339,11 @@ impl Drop for PairHost {
         // navigator is unseated (toggle off / disabled record). The detached
         // thread owns the pilot and reverts, hangs up, and grace-kills on its
         // own. Exit paths that must reap the child first use
-        // `shutdown_blocking` instead.
+        // `shutdown_blocking` instead, plus [`join_teardowns`] for drops
+        // that happened shortly before exit.
         if let Some(p) = self.pilot.take() {
-            std::thread::spawn(move || p.shutdown());
+            let handle = std::thread::spawn(move || p.shutdown());
+            TEARDOWNS.lock().unwrap().push(handle);
         }
     }
 }

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -62,18 +62,18 @@ pub struct ReleaseNote {
 pub const RELEASE_NOTES: &[ReleaseNote] = &[
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "A failed local-model turn no longer poisons the conversation: the unanswered ask is dropped so the next one starts clean, and every failure mode (mid-stream drop, timeout, token-limit truncation, stream errors) is reported honestly instead of as a finished turn.",
+        summary: "Cancelling or aborting a navigator edit no longer drifts its comment anchors: the revert now un-shifts every note the streamed edit had moved, so the gutter marks and F4 land where the navigator actually commented.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "Toggling the navigator off and on keeps its backend: a local ollama seat no longer silently becomes a cloud claude seat, and croft pair --provider ollama --off simply deactivates.",
+        summary: "A croft window whose navigator failed to seat releases the workspace's single-host lock, so another window can host instead of nobody; re-running croft pair after fixing the backend now retries the seat, and the 'hosted by another window' notice is announced once instead of overwriting the status line every second.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "Local endpoint problems name their cause: HTTP error bodies (like ollama's 'model not found, try pulling it') reach the status line, and a malformed --base-url is refused at activation instead of failing hours later.",
+        summary: "The ask box no longer eats a typed instruction: a proactive look cannot steal the seat while a prompt is open, and a failed ask keeps the box open with the draft intact for a retry.",
     },
     ReleaseNote {
         kind: NoteKind::Fix,
-        summary: "The gateway token travels as a proper Bearer header and only over https or to loopback hosts, a stalled endpoint can no longer hold the seat busy past ten minutes (the deadline now cuts at the socket itself, so failed turns leak no threads or connections), and an inverted edit fence reports to OUTPUT instead of corrupting the screen.",
+        summary: "Quitting right after unseating the navigator no longer orphans its claude child (exit now joins the detached teardown), and a re-seated navigator's first turn summary no longer inherits a dead seat's comment count or claims every comment sits in one file when they span several.",
     },
 ];

--- a/src/session.rs
+++ b/src/session.rs
@@ -147,6 +147,14 @@ pub(crate) fn write_pair_record(path: &Path, record: &PairRecord) -> Result<()> 
             .map(|d| d.as_nanos() as u64)
             .unwrap_or(0),
     );
+    // The clock alone cannot guarantee distinct bytes (SystemTime can
+    // repeat for rapid writes under coarse granularity): pid + a
+    // process-local counter differs on every call, in every process.
+    static WRITE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    v["write_nonce"] = serde_json::Value::from(
+        (u64::from(std::process::id()) << 32)
+            | (WRITE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed) & 0xffff_ffff),
+    );
     std::fs::write(path, v.to_string()).with_context(|| format!("writing {}", path.display()))
 }
 
@@ -442,6 +450,43 @@ pub fn bind_socket_0600(socket: &Path) -> std::io::Result<std::os::unix::net::Un
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An enabled→enabled rewrite must NEVER serialize byte-identically:
+    /// the App re-arms a downed navigator on record-content change, and the
+    /// clock alone cannot carry that guarantee (SystemTime can repeat for
+    /// rapid writes under coarse clock granularity). A per-write nonce
+    /// (pid + process-local counter) differs even when the clock stands
+    /// still.
+    #[test]
+    fn every_pair_record_write_serializes_differently() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("pair.json");
+        let record = PairRecord {
+            model: None,
+            name: String::from("nav"),
+            enabled: true,
+            task: None,
+            provider: None,
+            base_url: None,
+        };
+        write_pair_record(&path, &record).unwrap();
+        let a = std::fs::read(&path).unwrap();
+        write_pair_record(&path, &record).unwrap();
+        let b = std::fs::read(&path).unwrap();
+        assert_ne!(a, b, "identical records must still write distinct bytes");
+        let va: serde_json::Value = serde_json::from_slice(&a).unwrap();
+        let vb: serde_json::Value = serde_json::from_slice(&b).unwrap();
+        assert!(
+            va["write_nonce"].is_u64(),
+            "the nonce is part of the record"
+        );
+        assert_ne!(
+            va["write_nonce"], vb["write_nonce"],
+            "the nonce differs even when the clock stands still"
+        );
+        // The stamp fields stay invisible to the typed read path.
+        assert_eq!(read_pair_record(&path).as_ref(), Some(&record));
+    }
 
     /// Two attach-or-create racers for the SAME target must never both
     /// publish: before creation was serialized, the later publisher replaced

--- a/src/session.rs
+++ b/src/session.rs
@@ -135,8 +135,19 @@ pub(crate) struct PairRecord {
 }
 
 pub(crate) fn write_pair_record(path: &Path, record: &PairRecord) -> Result<()> {
-    let json = serde_json::to_string(record).context("serializing pair record")?;
-    std::fs::write(path, json).with_context(|| format!("writing {}", path.display()))
+    let mut v = serde_json::to_value(record).context("serializing pair record")?;
+    // Every write is observable: the App re-arms a downed navigator when
+    // the record CHANGES, and an enabled→enabled rewrite (`croft pair`
+    // after a failed seat) would otherwise be byte-identical — and mtime
+    // alone misses a same-grain rewrite on coarse-timestamp filesystems.
+    // The read path ignores the stamp (serde skips unknown fields).
+    v["written_at_nanos"] = serde_json::Value::from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0),
+    );
+    std::fs::write(path, v.to_string()).with_context(|| format!("writing {}", path.display()))
 }
 
 pub(crate) fn read_pair_record(path: &Path) -> Option<PairRecord> {


### PR DESCRIPTION
Six confirmed bugs from an adversarial review of the 0.1.635 resident-navigator span, each fixed RED first.

## Fixes

1. **Aborted edits drifted comment anchors.** `open_region` and `EditBody` shift note offsets for the streamed edit's delete and inserts, but `revert_region` restored the text without the inverse shift, so every cancel/abort left the turn's notes anchored below where the model put them. The revert now applies the inverse span. The REPL note path also pushed its note after a lock gap (`say` re-locks internally), letting a concurrent remote edit strand the new note's anchor; the note now lands under the same lock as its offset computation.

2. **A failed spawner deadlocked the workspace's navigator.** The single-host flock was claimed before the spawn and never released on failure, while the death latch blocked retries: one window with a broken claude blocked every other window from hosting, and the "hosted by another croft window" status was a lie. A failed spawner now releases the lock and undoes its same-tick owner self-appointment (a host whose pilot died later keeps both, since it is still the live collab owner and re-seats on re-activation).

3. **`croft pair` after a failure did nothing.** The death latch only cleared on an enabled-to-disabled transition, so re-running `croft pair` (record already enabled) never retried, despite the CLI's printed promise. Any record rewrite (mtime change) now re-arms seating.

4. **The refusal status clobbered the losing window forever.** The non-hosting window re-announced the lock refusal every second, permanently overwriting its status line and dirtying a frame at 1 Hz. It now announces once and polls silently for takeover.

5. **A proactive look could eat a typed ask.** `tick_proactive_navigator` did not check for an open input prompt, so it could steal the seat while the user typed in the ask box; their Enter then failed against a busy host and the submit path had already closed the prompt, destroying the draft. Proactive looks are now suppressed while a prompt is open (without consuming the scan latch), and a failed ask keeps the box open with the draft intact.

6. **A quick quit after unseat orphaned the claude child.** `Drop` detaches the 2s grace-kill onto a thread; if the process exited within that window the thread died mid-kill and the child (plus its MCP subprocesses) survived. Detached teardowns are now registered and joined on the exit path.

Plus: turn note counters reset on unseat/death (a re-seated navigator's first TurnDone no longer inherits a dead seat's count), and the TurnDone hint only names a file when every note landed in it ("3 comments across 2 files" otherwise).

## Testing

Every fix landed RED first: 9 new/extended tests (note un-shift, lock release + second-window hosting, record-rewrite re-arm, refusal announced once, prompt suppression, draft preservation, teardown reaping via a live sleeper child, counter reset, summary wording). Full suite 2797 + 6 CLI green, clippy zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigator recovery after pairing records are rewritten or reactivated.
  * Prevented workspace locks and ownership from remaining held after failed setup.
  * Preserved ask-box drafts and prompts after unsuccessful submissions.
  * Improved note placement, multi-file summaries, and edit reversion behavior.
  * Ensured background shutdown tasks and child processes finish cleanly.
* **Release**
  * Updated the package version to 0.1.659.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->