### PR TITLE
fix(editor): refuse a save the encoding cannot represent instead of silently writing HTML character references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.685"
+version = "0.1.686"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.685"
+version = "0.1.686"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,6 +74,11 @@ src/
 │   │                    file as UTF-8 and hand the next save the mojibake to write back). "Reopen with Encoding"
 │   │                    refuses on a dirty buffer and points at undo, never at saving: the buffer may hold mojibake from a wrong decode, and
 │   │                    saving would write those replacement chars over the real bytes.
+│   │                    A save whose encoding cannot represent the buffer is REFUSED (`SaveOutcome::EncodingLoss`): `encoding_rs` substitutes
+│   │                    HTML numeric character references (`&#26085;`), not `?`, so the write would be silent irreversible loss. The refusal
+│   │                    latches (`encoding_loss`, so auto save stops retrying) and the explicit path arms a one-shot consent
+│   │                    (`lossy_save_armed`): the second Cmd+S — told which characters are doomed — writes the substitutions. Force save
+│   │                    (disk-conflict overwrite) does NOT bypass the guard; only the armed consent does.
 ├── app/                 event loop, three-pane layout + activity bar, key dispatch, status bar, mouse, clipboard, splitters, preview overlays, Customize Layout (compute_chrome_layout / panel_band_rect pure geometry, secondary side bar, Zen Mode)
 │   ├── mod.rs           the main App: render, key / mouse dispatch, status bar, splitters
 │   ├── click.rs         double / triple click detection

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,8 +77,9 @@ src/
 │   │                    A save whose encoding cannot represent the buffer is REFUSED (`SaveOutcome::EncodingLoss`): `encoding_rs` substitutes
 │   │                    HTML numeric character references (`&#26085;`), not `?`, so the write would be silent irreversible loss. The refusal
 │   │                    latches (`encoding_loss`, so auto save stops retrying) and the explicit path arms a one-shot consent
