### PR TITLE
fix(fmt): bring main to its own pinned rustfmt and gate it in CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,7 +1,6 @@
-# Bulk reformats to skip in `git blame`.
-# Enable locally with:
-#   git config blame.ignoreRevsFile .git-blame-ignore-revs
-# Codeberg/Forgejo and GitHub honor this file automatically.
+# Pure-formatting commits, skipped by git blame when
+# blame.ignoreRevsFile points at this file (GitHub honours it
+# automatically).
 
-# style: format entire codebase with cargo fmt
-ee3da15811f250904a72f953ef4744e4e2205c36
+# style: apply the pinned rustfmt across the tree
+ccbfd53867a9b8443f9ecf78c65fe55b29ffb91e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Install the pinned toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@v2
+      - name: Formatting (pinned rustfmt, zero diffs)
+        run: cargo fmt --check
       - name: Clippy (zero warnings)
         run: cargo clippy --all-targets -- -D warnings
       - name: Tests

--- a/src/git.rs
+++ b/src/git.rs
@@ -106,7 +106,8 @@ fn query_ignored(root: &Path) -> HashSet<PathBuf> {
     }
     // check-ignore exits 1 when nothing matches: a verdict, not a failure, so
     // `git_raw` deliberately does not gate on the exit status.
-    let confirmed = git_raw(root, &["check-ignore", "-z", "--stdin"], Some(&stdin)).unwrap_or_default();
+    let confirmed =
+        git_raw(root, &["check-ignore", "-z", "--stdin"], Some(&stdin)).unwrap_or_default();
     confirmed
         .split(|b| *b == 0)
         .filter(|s| !s.is_empty())
@@ -2078,7 +2079,8 @@ mod tests {
             );
             payload.push(0);
         }
