### PR TITLE
fix(tests): stage the cwd-impersonation test on the forged claim, not any OSC 7

### DIFF
--- a/src/widgets/terminal.rs
+++ b/src/widgets/terminal.rs
@@ -4670,22 +4670,40 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(20));
             waited += 20;
         }
+        // Stage the decoy: the shim's own prompt-time OSC 7 reports the
+        // shell's real cwd (the tempdir), so `shell_cwd()` is `Some` long
+        // before the forged claim exists — an `is_some()` stage exits on
+        // this report and reads the wrong value (#69).
+        let mut waited = 0u32;
+        while waited < 4000 && term.shell_cwd().is_none() {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            waited += 20;
+        }
         // A foreground job (the ssh stand-in) prints an OSC 7 claiming
-        // this machine's own hostname.
+        // this machine's own hostname. It sleeps BEFORE printing, so the
+        // tty is lost to the job well before the claim can be parsed —
+        // deterministically the ordering that flaked under suite load.
         term.write_input(
-            format!("printf '\\033]7;file://{local}/tmp\\007'; sleep 10\n").as_bytes(),
+            format!("sleep 0.5; printf '\\033]7;file://{local}/tmp\\007'; sleep 10\n").as_bytes(),
         );
         let mut waited = 0u32;
-        while waited < 4000 && (term.foreground_is_shell() || term.shell_cwd().is_none()) {
+        while waited < 4000 && term.foreground_is_shell() {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            waited += 20;
+        }
+        assert!(!term.foreground_is_shell(), "staging: a job owns the tty");
+        // Wait for the claim ITSELF: any earlier `Some` is the decoy.
+        let claim = std::path::PathBuf::from("/tmp");
+        let mut waited = 0u32;
+        while waited < 6000 && term.shell_cwd().as_deref() != Some(claim.as_path()) {
             std::thread::sleep(std::time::Duration::from_millis(20));
             waited += 20;
         }
         assert_eq!(
             term.shell_cwd(),
-            Some(std::path::PathBuf::from("/tmp")),
+            Some(claim),
             "staging: the claim was captured"
         );
-        assert!(!term.foreground_is_shell(), "staging: a job owns the tty");
         assert_eq!(
             term.local_shell_cwd(),
             None,


### PR DESCRIPTION
Fixes #69.

The staging loop exited on `!foreground_is_shell() && shell_cwd().is_some()` — but `shell_cwd()` goes `Some` long before the forged claim arrives: croft's shell shim reports the shell's **own** cwd (the test's tempdir) via OSC 7 at the first prompt. The remaining gate, the job taking the tty, is an immediate kernel query, while the forged OSC 7 must travel through the reader thread's parse. Under suite load the kernel query flips first, the loop exits, and the staging assert reads the decoy: `left: Some("/tmp/.tmpuexGki")` in the CI failure is the tempdir's prompt-time report.

## Fix (test-only)

Two changes:

- **Stage on the claim itself.** The decoy report is now staged explicitly (wait for the prompt's own `Some`), and after the job takes the tty the loop waits for `shell_cwd() == Some("/tmp")` — any earlier `Some` is the decoy. The security assertion (`local_shell_cwd()` must be `None` while a job owns the tty) is unchanged and now runs with both of its premises deterministically established.
- **Force the flaked ordering on every run.** The forged job now sleeps *before* printing the claim (`sleep 0.5; printf CLAIM; sleep 10`), so the tty is always lost to the job well before the claim can be parsed — the exact interleaving that previously required suite load to hit. With the old staging this reproduces the CI failure deterministically solo (verified: identical `left: Some(tempdir)` signature, red on first try); with the new staging it passes.

Verified red→green: deterministic red with the amplifier alone, then 5/5 green solo with the fix, and a full-suite run where this test passed under load (the run's only failure was the already-filed #68, which flaked identically on unmodified main).