-│   │                    (`lossy_save_armed`): the second Cmd+S — told which characters are doomed — writes the substitutions. Force save
-│   │                    (disk-conflict overwrite) does NOT bypass the guard; only the armed consent does.
+│   │                    (`lossy_save_armed`): the second Cmd+S — told which characters are doomed — writes the substitutions. Any edit revokes
+│   │                    both flags (`mark_buffer_changed`): consent named the characters at prompt time, so a changed buffer re-prompts. Force
+│   │                    save (disk-conflict overwrite) does NOT bypass the guard; only the armed consent does.
 ├── app/                 event loop, three-pane layout + activity bar, key dispatch, status bar, mouse, clipboard, splitters, preview overlays, Customize Layout (compute_chrome_layout / panel_band_rect pure geometry, secondary side bar, Zen Mode)
 │   ├── mod.rs           the main App: render, key / mouse dispatch, status bar, splitters
 │   ├── click.rs         double / triple click detection

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27866,22 +27866,16 @@ impl App {
                 );
             }
             Ok(SaveOutcome::EncodingLoss) => {
-                let enc = editor.encoding.name();
-                // A format-on-save tab routes EVERY Cmd+S through this
-                // deferred write, so the still-focused case must arm the
-                // press-again consent here or the refusal would loop forever
-                // with no way to accept it.
-                if self.editor.path.as_deref() == Some(path) {
-                    self.prompt_encoding_loss();
-                } else {
-                    // A tab the user moved away from never gets lossy
-                    // consent; resolving needs it back in front of them.
-                    self.status = format!(
-                        "{} not saved: it has characters {} cannot represent - open the tab and press Cmd+S to resolve",
-                        path.display(),
-                        enc
-                    );
-                }
+                // Both callers route a still-focused tab to
+                // `write_current_to_disk`, which arms the press-again consent
+                // itself; this function only ever runs for a tab the user
+                // moved away from, and such a tab never gets lossy consent —
+                // resolving needs it back in front of them.
+                self.status = format!(
+                    "{} not saved: it has characters {} cannot represent - open the tab and press Cmd+S to resolve",
+                    path.display(),
+                    editor.encoding.name()
+                );
             }
             Err(e) => self.status = format!("Save failed: {e}"),
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6906,7 +6906,10 @@ impl App {
                 .unwrap_or(encoding_rs::UTF_8);
             let text = enc.decode(&content).0.into_owned();
             let label = std::path::PathBuf::from(format!("{rel} (local snapshot)"));
-            if let Err(e) = self.editor.open_head_diff_with_text(label, &text, &path, false) {
+            if let Err(e) = self
+                .editor
+                .open_head_diff_with_text(label, &text, &path, false)
+            {
                 self.status = format!("Could not open snapshot diff: {e}");
                 return;
             }
@@ -17881,7 +17884,8 @@ impl App {
         if let Some(idx) = self.terminals.iter().position(|t| {
             t.label() == pane_name
                 && t.foreground_is_shell()
-                && t.kernel_shell_cwd().is_none_or(|cwd| cwd.starts_with(&root))
+                && t.kernel_shell_cwd()
+                    .is_none_or(|cwd| cwd.starts_with(&root))
         }) {
             self.active_terminal = idx;
             self.terminals[idx].write_input(command.as_bytes());
@@ -27552,6 +27556,10 @@ impl App {
             e.dirty
                 && e.path.is_some()
                 && !e.disk_conflict
+                // A latched encoding refusal: only an explicit Cmd+S can
+                // consent to the lossy write, so retrying here would just
+                // re-refuse every tick.
+                && !e.encoding_loss
                 && !(guest
                     && e.path
                         .as_ref()
@@ -27560,6 +27568,9 @@ impl App {
                     .is_some_and(|t| t.elapsed() >= Self::AUTO_SAVE_DELAY)
         };
         let mut conflicted: Vec<PathBuf> = Vec::new();
+        // "name (encoding)" per refused tab: the refusal message names each
+        // tab's OWN encoding, which need not be the active tab's.
+        let mut lossy: Vec<String> = Vec::new();
         let mut sweep = |editors: &mut [crate::widgets::editor::Editor]| {
             for e in editors.iter_mut().filter(|e| due(e)) {
                 // `save_to_disk` re-checks the disk and flags (never
@@ -27576,6 +27587,20 @@ impl App {
                     Ok(crate::widgets::editor::SaveOutcome::DiskConflict) => {
                         conflicted.extend(e.path.clone());
                     }
+                    // Same transition-only reporting as the conflict arm:
+                    // the latch just set removes the tab from `due`, so
+                    // this tick is the one chance to say why it stopped
+                    // saving. Never arms the lossy write — consent is the
+                    // explicit path's alone.
+                    Ok(crate::widgets::editor::SaveOutcome::EncodingLoss) => {
+                        if let Some(name) = e.path.as_ref().and_then(|p| p.file_name()) {
+                            lossy.push(format!(
+                                "{} ({})",
+                                name.to_string_lossy(),
+                                e.encoding.name()
+                            ));
+                        }
+                    }
                     Err(_) => {}
                 }
             }
@@ -27588,10 +27613,20 @@ impl App {
         if had_conflicts {
             self.prompt_disk_conflict(conflicted);
         }
+        let had_lossy = !lossy.is_empty();
+        if had_lossy {
+            // The status line, not the modal prompt: nothing was lost and
+            // nothing is racing, so an auto-save refusal must not steal the
+            // keyboard mid-typing burst.
+            self.status = format!(
+                "Auto save paused for {}: the buffer has characters the encoding cannot represent - open the tab and press Cmd+S to resolve",
+                lossy.join(", ")
+            );
+        }
         if saved_paths.is_empty() {
-            // A conflict-only tick still changed the UI (the prompt is up):
+            // A conflict-only (or refusal-only) tick still changed the UI:
             // returning false would defer it to the next incidental redraw.
-            return had_conflicts;
+            return had_conflicts || had_lossy;
         }
         // Mirror the explicit-save path: a config file written by auto save
         // must take effect exactly like one written by Cmd+S — including one
@@ -27693,14 +27728,26 @@ impl App {
         // Cmd+S overwrites the external change. Consume it here so it never
         // lingers past the press it was meant for.
         if std::mem::take(&mut self.force_save_armed) {
+            use crate::widgets::editor::SaveOutcome;
             match self.editor.save_to_disk_force() {
-                Ok(()) => {
+                Ok(SaveOutcome::Saved) => {
                     self.status = self.editor.status.clone();
                     if let Some(path) = self.editor.path.clone() {
                         self.record_history_snapshot(&path);
                     }
                     self.lsp_notify_saved();
                     self.reload_config_if_needed();
+                }
+                // Overwriting the external change was consented to; mangling
+                // the buffer's characters was not. Route the refusal through
+                // the same prompt-and-rearm as a plain save, keeping the
+                // overwrite consent so the NEXT Cmd+S resolves both at once.
+                Ok(SaveOutcome::EncodingLoss) => {
+                    self.force_save_armed = true;
+                    self.prompt_encoding_loss();
+                }
+                Ok(SaveOutcome::DiskConflict) => {
+                    unreachable!("force save never reports a conflict")
                 }
                 Err(e) => self.status = format!("Save failed: {e}"),
             }
@@ -27818,6 +27865,24 @@ impl App {
                     path.display()
                 );
             }
+            Ok(SaveOutcome::EncodingLoss) => {
+                let enc = editor.encoding.name();
+                // A format-on-save tab routes EVERY Cmd+S through this
+                // deferred write, so the still-focused case must arm the
+                // press-again consent here or the refusal would loop forever
+                // with no way to accept it.
+                if self.editor.path.as_deref() == Some(path) {
+                    self.prompt_encoding_loss();
+                } else {
+                    // A tab the user moved away from never gets lossy
+                    // consent; resolving needs it back in front of them.
+                    self.status = format!(
+                        "{} not saved: it has characters {} cannot represent - open the tab and press Cmd+S to resolve",
+                        path.display(),
+                        enc
+                    );
+                }
+            }
             Err(e) => self.status = format!("Save failed: {e}"),
         }
     }
@@ -27845,8 +27910,27 @@ impl App {
                     "{name} changed on disk since you opened it - press Cmd+S again to overwrite, or close the tab to keep the disk version"
                 );
             }
+            Ok(SaveOutcome::EncodingLoss) => self.prompt_encoding_loss(),
             Err(e) => self.status = format!("Save failed: {e}"),
         }
+    }
+
+    /// An explicit save was refused because the encoding cannot represent the
+    /// buffer (`SaveOutcome::EncodingLoss`). Arm the one-shot lossy consent
+    /// and spell out exactly what the next Cmd+S will destroy, mirroring the
+    /// press-again flow of a disk conflict. The alternative exits are the
+    /// same two the refusal preserved: reopen the status-bar encoding picker
+    /// (a clean buffer switches encodings losslessly) or edit the characters
+    /// out.
+    fn prompt_encoding_loss(&mut self) {
+        self.editor.lossy_save_armed = true;
+        let chars = self.editor.unmappable_chars();
+        let shown: String = chars.iter().map(|c| format!("{c} ")).collect();
+        self.status = format!(
+            "Not saved: {} cannot represent {}- press Cmd+S again to replace them with &#…; references (irreversible), or switch encoding via the status bar",
+            self.editor.encoding.name(),
+            shown
+        );
     }
 
     /// Whether an open context menu (or its submenu panel) overlaps `rect`

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4526,7 +4526,12 @@ fn hunk_actions_refuse_a_timeline_snapshot_diff() {
     std::fs::write(&path, "new\n").unwrap();
     let mut app = App::new(tmp.path().to_path_buf()).unwrap();
     app.editor
-        .open_head_diff_with_text(PathBuf::from("a.txt (local snapshot)"), "old\n", &path, false)
+        .open_head_diff_with_text(
+            PathBuf::from("a.txt (local snapshot)"),
+            "old\n",
+            &path,
+            false,
+        )
         .unwrap();
     app.stage_hunk_at_caret();
     assert_eq!(
@@ -4551,8 +4556,7 @@ fn workspace_symbol_queries_debounce_instead_of_firing_per_keystroke() {
     std::thread::sleep(std::time::Duration::from_millis(250));
     app.workspace_symbols_dispatch_due();
     assert!(
-        app.ws_symbols_request_id.is_some()
-            || app.workspace_symbols.as_ref().unwrap().unsupported,
+        app.ws_symbols_request_id.is_some() || app.workspace_symbols.as_ref().unwrap().unsupported,
         "the settled query must dispatch (or surface no-LSP) after the window"
     );
 }
@@ -4571,7 +4575,9 @@ fn a_reply_to_a_superseded_workspace_symbol_query_is_dropped() {
     app.workspace_symbols_requery();
     std::thread::sleep(std::time::Duration::from_millis(250));
     app.workspace_symbols_dispatch_due();
-    let id = app.ws_symbols_request_id.expect("the settled query dispatched");
+    let id = app
+        .ws_symbols_request_id
+        .expect("the settled query dispatched");
     if let Some(p) = app.workspace_symbols.as_mut() {
         p.query.push('b');
     }
@@ -18935,7 +18941,10 @@ fn reordering_panes_defers_the_session_write_off_the_input_path() {
         !app.terminal_session_path.exists(),
         "the session write must not sit on the input path"
     );
-    assert!(app.terminal_session_dirty, "the move is recorded as pending");
+    assert!(
+        app.terminal_session_dirty,
+        "the move is recorded as pending"
+    );
     app.flush_terminal_session();
     assert!(
         app.terminal_session_path.exists(),
@@ -19406,6 +19415,81 @@ fn auto_save_surfaces_a_disk_conflict_instead_of_latching_silently() {
         app.input_prompt.is_some() || app.status.to_lowercase().contains("conflict"),
         "the collision must be surfaced, not swallowed; status: {:?}",
         app.status
+    );
+}
+
+#[test]
+fn explicit_save_prompts_before_a_lossy_encoding_write_then_second_press_consents() {
+    // Issue #41: encoding_rs substitutes HTML numeric character references
+    // (not `?`) for unmappable characters, so an unguarded save silently
+    // rewrites 日本語 as `&#26085;…` on disk while the buffer looks fine.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = app_with_open_file(tmp.path(), "a.txt", "plain");
+    app.editor
+        .reopen_with_encoding(encoding_rs::WINDOWS_1252)
+        .unwrap();
+    app.editor.lines = vec![String::from("日本語 costs 5€")];
+    app.editor.dirty = true;
+    app.save();
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+        "plain",
+        "the first Cmd+S must refuse, leaving the file untouched"
+    );
+    assert!(
+        app.status.contains("windows-1252") && app.status.contains('日'),
+        "the refusal must name the encoding and the doomed characters; status: {:?}",
+        app.status
+    );
+    assert!(
+        app.editor.lossy_save_armed,
+        "the refusal arms the second press"
+    );
+    app.save();
+    assert_eq!(
+        std::fs::read(tmp.path().join("a.txt")).unwrap(),
+        b"&#26085;&#26412;&#35486; costs 5\x80",
+        "the second Cmd+S is explicit consent to the lossy write"
+    );
+    assert!(!app.editor.dirty, "the consented save completes normally");
+}
+
+#[test]
+fn auto_save_surfaces_an_encoding_refusal_instead_of_latching_silently() {
+    // The same latch-and-tell contract as the disk-conflict arm: the refusal
+    // removes the tab from due(), so the transition tick must both redraw
+    // and say why auto save stopped — and must never write the mangled bytes.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = app_with_open_file(tmp.path(), "a.txt", "plain");
+    app.auto_save = true;
+    app.editor
+        .reopen_with_encoding(encoding_rs::WINDOWS_1252)
+        .unwrap();
+    app.editor.lines = vec![String::from("日本語")];
+    app.editor.dirty = true;
+    age_last_edit(&mut app.editor);
+    assert!(
+        app.tick_auto_save(),
+        "a refusal-only tick must signal a redraw so the message shows now"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+        "plain",
+        "auto save must never write the substituted bytes"
+    );
+    assert!(app.editor.encoding_loss, "the refusal latches");
+    assert!(
+        !app.editor.lossy_save_armed,
+        "auto save must never consent to the lossy write on the user's behalf"
+    );
+    assert!(
+        app.status.contains("a.txt") && app.status.contains("windows-1252"),
+        "the stall must be surfaced with the tab and its encoding; status: {:?}",
+        app.status
+    );
+    assert!(
+        !app.tick_auto_save(),
+        "the latch keeps later ticks quiet instead of re-refusing every second"
     );
 }
 
@@ -24337,7 +24421,10 @@ fn a_test_name_click_jumps_to_source_via_the_background_locator() {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     loop {
         app.sync_explorer_panels();
-        if app.status.contains("No source found for test nope::missing") {
+        if app
+            .status
+            .contains("No source found for test nope::missing")
+        {
             break;
         }
         assert!(

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -19455,6 +19455,44 @@ fn explicit_save_prompts_before_a_lossy_encoding_write_then_second_press_consent
 }
 
 #[test]
+fn an_edit_between_refusal_and_consent_forces_a_fresh_prompt() {
+    // The first Cmd+S arms the second — but consent named the characters the
+    // buffer held at prompt time. Typing in between changes what the write
+    // would destroy, so the next Cmd+S must refuse and re-prompt (now naming
+    // the new character too), and only the press after that writes.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = app_with_open_file(tmp.path(), "a.txt", "plain");
+    app.editor
+        .reopen_with_encoding(encoding_rs::WINDOWS_1252)
+        .unwrap();
+    app.editor.lines = vec![String::from("日")];
+    app.editor.dirty = true;
+    app.save();
+    assert!(
+        app.editor.lossy_save_armed,
+        "the refusal arms the second press"
+    );
+    app.editor.insert_char('語');
+    app.save();
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+        "plain",
+        "the edit revoked the consent, so this press must refuse again"
+    );
+    assert!(
+        app.status.contains('語'),
+        "the fresh prompt must name the newly typed character; status: {:?}",
+        app.status
+    );
+    app.save();
+    assert_eq!(
+        std::fs::read(tmp.path().join("a.txt")).unwrap(),
+        b"&#35486;&#26085;",
+        "consent given after the prompt that named both characters writes"
+    );
+}
+
+#[test]
 fn auto_save_surfaces_an_encoding_refusal_instead_of_latching_silently() {
     // The same latch-and-tell contract as the disk-conflict arm: the refusal
     // removes the tab from due(), so the transition tick must both redraw

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -59,17 +59,7 @@ pub struct ReleaseNote {
 }
 
 /// What shipped in the current release. Replace on every version bump.
-pub const RELEASE_NOTES: &[ReleaseNote] = &[
-    ReleaseNote {
-        kind: NoteKind::Fix,
-        summary: "Updating croft on a remote machine is fast again. It had been shipping the entire local build directory, 176 GB of it, over a throttled link before compiling on the remote box, because the transfer skipped a folder named \"target\" while the real one is called \"target.noindex\".",
-    },
-    ReleaseNote {
-        kind: NoteKind::Fix,
-        summary: "A remote update now ships a prebuilt binary instead of compiling on your server. Bumping the Rust version had quietly dropped the cross-compiler targets, and the check meant to catch that asked the wrong toolchain, so it always reported everything was fine.",
-    },
-    ReleaseNote {
-        kind: NoteKind::Feature,
-        summary: "Continuous integration now builds croft for Linux x86-64, Linux ARM64 and Android on every change, alongside the lint and test suites, so a platform can no longer break without anyone noticing.",
-    },
-];
+pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
+    kind: NoteKind::Fix,
+    summary: "Saving a file under a legacy encoding no longer silently destroys characters the encoding cannot represent. Such text used to be rewritten on disk as HTML references like &#26085; with no warning; croft now refuses the save, names the doomed characters, and only a deliberate second Cmd+S writes the substitutions.",
+}];

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -2025,6 +2025,14 @@ impl Editor {
         self.hscroll_content_cols = None;
         self.wrap_total_cache.clear();
         self.occurrences.clear();
+        // Lossy-save consent named the unmappable characters the buffer held
+        // when the prompt fired; an edit changes what a write would destroy,
+        // so stale consent must not carry over (unlike `force_save_armed`,
+        // whose overwrite consent is about the DISK state, which typing does
+        // not touch). Clearing the latch also lets auto save retry a buffer
+        // the user fixed by deleting the offending characters.
+        self.encoding_loss = false;
+        self.lossy_save_armed = false;
     }
 
     /// Install (or clear) the git-gutter HEAD baseline for `path`. The app
@@ -13730,6 +13738,36 @@ mod tests {
         e.reopen_with_encoding(encoding_rs::UTF_8).unwrap();
         assert!(!e.encoding_loss);
         assert_eq!(e.save_to_disk().unwrap(), SaveOutcome::Saved);
+    }
+
+    /// Armed consent covers the buffer the prompt described. An edit changes
+    /// what the write would destroy, so it must revoke the stale consent (and
+    /// the auto-save latch) and make the next save prompt afresh — otherwise
+    /// characters typed after the prompt get mangled under a consent that
+    /// never named them.
+    #[test]
+    fn an_edit_after_a_lossy_refusal_revokes_the_armed_consent() {
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "cafe\n").unwrap();
+        let mut e = Editor::new();
+        e.open(tmp.path()).unwrap();
+        e.reopen_with_encoding(encoding_rs::WINDOWS_1252).unwrap();
+        e.lines = vec![String::from("日")];
+        e.dirty = true;
+        assert_eq!(e.save_to_disk().unwrap(), SaveOutcome::EncodingLoss);
+        e.lossy_save_armed = true; // the app arms the second Cmd+S...
+        e.insert_char('本'); // ...but the user edits instead of pressing it
+        assert!(!e.lossy_save_armed, "an edit revokes the stale consent");
+        assert!(
+            !e.encoding_loss,
+            "the latch clears too, so a fixed-up buffer resumes auto save"
+        );
+        assert_eq!(
+            e.save_to_disk().unwrap(),
+            SaveOutcome::EncodingLoss,
+            "the next save must prompt again for the changed buffer"
+        );
+        assert_eq!(std::fs::read_to_string(tmp.path()).unwrap(), "cafe\n");
     }
 
     #[test]

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -1181,6 +1181,12 @@ pub enum SaveOutcome {
     /// The file changed on disk since we last synced; the save was refused
     /// to avoid clobbering the external edit. The caller must force it.
     DiskConflict,
+    /// The buffer holds characters the chosen encoding cannot represent, so
+    /// writing would replace them with HTML numeric character references and
+    /// lose the originals irreversibly (the buffer itself is unchanged, so
+    /// undo cannot bring them back). The save was refused; the caller
+    /// surfaces it and sets `lossy_save_armed` to write anyway.
+    EncodingLoss,
 }
 
 /// Per-tab results of an FS-sync sweep across all open tabs
@@ -1697,6 +1703,15 @@ pub struct Editor {
     /// the flag drives the conflict warning and makes `save_to_disk` refuse
     /// to overwrite until the user forces it.
     pub disk_conflict: bool,
+    /// Set when a save was refused because `encoding` cannot represent the
+    /// buffer. Latches like `disk_conflict` so auto save stops retrying (and
+    /// stops re-reporting) a file only an explicit Cmd+S can resolve; cleared
+    /// by a successful write and by any reopen, which may change `encoding`.
+    pub encoding_loss: bool,
+    /// One-shot consent to write characters `encoding` cannot represent,
+    /// answering an `EncodingLoss` refusal. Set by the explicit-save path
+    /// only (never by auto save) and consumed by the write it authorises.
+    pub lossy_save_armed: bool,
     /// When the buffer last changed, driving the auto-save delay. `None`
     /// until the first edit.
     pub last_edit_at: Option<std::time::Instant>,
@@ -1796,6 +1811,8 @@ impl Editor {
             diff_next_arrow: Rect::default(),
             disk_stamp: None,
             disk_conflict: false,
+            encoding_loss: false,
+            lossy_save_armed: false,
             last_edit_at: None,
         }
     }
@@ -2678,6 +2695,10 @@ impl Editor {
         self.path = Some(path.to_path_buf());
         self.disk_stamp = Self::disk_stamp_of(path);
         self.disk_conflict = false;
+        // A whole-buffer swap: whatever the previous contents could not be
+        // encoded as is no longer this tab's problem.
+        self.encoding_loss = false;
+        self.lossy_save_armed = false;
         self.lang = path
             .extension()
             .and_then(|e| e.to_str())
@@ -2764,6 +2785,10 @@ impl Editor {
         self.path = Some(path.to_path_buf());
         self.disk_stamp = Self::disk_stamp_of(path);
         self.disk_conflict = false;
+        // A whole-buffer swap: whatever the previous contents could not be
+        // encoded as is no longer this tab's problem.
+        self.encoding_loss = false;
+        self.lossy_save_armed = false;
         self.lines = vec![String::new()];
         // A whole-buffer swap like every other opener: caches memoised on
         // edit_seq (conflicts, git marks) must not survive into this tab.
@@ -2798,6 +2823,10 @@ impl Editor {
         self.path = Some(path.to_path_buf());
         self.disk_stamp = Self::disk_stamp_of(path);
         self.disk_conflict = false;
+        // A whole-buffer swap: whatever the previous contents could not be
+        // encoded as is no longer this tab's problem.
+        self.encoding_loss = false;
+        self.lossy_save_armed = false;
         self.lines = vec![String::new()];
         // A whole-buffer swap like every other opener: caches memoised on
         // edit_seq (conflicts, git marks) must not survive into this tab.
@@ -2831,6 +2860,10 @@ impl Editor {
         self.path = Some(path.to_path_buf());
         self.disk_stamp = Self::disk_stamp_of(path);
         self.disk_conflict = false;
+        // A whole-buffer swap: whatever the previous contents could not be
+        // encoded as is no longer this tab's problem.
+        self.encoding_loss = false;
+        self.lossy_save_armed = false;
         self.lines = vec![String::new()];
         // A whole-buffer swap like every other opener: caches memoised on
         // edit_seq (conflicts, git marks) must not survive into this tab.
@@ -3430,6 +3463,11 @@ impl Editor {
         // The buffer now matches disk decoded as `enc`, so it is clean; bump the
         // edit seq so the LSP/outline/highlight resync sees the new content.
         self.dirty = false;
+        // The encoding just changed, so a refusal recorded against the old
+        // one is stale — without this, auto save would keep skipping a tab
+        // whose new encoding covers the buffer fine.
+        self.encoding_loss = false;
+        self.lossy_save_armed = false;
         self.edit_seq = self.edit_seq.wrapping_add(1);
         self.recompute_highlights();
         Ok(())
@@ -4510,13 +4548,17 @@ impl Editor {
             self.disk_conflict = true;
             return Ok(SaveOutcome::DiskConflict);
         }
-        self.write_buffer_to_disk()?;
-        Ok(SaveOutcome::Saved)
+        self.write_buffer_to_disk()
     }
 
-    /// Save unconditionally, overwriting any external change. The "Overwrite"
-    /// half of a conflict resolution.
-    pub fn save_to_disk_force(&mut self) -> Result<()> {
+    /// Save past a disk conflict, overwriting the external change. The
+    /// "Overwrite" half of a conflict resolution.
+    ///
+    /// It does NOT bypass the encoding-loss guard: consenting to overwrite
+    /// someone else's edit is not consent to mangle your own characters, so a
+    /// buffer with both problems still reports `EncodingLoss` here and needs
+    /// `lossy_save_armed` on top.
+    pub fn save_to_disk_force(&mut self) -> Result<SaveOutcome> {
         self.write_buffer_to_disk()
     }
 
@@ -4529,7 +4571,13 @@ impl Editor {
     /// `output_encoding()` to UTF-8 and hands back the string's UTF-8 bytes.
     /// Taking that output at face value wrote a file that disagreed with the
     /// encoding the status bar reported for it.
-    fn encode_for_disk(&self, content: &str) -> Vec<u8> {
+    ///
+    /// Returns the bytes and whether the encoder had to substitute: for a
+    /// legacy encoding `encoding_rs` does NOT write `?` the way iconv-lite
+    /// (and so VS Code) does — per the WHATWG Encoding Standard it emits an
+    /// HTML numeric character reference, which is valid content that no
+    /// longer round-trips. Callers must not write that without consent.
+    fn encode_for_disk(&self, content: &str) -> (Vec<u8>, bool) {
         let enc = self.encoding;
         if enc == encoding_rs::UTF_16LE || enc == encoding_rs::UTF_16BE {
             let le = enc == encoding_rs::UTF_16LE;
@@ -4547,28 +4595,75 @@ impl Editor {
                     unit.to_be_bytes()
                 });
             }
-            return out;
+            // Every `char` encodes to UTF-16 losslessly (a `str` cannot hold
+            // an unpaired surrogate), so this branch never substitutes.
+            return (out, false);
         }
-        // Unmappable characters are replaced per encoding_rs, matching VS Code.
-        let (encoded, _, _) = enc.encode(content);
+        let (encoded, _, had_errors) = enc.encode(content);
         if self.bom && enc == encoding_rs::UTF_8 {
             let mut out = Vec::with_capacity(encoded.len() + 3);
             out.extend_from_slice(&[0xEF, 0xBB, 0xBF]);
             out.extend_from_slice(&encoded);
-            return out;
+            return (out, had_errors);
         }
-        encoded.into_owned()
+        (encoded.into_owned(), had_errors)
     }
 
-    fn write_buffer_to_disk(&mut self) -> Result<()> {
+    /// The distinct characters `encoding` cannot represent, in first-seen
+    /// order and capped, for the message an `EncodingLoss` refusal shows.
+    ///
+    /// Walks the buffer and encodes each non-ASCII character on its own, so
+    /// call it once to build that message rather than per frame. Empty for
+    /// UTF-8 and UTF-16, which cover every `char`.
+    pub fn unmappable_chars(&self) -> Vec<char> {
+        /// Enough to name the problem without turning the status line into a
+        /// character dump.
+        const MAX: usize = 8;
+        let enc = self.encoding;
+        if enc == encoding_rs::UTF_8 || enc == encoding_rs::UTF_16LE || enc == encoding_rs::UTF_16BE
+        {
+            return Vec::new();
+        }
+        let mut out: Vec<char> = Vec::new();
+        let mut buf = [0u8; 4];
+        for line in &self.lines {
+            // ASCII is mappable in every encoding croft offers, and is the
+            // overwhelming majority of a source file: skip it without paying
+            // for an encode call.
+            for ch in line.chars().filter(|c| !c.is_ascii()) {
+                if out.contains(&ch) {
+                    continue;
+                }
+                let (_, _, had_errors) = enc.encode(ch.encode_utf8(&mut buf));
+                if had_errors {
+                    out.push(ch);
+                    if out.len() == MAX {
+                        return out;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    fn write_buffer_to_disk(&mut self) -> Result<SaveOutcome> {
         let path = self
             .path
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("No file open"))?
             .clone();
         let content = self.lines.join(self.eol.sequence());
-        let encoded = self.encode_for_disk(&content);
+        let (encoded, had_errors) = self.encode_for_disk(&content);
+        // The single choke point every save funnels through, so no caller can
+        // route around the guard. The consent flag survives a failed write
+        // (the user still consented) and is cleared only once the bytes land.
+        if had_errors && !self.lossy_save_armed {
+            self.encoding_loss = true;
+            return Ok(SaveOutcome::EncodingLoss);
+        }
         std::fs::write(&path, encoded)?;
+        self.encoding_loss = false;
+        self.lossy_save_armed = false;
         self.dirty = false;
         // The next keystroke opens a fresh undo step: coalescing across the
         // save point would make one Cmd+Z discard work from both sides.
@@ -4577,7 +4672,7 @@ impl Editor {
         // The buffer now matches disk, so this is the new sync point and any
         // prior conflict is resolved.
         self.mark_synced_with_disk();
-        Ok(())
+        Ok(SaveOutcome::Saved)
     }
 
     pub fn move_up(&mut self) {
@@ -6961,7 +7056,10 @@ fn wrap_segments(chars: &[char], width: usize) -> Vec<(usize, usize)> {
 /// would then resolve one row off. Normalizing first keeps the two in lockstep
 /// and is a no-op for clean `\n`-only files.
 fn split_into_lines(text: &str) -> Vec<String> {
-    normalize_newlines(text).lines().map(|s| s.to_string()).collect()
+    normalize_newlines(text)
+        .lines()
+        .map(|s| s.to_string())
+        .collect()
 }
 
 /// Fold every line-ending convention to `\n` so callers can split on it
@@ -9930,8 +10028,13 @@ mod tests {
         tabs.open(&path).unwrap();
         tabs.lines[0].push('x');
         tabs.dirty = true;
-        tabs.open_head_diff_with_text(PathBuf::from("a.txt (local snapshot)"), "old\n", &path, false)
-            .unwrap();
+        tabs.open_head_diff_with_text(
+            PathBuf::from("a.txt (local snapshot)"),
+            "old\n",
+            &path,
+            false,
+        )
+        .unwrap();
         assert!(
             tabs.editors
                 .iter()
@@ -13360,7 +13463,11 @@ mod tests {
         e.lines = vec!["abc".to_string()];
         e.replace_find_match(0, 1, 1, "x\ny");
         assert_eq!(e.lines, vec!["ax".to_string(), "yc".to_string()]);
-        assert_eq!((e.cursor_row, e.cursor_col), (1, 1), "caret after the inserted text");
+        assert_eq!(
+            (e.cursor_row, e.cursor_col),
+            (1, 1),
+            "caret after the inserted text"
+        );
     }
 
     #[test]
@@ -13551,6 +13658,78 @@ mod tests {
                 .contains("local")
         );
         assert!(!e.disk_conflict);
+    }
+
+    /// A legacy encoding that cannot represent the buffer must never write
+    /// silently: `encoding_rs` substitutes HTML numeric character references
+    /// (NOT `?`), so the file ends up holding ASCII text that no longer
+    /// round-trips, while the buffer still shows the originals.
+    #[test]
+    fn saving_text_the_encoding_cannot_represent_is_refused_not_silently_mangled() {
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "cafe\n").unwrap();
+        let mut e = Editor::new();
+        e.open(tmp.path()).unwrap();
+        e.reopen_with_encoding(encoding_rs::WINDOWS_1252).unwrap();
+        // € lives at 0x80 in Windows-1252, so only the CJK is unmappable.
+        e.lines = vec![String::from("日本語 costs 5€")];
+        e.dirty = true;
+        assert_eq!(e.save_to_disk().unwrap(), SaveOutcome::EncodingLoss);
+        assert_eq!(
+            std::fs::read_to_string(tmp.path()).unwrap(),
+            "cafe\n",
+            "a refused save must leave the file untouched"
+        );
+        assert!(e.encoding_loss, "the refusal latches so auto save skips it");
+        assert_eq!(e.unmappable_chars(), vec!['日', '本', '語']);
+        // Explicit consent (the second Cmd+S) writes the replacements.
+        e.lossy_save_armed = true;
+        assert_eq!(e.save_to_disk().unwrap(), SaveOutcome::Saved);
+        assert_eq!(
+            std::fs::read(tmp.path()).unwrap(),
+            b"&#26085;&#26412;&#35486; costs 5\x80",
+            "consent writes encoding_rs' references, and € as the 0x80 byte"
+        );
+        assert!(!e.encoding_loss);
+        assert!(!e.lossy_save_armed, "consent is one-shot");
+    }
+
+    /// The refusal must not fire for a buffer the encoding covers, and must
+    /// not fire at all for UTF-8/UTF-16, which cover everything.
+    #[test]
+    fn a_representable_buffer_saves_without_a_prompt() {
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "cafe\n").unwrap();
+        let mut e = Editor::new();
+        e.open(tmp.path()).unwrap();
+        e.reopen_with_encoding(encoding_rs::WINDOWS_1252).unwrap();
+        e.lines = vec![String::from("café")];
+        assert_eq!(e.save_to_disk().unwrap(), SaveOutcome::Saved);
+        assert_eq!(std::fs::read(tmp.path()).unwrap(), b"caf\xE9");
+        assert!(e.unmappable_chars().is_empty());
+        // The same text in UTF-8 is always representable.
+        let mut u = Editor::new();
+        u.open(tmp.path()).unwrap();
+        u.lines = vec![String::from("日本語")];
+        assert_eq!(u.encoding, encoding_rs::UTF_8);
+        assert_eq!(u.save_to_disk().unwrap(), SaveOutcome::Saved);
+        assert!(u.unmappable_chars().is_empty());
+    }
+
+    /// Switching the buffer to an encoding that covers it must clear the
+    /// latch, or auto save would stay wedged on a file that is now fine.
+    #[test]
+    fn reopening_with_another_encoding_clears_the_encoding_loss_latch() {
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "日本語").unwrap();
+        let mut e = Editor::new();
+        e.open(tmp.path()).unwrap();
+        e.encoding = encoding_rs::WINDOWS_1252;
+        assert_eq!(e.save_to_disk().unwrap(), SaveOutcome::EncodingLoss);
+        assert!(e.encoding_loss);
+        e.reopen_with_encoding(encoding_rs::UTF_8).unwrap();
+        assert!(!e.encoding_loss);
+        assert_eq!(e.save_to_disk().unwrap(), SaveOutcome::Saved);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #41.

`encoding_rs` substitutes HTML numeric character references (`&#26085;`), not `?`, for unmappable characters — per the WHATWG Encoding Standard — so saving a buffer under a legacy encoding silently rewrote text like 日本語 as ASCII reference strings on disk, with no warning and no way back (the buffer itself is unchanged, so undo cannot help). The comment on the encode line claimed VS Code parity; VS Code goes through iconv-lite, which writes `?`, so the claim was wrong and has been removed.

## What changed

- `encode_for_disk` now surfaces `encoding_rs`' `had_errors` flag, and `write_buffer_to_disk` — the single choke point every save funnels through, so no caller can route around the guard — refuses with the new `SaveOutcome::EncodingLoss` unless the one-shot `lossy_save_armed` consent is set. UTF-8/UTF-16 never trip it (every `char` is representable).
- The explicit Cmd+S path mirrors the existing disk-conflict press-again flow: the refusal names the encoding and the doomed characters (`unmappable_chars`, distinct, first-seen order, capped at 8), arms the consent, and the second Cmd+S writes the substitutions. Force save (the disk-conflict overwrite) does NOT bypass the guard: consenting to overwrite someone else's edit is not consent to mangle your own characters.
- Auto save latches `encoding_loss` (like `disk_conflict`) so it stops retrying, reports the stall once on the transition tick via the status line (not the modal prompt — nothing is lost or racing, so it must not steal the keyboard mid-burst), and never consents on the user's behalf.
- The deferred format-on-save write routes a still-focused tab into the same press-again prompt; without that, a format-on-save file's every Cmd+S re-entered the deferred path and the refusal looped with no way to accept it.
- Any reopen (`open`, `reopen_with_encoding`, image/sheet/pdf) clears the latch, since the buffer or encoding it was recorded against is gone.

## Product call

Issue #41 left refuse-vs-warn open. This picks refuse + press-again consent, matching the disk-conflict flow exactly, so the two guards behave identically and reuse the same muscle memory.

## Tests

- `saving_text_the_encoding_cannot_represent_is_refused_not_silently_mangled` — the issue's exact probe (windows-1252, `日本語 costs 5€`): refusal leaves the file untouched, consent writes `&#26085;&#26412;&#35486; costs 5\x80` (€ maps to 0x80, so it survives).
- `a_representable_buffer_saves_without_a_prompt` — no false positives, UTF-8 never trips.
- `reopening_with_another_encoding_clears_the_encoding_loss_latch`
- `explicit_save_prompts_before_a_lossy_encoding_write_then_second_press_consents` — the full Cmd+S/Cmd+S app flow.
- `auto_save_surfaces_an_encoding_refusal_instead_of_latching_silently` — transition-tick report, no write, no consent, quiet afterwards.

Full suite green, clippy zero warnings. rustfmt drift in the three touched files is included (part of #32).

Also bumps to 0.1.686 with release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saves from silently replacing unsupported characters when using legacy encodings.
  * Files with encoding loss now remain unchanged until you explicitly confirm a one-time lossy save.
  * Auto-save pauses for affected files and reports the issue in the status bar.
  * Improved reload behavior, line-ending normalization, and caret placement after multiline edits.

* **Tests**
  * Added coverage for encoding-loss handling, encoding changes, reloads, and dirty-file comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->