### PR TITLE
fix(app): make the quick-select scroll test immune to the child shell's prompt timing

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -24803,23 +24803,37 @@ fn quick_select_labels_follow_content_that_streams_below_them() {
     // Park the cursor at the pane bottom so every further row SCROLLS.
     let h = app.terminals[0].last_inner.height as usize;
     app.terminals[0].feed_bytes_for_test("\r\n".repeat(h * 2).as_bytes());
-    app.terminals[0].feed_bytes_for_test(b"http://drift.io");
+    // One atomic feed, opening with its own newline: the live child
+    // shell's prompt can flush between feed calls under suite load (#62),
+    // and a prompt landing just before the URL used to push it across the
+    // pane edge, wrapping the match. Advancing "\r\n" + URL under one grid
+    // lock keeps the URL at column 0 whether the prompt arrives before
+    // this chunk (its row is above) or after it (it appends to the right).
+    app.terminals[0].feed_bytes_for_test(b"\r\nhttp://drift.io");
     app.open_terminal_quick_select();
     assert!(app.terminal_quick_select.is_some(), "staging: one hint");
     app.terminals[0].feed_bytes_for_test(b"\r\nx1\r\nx2\r\nx3");
     term.draw(|f| app.render(f)).unwrap();
     let buf = term.backend().buffer().clone();
-    let rows: Vec<String> = (0..buf.area.height)
-        .map(|y| {
-            (0..buf.area.width)
-                .map(|x| buf[(x, y)].symbol().chars().next().unwrap_or(' '))
-                .collect()
+    // Join the pane's inner rows into one stream before searching, so pane
+    // geometry can't split the needle across a row boundary (#62), and
+    // don't pin WHICH gold label the URL drew: when the live shell's
+    // prompt lands above the URL its path is a match too, and label
+    // assignment is bottom-priority, so the URL's letter depends on that
+    // race. The invariant is that SOME label still covers the URL's first
+    // cell after the scroll — the 'h' is overlaid, the rest is intact.
+    let inner = app.terminals[0].last_inner;
+    let joined: String = (inner.y..inner.y + inner.height)
+        .flat_map(|y| {
+            (inner.x..inner.x + inner.width)
+                .map(move |x| (x, y))
+                .map(|(x, y)| buf[(x, y)].symbol().chars().next().unwrap_or(' '))
         })
         .collect();
     assert!(
-        rows.iter().any(|r| r.contains("attp://drift.io")),
-        "the label 'a' must still overlay its own URL's first cell after the\n\
-         content scrolled; rows: {rows:?}"
+        joined.contains("ttp://drift.io") && !joined.contains("http://drift.io"),
+        "a label must still overlay the URL's first cell after the content\n\
+         scrolled (the 'h' covered, the tail intact); pane text: {joined:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #62.

`quick_select_labels_follow_content_that_streams_below_them` flaked under full-suite load: `App::new` spawns a real shell on the PTY, and its prompt could flush *between* the test's feed calls. A prompt landing just before the fed URL pushed it across the pane edge, wrapping the match — and the row-substring assertion (`contains("attp://drift.io")`) can never match a wrapped URL, because no single row holds it.

## Fix (test-only)

Two structural changes, each killing one arm of the race:

- **Atomic feed.** The `"\r\n"` and the URL now go into the grid in one `feed_bytes_for_test` call. The advance holds the grid lock, so shell output can land before the chunk (its row is above, URL still starts at column 0) or after it (appends to the right of the URL) — but can no longer land *between* the newline and the URL and wrap the match.
- **Wrap-proof, label-agnostic assertion.** The pane's inner rows are joined into one stream before searching, so geometry can't split the needle; and the assertion no longer pins *which* gold label the URL draws — when the shell prompt lands above the URL its path is matched too, and label assignment is bottom-priority, so the URL's letter depends on that race. The pinned invariant is the real one: some label covers the URL's first cell after the scroll (`ttp://drift.io` present, intact `http://drift.io` absent — the second clause is what keeps the original regression red: a label left behind by the scroll leaves the URL intact).

Verified: 5/5 green in isolation, and two full-suite runs where this test passed both (the one failing run hit only the already-filed #57 and the newly-filed #65 — unrelated wall-clock flakes).

## Filed along the way

Making the wrap deterministic (prompt-length pad before the URL) exposed a real product defect, filed as #64: `find_matches` scans display rows independently, so a match wrapping the pane edge is never seen whole — the wrapped URL's tail is labelled as a filesystem-path fragment and typing the label copies `/drift.io`, not the URL. This PR deliberately does not pin that behavior; #64 owns fixing the scanner (logical-line stitching).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved terminal display test coverage for URLs split across pane rows.
  * Relaxed assertions to verify visible label placement and preserved URL text without relying on fixed labels or URL fragments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->