-        let out = git_raw(p, &["check-ignore", "-z", "--stdin"], Some(&payload)).unwrap_or_default();
+        let out =
+            git_raw(p, &["check-ignore", "-z", "--stdin"], Some(&payload)).unwrap_or_default();
         let got = out.split(|b| *b == 0).filter(|s| !s.is_empty()).count();
         assert_eq!(
             got, n,

--- a/src/testing/locate.rs
+++ b/src/testing/locate.rs
@@ -94,7 +94,8 @@ fn pytest_source(root: &Path, full_name: &str) -> Option<(PathBuf, u32)> {
     let (file, rest) = full_name.split_once(".py::")?;
     let path = root.join(format!("{file}.py"));
     let leaf = rest.rsplit("::").next()?.split('[').next()?;
-    let matcher = RegexMatcher::new(&format!(r"\bdef\s+{}\s*\(", super::regex_escape(leaf))).ok()?;
+    let matcher =
+        RegexMatcher::new(&format!(r"\bdef\s+{}\s*\(", super::regex_escape(leaf))).ok()?;
     let mut searcher = SearcherBuilder::new()
         .line_number(true)
         .binary_detection(BinaryDetection::quit(b'\x00'))
@@ -376,7 +377,11 @@ mod tests {
         std::fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("target/debug/parse.rs"), "fn target_case() {}\n").unwrap();
-        std::fs::write(root.join("node_modules/pkg/parse.rs"), "fn target_case() {}\n").unwrap();
+        std::fs::write(
+            root.join("node_modules/pkg/parse.rs"),
+            "fn target_case() {}\n",
+        )
+        .unwrap();
         std::fs::write(root.join("src/lib.rs"), "fn target_case() {}\n").unwrap();
 
         let (path, _) = find_test_source(root, "widgets::parse::tests::target_case").unwrap();
@@ -404,8 +409,7 @@ mod tests {
         assert_eq!(line, 2, "0-based line of the first test title");
         // A describe chain still resolves through the last segment, and an
         // unbalanced bracket must not abort the regex build.
-        let (_, line) =
-            find_test_source(root, "src/math.test.ts::suite::parses [ tokens").unwrap();
+        let (_, line) = find_test_source(root, "src/math.test.ts::suite::parses [ tokens").unwrap();
         assert_eq!(line, 4);
     }
 
@@ -432,7 +436,11 @@ mod tests {
         // instead of reporting no source.
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
-        std::fs::write(root.join("a.test.js"), "xit('odd little title', () => {})\n").unwrap();
+        std::fs::write(
+            root.join("a.test.js"),
+            "xit('odd little title', () => {})\n",
+        )
+        .unwrap();
         let (_, line) = find_test_source(root, "a.test.js::odd little title").unwrap();
         assert_eq!(line, 0);
     }

--- a/src/testing/worker.rs
+++ b/src/testing/worker.rs
@@ -11,11 +11,11 @@ use std::process::{Command, Stdio};
 use std::sync::mpsc::{Receiver, Sender};
 
 use super::model::{Activity, TestCase, TestStatus};
-use super::regex_escape;
 use super::parse::{
     parse_jest_json, parse_list_line, parse_pytest_collect_line, parse_pytest_line,
     parse_test_line, parse_vitest_list_line, parse_vitest_tap_line,
 };
+use super::regex_escape;
 use crate::output::{self, OutputLevel};
 use crate::widgets::testing::TestingPanel;
 
@@ -569,7 +569,11 @@ fn vitest_one_args(name: &str) -> Vec<String> {
 /// where the positional file argument already scopes the run exactly.
 fn suite_title_anchor(pattern: &str) -> Option<String> {
     let (_, rest) = pattern.split_once("::")?;
-    let joined = rest.split("::").map(regex_escape).collect::<Vec<_>>().join(" ");
+    let joined = rest
+        .split("::")
+        .map(regex_escape)
+        .collect::<Vec<_>>()
+        .join(" ");
     Some(format!("^{joined} "))
 }
 
@@ -1235,7 +1239,13 @@ mod tests {
     fn a_js_suite_click_anchors_the_name_filter_to_the_describe_chain() {
         assert_eq!(
             vitest_filter_args("tests/a.test.js::auth", true),
-            vec!["run", "tests/a.test.js", "-t", "^auth ", "--reporter=tap-flat"]
+            vec![
+                "run",
+                "tests/a.test.js",
+                "-t",
+                "^auth ",
+                "--reporter=tap-flat"
+            ]
         );
         assert_eq!(
             jest_filter_args("tests/a.test.js::group (x)::inner", true),

--- a/src/widgets/diff.rs
+++ b/src/widgets/diff.rs
@@ -195,7 +195,10 @@ impl DiffData {
         let side_meta = |raw: Option<&str>, lines: usize| -> (Vec<bool>, bool) {
             match raw {
                 Some(t) => (
-                    t.split('\n').take(lines).map(|l| l.ends_with('\r')).collect(),
+                    t.split('\n')
+                        .take(lines)
+                        .map(|l| l.ends_with('\r'))
+                        .collect(),
                     !t.is_empty() && !t.ends_with('\n'),
                 ),
                 None => (Vec::new(), false),
@@ -985,11 +988,19 @@ impl DiffData {
         // rejects every hunk that reaches the end of such a file.
         const NO_NL: &str = "\\ No newline at end of file";
         let left_line = |sig: char, i: usize| {
-            let cr = if self.left_crlf.get(i).copied().unwrap_or(false) { "\r" } else { "" };
+            let cr = if self.left_crlf.get(i).copied().unwrap_or(false) {
+                "\r"
+            } else {
+                ""
+            };
             format!("{sig}{}{cr}", self.left_lines[i])
         };
         let right_line = |sig: char, i: usize| {
-            let cr = if self.right_crlf.get(i).copied().unwrap_or(false) { "\r" } else { "" };
+            let cr = if self.right_crlf.get(i).copied().unwrap_or(false) {
+                "\r"
+            } else {
+                ""
+            };
             format!("{sig}{}{cr}", self.right_lines[i])
         };
         let left_last = |i: usize| i + 1 == self.left_lines.len() && self.left_no_final_nl;

--- a/src/widgets/editor_find.rs
+++ b/src/widgets/editor_find.rs
@@ -446,11 +446,18 @@ mod tests {
             use_regex: true,
             ..SearchOpts::default()
         };
-        let (out, n) =
-            replace_all_in_lines(&lines(&["banana"]), "a*", "-", re_opts).unwrap();
-        assert_eq!((out, n), (lines(&["b-n-n-"]), 3), "zero-width matches are not replaced");
+        let (out, n) = replace_all_in_lines(&lines(&["banana"]), "a*", "-", re_opts).unwrap();
+        assert_eq!(
+            (out, n),
+            (lines(&["b-n-n-"]), 3),
+            "zero-width matches are not replaced"
+        );
         let (out, n) = replace_all_in_lines(&lines(&["banana"]), "^", "// ", re_opts).unwrap();
-        assert_eq!((out, n), (lines(&["banana"]), 0), "an all-zero-width pattern replaces nothing");
+        assert_eq!(
+            (out, n),
+            (lines(&["banana"]), 0),
+            "an all-zero-width pattern replaces nothing"
+        );
         let lit = SearchOpts::default();
         // U+212A KELVIN SIGN: lowercasing shrinks the line's byte length,
         // so the literal scanner bails and paints nothing on this line.
@@ -471,17 +478,23 @@ mod tests {
             use_regex: true,
             ..SearchOpts::default()
         };
-        let (out, n) =
-            replace_all_in_lines(&lines(&["abc"]), "b", r"x\ny", re_opts).unwrap();
+        let (out, n) = replace_all_in_lines(&lines(&["abc"]), "b", r"x\ny", re_opts).unwrap();
         assert_eq!((out, n), (lines(&["ax", "yc"]), 1));
         let (out, _) = replace_all_in_lines(&lines(&["abc"]), "b", r"x\ty", re_opts).unwrap();
         assert_eq!(out, lines(&["ax\tyc"]));
-        let (out, _) =
-            replace_all_in_lines(&lines(&["abc"]), "b", r"x\\ny", re_opts).unwrap();
-        assert_eq!(out, lines(&[r"ax\nyc"]), "an escaped backslash stays literal");
+        let (out, _) = replace_all_in_lines(&lines(&["abc"]), "b", r"x\\ny", re_opts).unwrap();
+        assert_eq!(
+            out,
+            lines(&[r"ax\nyc"]),
+            "an escaped backslash stays literal"
+        );
         let (out, _) =
             replace_all_in_lines(&lines(&["abc"]), "b", r"x\ny", SearchOpts::default()).unwrap();
-        assert_eq!(out, lines(&[r"ax\nyc"]), "literal mode inserts the text verbatim");
+        assert_eq!(
+            out,
+            lines(&[r"ax\nyc"]),
+            "literal mode inserts the text verbatim"
+        );
     }
 
     #[test]
@@ -494,14 +507,21 @@ mod tests {
             ..SearchOpts::default()
         };
         let (out, n) = replace_all_in_lines(&lines(&["abc"]), "b", r"x\r\ny", re_opts).unwrap();
-        assert_eq!((out, n), (lines(&["ax", "yc"]), 1), "CRLF splits once, no stray CR");
+        assert_eq!(
+            (out, n),
+            (lines(&["ax", "yc"]), 1),
+            "CRLF splits once, no stray CR"
+        );
         let (out, _) = replace_all_in_lines(&lines(&["abc"]), "b", r"x\ry", re_opts).unwrap();
         assert_eq!(out, lines(&["ax", "yc"]), "a lone CR is a line break too");
         for line in replace_all_in_lines(&lines(&["abc"]), "b", r"x\r\ny", re_opts)
             .unwrap()
             .0
         {
-            assert!(!line.contains('\r'), "no CR may survive in a line: {line:?}");
+            assert!(
+                !line.contains('\r'),
+                "no CR may survive in a line: {line:?}"
+            );
         }
     }
 


### PR DESCRIPTION
Fixes #32.

Two commits, deliberately separate so the sweep reviews as pure formatting:

1. **`style: apply the pinned rustfmt across the tree`** — `cargo fmt` and nothing else. 18 diffs across 5 files remained at HEAD (down from the issue's 28: three files had been swept incidentally by intervening commits); these five (`git.rs`, `testing/locate.rs`, `testing/worker.rs`, `widgets/diff.rs`, `widgets/editor_find.rs`) are exactly the ones every branch has had to `git checkout --` after daring to run `cargo fmt`.
2. **The gate** — `.git-blame-ignore-revs` carrying the sweep commit's hash (GitHub honours the file automatically; locally `git config blame.ignoreRevsFile .git-blame-ignore-revs` opts in), and `cargo fmt --check` added to the `clippy + tests` CI job ahead of clippy, so the baseline can never drift again.

Verified: `cargo fmt --check` exits clean at the branch head; clippy zero warnings; full all-targets suite green (3042 + 6, 0 failed). Formatting is behavior-neutral by construction and the suite agrees.
