### PR TITLE
docs: add --locked to every documented cargo install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ## Install
 
 ```bash
-cargo install --git https://github.com/vitali87/croft.git
+cargo install --git https://github.com/vitali87/croft.git --locked
 ```
 
 This compiles croft from the latest `main` into `~/.cargo/bin/croft`. Re-run to upgrade. To build from source instead:
@@ -57,7 +57,7 @@ This compiles croft from the latest `main` into `~/.cargo/bin/croft`. Re-run to 
 ```bash
 git clone https://github.com/vitali87/croft.git
 cd croft
-cargo build --release && cargo install --path .
+cargo build --release && cargo install --path . --locked
 ```
 
 **macOS:** the build directory churns the Spotlight index and can spike your CPU and fans. Before building, point Cargo at a `.noindex` directory Spotlight ignores; see [MACOS.md](docs/MACOS.md#spotlight-indexing-and-the-build-directory).

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -9,7 +9,7 @@ There is **no required setup command** on Android. After `cargo install`, croft 
 ## Install
 
 ```bash
-cargo install --git https://github.com/vitali87/croft.git
+cargo install --git https://github.com/vitali87/croft.git --locked
 ```
 
 This builds croft into `~/.cargo/bin/croft` inside Termux. Re-run to upgrade.

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -8,7 +8,7 @@ croft has no separate "Windows" target. Inside WSL2 you are running real Linux, 
 
 ```bash
 # inside your WSL2 distro (Ubuntu, Debian, etc.)
-cargo install --git https://github.com/vitali87/croft.git
+cargo install --git https://github.com/vitali87/croft.git --locked
 ```
 
 The one thing WSL does **not** change is the terminal. A WSL shell renders into whatever Windows terminal emulator is hosting it, and that choice decides whether you get croft's full icon/image UI or the degraded text fallback:


### PR DESCRIPTION
Fixes #67.

Docs-only: every documented install command now carries `--locked`, so fresh installs build with the committed lockfile (zune-core pinned at 0.5.1) instead of resolving the 0.5.2 macro regression that breaks zune-jpeg 0.5.15 compilation.

Four sites, not just the README's `--git` line:

- `README.md` — `cargo install --git … --locked`
- `README.md` — the from-source path: `cargo install --path . --locked` (`cargo install` re-resolves dependencies without `--locked` exactly like the `--git` form; the preceding `cargo build` already honours the lockfile)
- `docs/WINDOWS.md` — the WSL2 install
- `docs/ANDROID.md` — the Termux install

No version bump: docs-only change. Once upstream zune ships a fix, unlocked installs recover on their own, but `--locked` stays correct — installs should build the dependency set CI tested regardless.
