### PR TITLE
fix(tests): let the collab no-echo check settle trailing caret frames

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -21359,7 +21359,26 @@ fn collab_solo_apps_bootstrap_edit_and_gate_saves() {
         &|o, g| o.editor.lines == g.editor.lines && o.editor.lines[0].contains("OWNER"),
     );
 
-    // No echo: with both sides converged and idle, the wire stays quiet.
+    // Settle: buffer convergence does not imply the WIRE is drained (#56).
+    // Typing sends caret frames besides the edits, every drained event —
+    // a caret included — reports redraw-worthy from poll_collab, and the
+    // relay thread can deliver a trailing caret after the convergence
+    // predicate already passed. Drain those, bounded so a genuine echo
+    // storm still reaches the silence check below and fails there.
+    let settle = Instant::now() + Duration::from_secs(5);
+    loop {
+        let owner_drained = owner.poll_collab();
+        let guest_drained = guest.poll_collab();
+        if !owner_drained && !guest_drained {
+            break;
+        }
+        assert!(
+            Instant::now() < settle,
+            "the wire never went quiet: an echo storm, not a trailing caret"
+        );
+        std::thread::sleep(Duration::from_millis(2));
+    }
+    // No echo: with the wire drained and both sides idle, it stays quiet.
     let settled = owner.editor.lines.clone();
     for _ in 0..20 {
         assert!(!owner.poll_collab(), "owner must be quiescent");


### PR DESCRIPTION
Fixes #56.

The issue parked a hypothesis — "a late frame arriving at the guest after the convergence predicate already passed … to verify against a captured wire trace". Verified against the event loop instead, and it holds with a named frame kind: `poll_collab` sets `changed = true` for **every** drained event (src/app/mod.rs, the `for event in events` loop), including `CollabEvent::Caret` — which never touches `editor.lines`. Typing sends caret frames alongside the edits, so the test's convergence predicate (buffers equal) can pass while a caret frame is still in flight through the relay thread; under CI load it lands one poll later, `poll_collab` returns `true`, and "guest must be quiescent" fires. Buffer convergence never implied a drained wire.

## Fix (test-only)

A bounded settle between convergence and the no-echo check: drain until both sides report quiet, capped at 5s — a genuine echo storm (the regression the check guards: re-broadcast loops) never goes quiet and fails the settle with its own message, and an echo that mutates buffers is still caught by the `settled` comparison after the 20-iteration silence loop. The silence check itself is unchanged.

Verified: 3/3 green solo; full all-targets suite green (3048 + 6, 0 failed); clippy zero warnings; fmt clean.

#30 (`a_live_relay_is_not_stolen_from`) remains open — same family, but its mechanism is still unidentified and nothing here assumes it shares this one.
