### PR TITLE
fix(tests): stop racing wall-clock deadlines against suite load

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4668,8 +4668,14 @@ fn cmd_click_on_a_file_line_reference_in_the_terminal_opens_the_file_there() {
     // The echoed command line also contains the reference; wait for the
     // OUTPUT line (the one starting with "ref "), then click that one.
     let is_output_line = |l: &str| l.trim_start().starts_with("ref src/probe.rs");
+    // A pure liveness backstop, generous on purpose (#44): the shell does
+    // its full interactive startup on a box the parallel suite saturates,
+    // and a tight ceiling here measured the scheduler, not croft — the
+    // one observed failure had the echoed command on screen but the
+    // output line not yet flushed. A genuine delivery failure still trips
+    // this, just later.
     let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(5000) {
+    while started.elapsed() < std::time::Duration::from_secs(30) {
         if app.terminal().visible_text().lines().any(is_output_line) {
             break;
         }
@@ -4680,7 +4686,7 @@ fn cmd_click_on_a_file_line_reference_in_the_terminal_opens_the_file_there() {
     let row_idx = snapshot
         .lines()
         .position(is_output_line)
-        .unwrap_or_else(|| panic!("shell must print the reference within 5s; got:\n{snapshot}"));
+        .unwrap_or_else(|| panic!("shell must print the reference; got:\n{snapshot}"));
     let line = snapshot.lines().nth(row_idx).unwrap();
     let col = line.find("probe.rs").unwrap() + 2;
 

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -2236,7 +2236,10 @@ mod tests {
         }
 
         fn wait_until(&self, what: &str, mut cond: impl FnMut(&Self) -> bool) {
-            let deadline = Instant::now() + Duration::from_secs(10);
+            // A liveness backstop, generous on purpose: the python3 helper
+            // and relay round trips race the parallel suite's load (#47),
+            // and a tight ceiling here measured the machine, not croft.
+            let deadline = Instant::now() + Duration::from_secs(60);
             while !cond(self) {
                 assert!(Instant::now() < deadline, "timed out waiting for {what}");
                 std::thread::sleep(Duration::from_millis(10));
@@ -2440,7 +2443,7 @@ mod tests {
         let state = host.state_for_tests().expect("pilot state");
         // Wait until the PILOT finished the turn (its reader cleared the
         // latch); the App has not polled yet.
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(60);
         while state.lock().unwrap().turn_active() {
             assert!(Instant::now() < deadline, "the fake turn never finished");
             std::thread::sleep(Duration::from_millis(5));
@@ -3382,7 +3385,7 @@ mod tests {
         send_turn(&pilot.state, &pilot.sink, "fix demo.txt").unwrap();
         let end = pilot
             .turn_rx
-            .recv_timeout(Duration::from_secs(10))
+            .recv_timeout(Duration::from_secs(60))
             .expect("turn ends");
         assert!(!end.is_error && !end.cancelled, "{}", end.text);
         server.join().unwrap();
@@ -3565,8 +3568,9 @@ mod tests {
             h.doc().as_deref() == Some("hello streamed edit")
         });
         // The pilot's REPL input is already at EOF; once the turn ends it
-        // must return promptly despite the child sleeping for 60s.
-        let deadline = Instant::now() + Duration::from_secs(10);
+        // must return promptly despite the child sleeping for 60s — half
+        // that sleep keeps the discriminant while absorbing suite load.
+        let deadline = Instant::now() + Duration::from_secs(30);
         while !pilot.is_finished() {
             assert!(
                 Instant::now() < deadline,
@@ -4099,7 +4103,7 @@ mod tests {
             crate::pair_host::PairHost::spawn_cmd(&harness.socket, "navigator", None, cmd).unwrap();
         host.send_task("@demo.txt look this over").unwrap();
 
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(60);
         let mut events: Vec<crate::pair_host::PairEvent> = Vec::new();
         while !events
             .iter()
@@ -4233,7 +4237,7 @@ mod tests {
             crate::pair_host::PairHost::spawn_cmd(&harness.socket, "nav", None, cmd).unwrap();
         host.send_task("@demo.txt look this over").unwrap();
 
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(60);
         while !host
             .poll()
             .iter()
@@ -4312,7 +4316,7 @@ mod tests {
         // Drive one turn so the child reaches its sleep (ignoring stdin EOF).
         host.send_ask_turn("demo.txt", (0, 0), "", "do a thing", "line zero\nline one")
             .unwrap();
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(60);
         while !host
             .poll()
             .iter()
@@ -4438,7 +4442,7 @@ mod tests {
             crate::pair_host::PairHost::spawn_cmd(&harness.socket, "navigator", None, cmd).unwrap();
         host.send_yield_turn("demo.txt", "hello world").unwrap();
 
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(60);
         let mut events: Vec<crate::pair_host::PairEvent> = Vec::new();
         while !events
             .iter()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -39,7 +39,7 @@ fn setup_terminal_help_works() {
 fn probe_subcommands_answer_instantly_even_with_a_stripped_path() {
     let dir = tempfile::tempdir().unwrap();
     let slow_shell = dir.path().join("slow-shell");
-    std::fs::write(&slow_shell, "#!/bin/sh\nsleep 10\n").unwrap();
+    std::fs::write(&slow_shell, "#!/bin/sh\nsleep 30\n").unwrap();
     let mut perm = std::fs::metadata(&slow_shell).unwrap().permissions();
     std::os::unix::fs::PermissionsExt::set_mode(&mut perm, 0o755);
     std::fs::set_permissions(&slow_shell, perm).unwrap();
@@ -52,12 +52,14 @@ fn probe_subcommands_answer_instantly_even_with_a_stripped_path() {
             .env("SHELL", &slow_shell)
             .assert()
             .success();
-        // The discriminant is the 10s sleeping shell: a probe that runs the
+        // The discriminant is the 30s sleeping shell: a probe that runs the
         // PATH repair blocks on it, one that early-outs answers in well
-        // under a second. 5s tolerates a loaded box without ever passing
-        // the failure mode.
+        // under a second. The measured span also covers the cargo_bin
+        // spawn, which a suite-saturated box once pushed past a 5s ceiling
+        // (#50) — half the sleep keeps the failure mode unreachable while
+        // giving load an order of magnitude more headroom.
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(5),
+            start.elapsed() < std::time::Duration::from_secs(15),
             "{sub} --probe took {:?} with a stripped PATH",
             start.elapsed()
         );


### PR DESCRIPTION
Fixes #44. Fixes #47. Fixes #50.

Three flakes, one family: a wall-clock deadline racing machine load instead of the failure mode it guards. Each site is reworked by its own kind:

- **#44** (`cmd_click_on_a_file_line_reference…`, src/app/tests.rs) — the 5s wait for the shell's output line is pure *liveness*: the test's real assertions come after. The observed failure had the echoed command on screen but the output not yet flushed — the shell simply hadn't been scheduled. Now a generous 30s backstop; a genuine delivery failure still trips it, just later.
- **#47** (`pair::tests`, src/pair.rs) — the 10s ceilings on the spawned python3 helper / relay round trips are liveness too. All seven sibling sites move to 60s (the shared `wait_until` helper, the four TurnDone waits, the turn-active wait, the fake-server `recv_timeout`) — same defect, every entry point. The one *discriminant* among them — pilot exit must not wait for a child sleeping 60s — moves to 30s, keeping a 2x gap.
- **#50** (`probe_subcommands_answer_instantly…`, tests/cli.rs) — here the deadline IS the discriminant (a probe that consults `$SHELL` blocks on the sleeping stub; an early-out answers in under a second), so it cannot become a lazy backstop. Instead the margin becomes proportional, the #65 treatment: the stub sleeps 30s and the ceiling moves to 15s — half the discriminant, three times the old headroom for the `cargo_bin` spawn the span also covers.

No production code touched (the 5s retry window in `connect_session` is production and untouched).

Verified: all three named tests green solo; all 68 pair tests green; full all-targets suite green (3042 + 6 cli, 0 failed); clippy zero warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased test wait periods to reduce failures caused by slow shell or process execution.
  * Expanded liveness-test timing allowances for longer-running shell commands.
  * Updated timeout-related test messages and comments to reflect the new limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->