### PR TITLE
fix(tests): assert the minimum of five source-control click timings

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8226,15 +8226,23 @@ fn clicking_source_control_does_not_block_on_git_and_posts_a_changes_request() {
     // racing with that startup reply.
     std::thread::sleep(std::time::Duration::from_millis(150));
     let _ = app.drain_git_responses();
-    let started = std::time::Instant::now();
-    app.set_sidebar_view(SidebarView::SourceControl);
-    let elapsed = started.elapsed();
     // The synchronous shell-out used to take 15-50 ms minimum on
     // any real machine; an order of magnitude headroom catches the
-    // regression even on a fast CI box.
+    // regression even on a fast CI box. A single wall-clock sample
+    // measures the scheduler as much as the code under suite load
+    // (#57): one preemption between the clock reads adds milliseconds
+    // with no regression present. The MINIMUM of several attempts is
+    // immune — a preemption doesn't repeat on every try, while a
+    // genuine synchronous shell-out fails all of them.
+    let mut fastest = std::time::Duration::MAX;
+    for _ in 0..5 {
+        let started = std::time::Instant::now();
+        app.set_sidebar_view(SidebarView::SourceControl);
+        fastest = fastest.min(started.elapsed());
+    }
     assert!(
-        elapsed < std::time::Duration::from_millis(5),
-        "Source Control click must not block on git; took {elapsed:?}",
+        fastest < std::time::Duration::from_millis(5),
+        "Source Control click must not block on git; fastest of 5 took {fastest:?}",
     );
     // The Changes request must have landed on the worker — give it
     // up to 2 s to respond, then drain. The response carries the


### PR DESCRIPTION
Fixes #57.

The test asserted a single `set_sidebar_view(SourceControl)` call returned inside a 5ms wall-clock budget. The click path is one non-blocking `mpsc` send (microseconds), but under full-suite load a single scheduler preemption between the two clock reads adds milliseconds with no regression present — the observed 5.45ms failure is exactly that shape, an order of magnitude below the 15ms floor of the synchronous-shell-out bug the budget guards. The 5ms line itself can't widen: it already sits at the order-of-magnitude boundary.

## Fix (test-only)

The issue's own direction: time **five** attempts and assert the *minimum* elapsed. A preemption doesn't repeat on every try; the genuine regression (a synchronous `git status` shell-out at 15-50ms minimum) fails all five. `set_sidebar_view` is repeat-safe — no toggle semantics, each call posts one more worker request, and the functional half of the test (the worker's Changes reply carrying the dirty file) drains those replies regardless.

Verified: 5/5 green solo; full suite fully green (3042 passed, 0 failed).
