### PR TITLE
feat(nav): give Go Back a keyboard chord, palette entry, and menu item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.694"
+version = "0.1.695"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.694"
+version = "0.1.695"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -248,6 +248,7 @@ All three live under `~/.config/croft/` (XDG-resolved, so the same paths on macO
 | `Cmd`+`.` / `Ctrl`+`.` inside a merge conflict | Resolve Merge Conflict picker: Accept Current / Accept Incoming / Accept Both (also Command Palette "Merge Conflict: Accept Current / Incoming / Both"); conflict regions render with VS Code's green (current) / blue (incoming) tints |
 | `F2` | Rename Symbol across every file it touches (open tabs edit in-memory and stay dirty) |
 | `F12` / `Ctrl`+click | Go to Definition (`Shift`+`Ctrl`+click navigates back); `Ctrl` because mouse reports carry no `Cmd` bit and `Option` belongs to multi-cursor |
+| `Ctrl`+`-` | Go Back: return to the location before the last navigation jump (the keyboard twin of `Shift`+`Ctrl`+click; also on the editor right-click menu and as Command Palette "Go Back") |
 | `Shift`+`F12` | Go to References (project-wide; one use jumps, several open a picker) |
 | `Ctrl`+`Shift`+`F12` | Go to Declaration (where the server implements it; hidden for TypeScript) |
 | `Ctrl`+`F12` | Go to Type Definition |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1002,6 +1002,8 @@ enum MenuAction {
         row: usize,
         col: usize,
     },
+    /// Return to the location before the last navigation jump (#31).
+    NavigateBack,
     /// Editor body: LSP "Quick Fix" of the position at buffer `(row, col)`.
     QuickFixAt {
         row: usize,
@@ -1171,6 +1173,7 @@ fn shortcut_for(action: &MenuAction) -> Option<&'static str> {
         MenuAction::ChangeAllOccurrencesAt { .. } => Some("⌘F2"),
         MenuAction::GoToDefinitionAt { .. } => Some("F12"),
         MenuAction::GoToReferencesAt { .. } => Some("⇧F12"),
+        MenuAction::NavigateBack => Some("⌃-"),
         MenuAction::QuickFixAt { .. } => Some("⌘."),
         MenuAction::GoToDeclarationAt { .. } => Some("⌃⇧F12"),
         MenuAction::GoToTypeDefinitionAt { .. } => Some("⌃F12"),
@@ -19222,6 +19225,13 @@ impl App {
             }
             return;
         }
+        // VS Code "Go Back" (Ctrl+-): the keyboard twin of the
+        // Ctrl+Shift+click chord, so navigation history is reachable
+        // without depending on the host terminal's mouse delivery (#31).
+        if is_navigate_back_key(key) {
+            self.nav_back();
+            return;
+        }
         // VS Code "Transpose Characters around the Cursor" (Ctrl+T).
         if is_transpose_key(key) {
             if self.editor_is_text() {
@@ -23306,6 +23316,7 @@ impl App {
             Cmd::QuickOpen => self.open_file_finder(),
             Cmd::GoToSymbol => self.open_go_to_symbol(),
             Cmd::GoToWorkspaceSymbol => self.open_workspace_symbols(""),
+            Cmd::NavigateBack => self.nav_back(),
             Cmd::ToggleVimMode => self.toggle_vim_mode(),
             Cmd::ShowExplorer => self.set_sidebar_view(SidebarView::Explorer),
             Cmd::ShowSearch => self.set_sidebar_view(SidebarView::Search),
@@ -25933,6 +25944,7 @@ impl App {
                             },
                         ));
                     }
+                    items.push((String::from("Go Back"), MenuAction::NavigateBack));
                     items.push((
                         String::from("Rename Symbol"),
                         MenuAction::RenameSymbolAt { row, col },
@@ -28556,6 +28568,7 @@ impl App {
                 self.focus_pane(Pane::Editor);
                 self.start_change_all_occurrences();
             }
+            MenuAction::NavigateBack => self.nav_back(),
             MenuAction::GoToDefinitionAt { row, col } => {
                 self.editor.cursor_row = row;
                 self.editor.cursor_col = col;
@@ -31451,6 +31464,19 @@ fn is_select_to_bracket_key(key: KeyEvent) -> bool {
 /// `editor.action.transpose`). A raw control byte, so it needs no iTerm2 /
 /// Ghostty forwarder; the editor intercepts it only when focused, leaving the
 /// shell's own `Ctrl+T` intact when the terminal is focused.
+/// VS Code "Go Back" (Ctrl+-). The kitty keyboard protocol delivers the
+/// chord as `-` + CONTROL; the legacy encoding folds Ctrl+- into 0x1F,
+/// which decodes as `_` + CONTROL, so both spellings are accepted.
+fn is_navigate_back_key(key: KeyEvent) -> bool {
+    let KeyCode::Char(c) = key.code else {
+        return false;
+    };
+    (c == '-' || c == '_')
+        && key.modifiers.contains(KeyModifiers::CONTROL)
+        && !key.modifiers.contains(KeyModifiers::SUPER)
+        && !key.modifiers.contains(KeyModifiers::ALT)
+}
+
 fn is_transpose_key(key: KeyEvent) -> bool {
     let KeyCode::Char(c) = key.code else {
         return false;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1695,6 +1695,52 @@ fn go_back_returns_to_the_location_before_a_definition_jump() {
     );
 }
 
+/// #31: navigate-back rested entirely on the Ctrl+Shift+click mouse chord.
+/// The VS Code keyboard chord (Ctrl+-) and the palette command are the
+/// fallbacks that work when the host terminal never delivers that chord.
+#[test]
+fn ctrl_minus_and_the_palette_both_navigate_back() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a.rs");
+    let b = tmp.path().join("b.rs");
+    std::fs::write(&a, "fn main() {}\nlet x = helper();\n").unwrap();
+    std::fs::write(&b, "fn helper() {}\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open_pinned(&a).unwrap();
+    app.editor.cursor_row = 1;
+    app.focus_pane(Pane::Editor);
+
+    // The keyboard chord.
+    app.go_to_definition(b.clone(), 0, 3);
+    assert_eq!(app.editor.path.as_deref(), Some(b.as_path()));
+    app.handle_key(key(KeyCode::Char('-'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(a.as_path()),
+        "Ctrl+- goes back"
+    );
+
+    // The legacy encoding: Ctrl+- folds to 0x1F, decoded as Ctrl+_.
+    app.go_to_definition(b.clone(), 0, 3);
+    app.handle_key(key(KeyCode::Char('_'), KeyModifiers::CONTROL))
+        .unwrap();
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(a.as_path()),
+        "the legacy Ctrl+- spelling goes back too"
+    );
+
+    // The palette command.
+    app.go_to_definition(b.clone(), 0, 3);
+    app.run_command(crate::widgets::command_palette::Command::NavigateBack);
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(a.as_path()),
+        "the Go Back palette command goes back"
+    );
+}
+
 #[test]
 fn go_back_with_empty_history_stays_put() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Fix,
-    summary: "The completion popup stays inside its editor pane: when the pane was narrower than the popup (a long Rust or TypeScript symbol in a split), it was pushed left past the pane's edge and painted over the Explorer; a squeezed short pane could likewise leak it over the tab strip.",
+    kind: NoteKind::Feature,
+    summary: "Go Back is now a first-class command: Ctrl+- (the VS Code chord) returns to the location before the last navigation jump, alongside a Command Palette entry and an editor right-click item — it used to be reachable only through the Shift+Ctrl+click mouse chord.",
 }];

--- a/src/widgets/command_palette.rs
+++ b/src/widgets/command_palette.rs
@@ -71,6 +71,9 @@ pub enum Command {
     QuickOpen,
     GoToSymbol,
     GoToWorkspaceSymbol,
+    /// VS Code "Go Back" (Ctrl+-): return to the location before the last
+    /// navigation jump (Go to Definition, a reference pick, a symbol jump).
+    NavigateBack,
     ToggleVimMode,
     // --- View / navigation ---
     ShowExplorer,
@@ -191,6 +194,7 @@ pub const ALL_COMMANDS: &[Command] = &[
     Command::QuickOpen,
     Command::GoToSymbol,
     Command::GoToWorkspaceSymbol,
+    Command::NavigateBack,
     Command::ToggleVimMode,
     Command::ShowExplorer,
     Command::ShowSearch,
@@ -295,6 +299,7 @@ impl Command {
             Command::QuickOpen => "Go to File",
             Command::GoToSymbol => "Go to Symbol in Editor",
             Command::GoToWorkspaceSymbol => "Go to Symbol in Workspace",
+            Command::NavigateBack => "Go Back",
             Command::ToggleVimMode => "Toggle Vim Mode",
             Command::ShowExplorer => "View: Show Explorer",
             Command::ShowSearch => "View: Show Search",
@@ -400,6 +405,7 @@ impl Command {
             Command::QuickOpen => "Cmd+P",
             Command::GoToSymbol => "Cmd+Shift+O",
             Command::GoToWorkspaceSymbol => "Cmd+P #",
+            Command::NavigateBack => "Ctrl+-",
             Command::ToggleVimMode => "Cmd+E",
             Command::ShowExplorer => "Cmd+Shift+E",
             Command::ShowSearch => "Cmd+Shift+F",
@@ -511,6 +517,7 @@ impl Command {
             Command::QuickOpen => "quick_open",
             Command::GoToSymbol => "go_to_symbol",
             Command::GoToWorkspaceSymbol => "go_to_workspace_symbol",
+            Command::NavigateBack => "navigate_back",
             Command::ToggleVimMode => "toggle_vim_mode",
             Command::ShowExplorer => "show_explorer",
             Command::ShowSearch => "show_search",

--- a/src/widgets/shortcuts.rs
+++ b/src/widgets/shortcuts.rs
@@ -407,6 +407,11 @@ pub const SHORTCUT_GROUPS: &[ShortcutGroup] = &[
                 handler: "is_vim_toggle_key",
             },
             ShortcutEntry {
+                keys: "Ctrl+-",
+                description: "Go Back: return to the location before the last navigation jump",
+                handler: "is_navigate_back_key",
+            },
+            ShortcutEntry {
                 keys: "Ctrl+T",
                 description: "Transpose the characters around the cursor",
                 handler: "is_transpose_key",


### PR DESCRIPTION
Fixes #31.

`nav_back` had exactly one entry point: the `Shift`+`Ctrl`+click mouse chord. No keyboard binding, no palette entry, no menu item — navigation history rested entirely on one mouse gesture whose delivery by the host terminal is unverified on Ghostty.

## What ships (v0.1.695)

Go Back everywhere the sibling navigation commands live:

- **Keyboard** — `Ctrl+-`, the VS Code macOS chord. The predicate accepts both spellings: the kitty keyboard protocol delivers `-` + CONTROL, and the legacy encoding folds Ctrl+- into 0x1F, which decodes as `_` + CONTROL. (Ctrl chords always reach croft — no iTerm2 GlobalKeyMap registration needed, unlike Cmd chords.)
- **Command Palette** — "Go Back" (`navigate_back`), which also makes it rebindable through keybindings.json.
- **Editor right-click menu** — "Go Back" with its `⌃-` shortcut glyph, after the Go To group.
- **F1 shortcuts overlay** — the panel's guard test (`every_app_keybinding_predicate_is_documented_in_f1`) caught the missing entry on the first full-suite run; the chord is documented there and in KEYBINDINGS.md.

## Test

`ctrl_minus_and_the_palette_both_navigate_back` drives all three keyboard-reachable paths end-to-end: a real definition jump followed by the kitty-spelling chord, the legacy-spelling chord, and the palette command, each asserting the file and caret return.

Full suite green (3047 + 6, 0 failed); clippy zero warnings; fmt clean. Release notes replaced for 0.1.695.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Go Back” command to return to the location before the most recent navigation jump.
  * Added the `Ctrl+-` shortcut, with support for legacy terminal encoding.
  * Made “Go Back” available from the Command Palette and editor context menu.

* **Documentation**
  * Updated keyboard shortcut documentation and release notes.

* **Chores**
  * Incremented the package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->