### PR TITLE
fix(tests): give the arrival-stamped OSC 133 duration asserts a load-proof margin

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20157,9 +20157,9 @@ fn finished_commands_land_in_durable_history_and_the_popup_types_them() {
     app.command_history =
         crate::command_history::CommandHistory::load(&tmp.path().join("hist.jsonl"));
     // Full OSC 133 marks around a fake command (B → command text → C →
-    // 0.25s of "runtime" → D;0), then a read so the popup's Enter-typed
+    // 1s of "runtime" → D;0), then a read so the popup's Enter-typed
     // bytes are observable through the shell.
-    let script = "printf '\\033]133;A\\007$ \\033]133;B\\007kubectl get pods\\n\\033]133;C\\007'; sleep 0.25; printf 'out\\n\\033]133;D;0\\007'; read x; echo typed-$x; sleep 30";
+    let script = "printf '\\033]133;A\\007$ \\033]133;B\\007kubectl get pods\\n\\033]133;C\\007'; sleep 1; printf 'out\\n\\033]133;D;0\\007'; read x; echo typed-$x; sleep 30";
     app.terminals[0] = crate::widgets::terminal::PtyTerminal::new_running(
         "/bin/sh",
         &[String::from("-c"), String::from(script)],
@@ -20179,8 +20179,13 @@ fn finished_commands_land_in_durable_history_and_the_popup_types_them() {
         "the typed text travels with the completion"
     );
     assert_eq!(e.exit, Some(0));
+    // The marks are stamped when the reader thread PARSES them, not when
+    // the child wrote them, so under suite load a late pickup of the
+    // pre-sleep chunk shrinks the measured gap (#65). The floor at half
+    // the sleep keeps a wrong-span measurement red while giving scheduler
+    // skew ~10x the largest undershoot ever observed (~55ms).
     assert!(
-        e.dur_ms >= 200,
+        e.dur_ms >= 500,
         "duration must cover the C→D gap, got {}",
         e.dur_ms
     );

--- a/src/widgets/terminal.rs
+++ b/src/widgets/terminal.rs
@@ -5502,7 +5502,7 @@ mod tests {
         // covering the sleep between CommandStart and CommandEnd, and the
         // same completion must arrive once through the notification drain.
         let tmp = tempfile::tempdir().unwrap();
-        let script = "printf '\\033]133;A\\007$ cmd\\n\\033]133;B\\007\\033]133;C\\007'; sleep 0.3; printf 'out\\n\\033]133;D;2\\007'";
+        let script = "printf '\\033]133;A\\007$ cmd\\n\\033]133;B\\007\\033]133;C\\007'; sleep 1; printf 'out\\n\\033]133;D;2\\007'";
         let term =
             PtyTerminal::new_running("/bin/sh", &[String::from("-c"), script.into()], tmp.path())
                 .unwrap();
@@ -5512,8 +5512,11 @@ mod tests {
             if let Some(d) = decos.first() {
                 assert_eq!(d.exit, Some(2), "exit code from 133;D;2");
                 let dur = d.duration.expect("duration must be measured");
+                // Marks are arrival-stamped by the reader thread, so a late
+                // pickup of the pre-sleep chunk shrinks the measured gap
+                // under suite load (#65): the floor sits at half the sleep.
                 assert!(
-                    dur >= std::time::Duration::from_millis(250),
+                    dur >= std::time::Duration::from_millis(500),
                     "duration must cover the sleep; got {dur:?}"
                 );
                 break;
@@ -5529,7 +5532,7 @@ mod tests {
         let finished = term.drain_finished_commands();
         assert_eq!(finished.len(), 1, "one completion in the drain");
         assert_eq!(finished[0].exit, Some(2));
-        assert!(finished[0].dur >= std::time::Duration::from_millis(250));
+        assert!(finished[0].dur >= std::time::Duration::from_millis(500));
         assert!(
             term.drain_finished_commands().is_empty(),
             "a second drain returns nothing"


### PR DESCRIPTION
Fixes #65.

The OSC 133 C and D marks are timestamped when the reader thread *parses* them, not when the child writes them (src/widgets/terminal.rs:1542). Under full-suite load the pre-sleep chunk (prompt + command + `C`) can be picked up tens of milliseconds after the child wrote it, while `D` — written into a quiet pipe after the sleep — is picked up promptly, so the measured C→D gap undershoots the real one. The observed failure was `got 195` against a 250ms sleep with a `>= 200` floor: a ~55ms late `C` stamp eating a 50ms margin.

## Fix (test-only)

Arrival time is the only clock croft has for marks, so the test's margin has to absorb scheduling rather than fight it. Both duration-asserting tests lengthen the simulated runtime to `sleep 1` and set the floor at half of it (`>= 500ms`):

- `app::tests::finished_commands_land_in_durable_history_and_the_popup_types_them` (the flake #65 reports)
- `widgets::terminal::tests::osc133_decorations_carry_exit_and_duration_end_to_end` — same defect class found by sweeping for sleep-vs-floor pairs: `sleep 0.3` against a `>= 250ms` floor, asserted twice

The assertion still proves the duration covers the C→D gap — a wrong-span measurement (e.g. stamping both ends at `D`) reads ~0 and stays red — while the scheduling margin grows from 50ms to 500ms, ~10x the largest undershoot ever observed.

Verified: both tests green solo; one full-suite run fully green (3037 passed), one earlier run where both duration tests passed and the only failures were two unrelated load flakes filed as #68 and #69.

## Filed along the way

- #68 — `search_worker_loop_cancels_in_flight_scan_when_a_new_request_arrives`: 1.5s wall-clock deadline on a cancel-and-rescan over a 4M-line workspace, same margin-vs-preemption family.
- #69 — `a_foreground_process_cannot_impersonate_a_local_cwd_report`: staging loop exits on `shell_cwd().is_some()`, which the shell's *own* prompt-time OSC 7 satisfies before the forged claim is parsed.
