### PR TITLE
fix: end the $HOME test races and report failed external reloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.696"
+version = "0.1.697"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.696"
+version = "0.1.697"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4960,8 +4960,10 @@ impl App {
     /// change reported to a sweep that could not reach the tab is burned: no
     /// later tick reports it again and that pane keeps stale text forever.
     /// Clean tabs reload silently; dirty tabs are flagged as conflicts (the
-    /// buffer and the disk are both preserved). Returns true if any tab
-    /// reloaded or entered conflict, so the caller redraws.
+    /// buffer and the disk are both preserved); tabs whose reload FAILED
+    /// keep their last good view and say so in the status line (#37).
+    /// Returns true if any tab reloaded, failed, or entered conflict, so
+    /// the caller redraws.
     fn reload_open_file_after_external_change(&mut self) -> bool {
         let guest = self.is_collab_guest();
         let root = self.tree.root.clone();
@@ -4971,21 +4973,42 @@ impl App {
             let extra = group.reload_externally_changed_tabs(&skip);
             report.reloaded.extend(extra.reloaded);
             report.conflicts.extend(extra.conflicts);
+            report.failed.extend(extra.failed);
         }
         if report.is_empty() {
             return false;
         }
         self.refresh_git_status_debounced();
-        match (report.reloaded.len(), report.conflicts.len()) {
-            (1, 0) => {
+        match (
+            report.reloaded.len(),
+            report.conflicts.len(),
+            report.failed.len(),
+        ) {
+            // A dirty-buffer collision outranks everything: it needs a
+            // decision, so it gets the modal.
+            (_, c, _) if c > 0 => {
+                self.prompt_disk_conflict(report.conflicts.clone());
+            }
+            // A failed reload used to be silently discarded (#37): the tab
+            // keeps its last good view, and the status must say so instead
+            // of letting the user read stale content as current.
+            (0, 0, 1) => {
+                let p = report.failed[0].display();
+                self.status = format!("Reload failed for {p}; keeping the last good view");
+            }
+            (r, 0, f) if f > 0 => {
+                self.status = if r == 0 {
+                    format!("Reload failed for {f} files changed on disk")
+                } else {
+                    format!("Reloaded {r} files, reload failed for {f} (kept their last good view)")
+                };
+            }
+            (1, 0, 0) => {
                 let p = report.reloaded[0].display();
                 self.status = format!("Reloaded {p} (external change)");
             }
-            (n, 0) => {
+            (n, ..) => {
                 self.status = format!("Reloaded {n} files changed on disk");
-            }
-            (_, _) => {
-                self.prompt_disk_conflict(report.conflicts.clone());
             }
         }
         // Keep the watcher's active-file baseline aligned with the reload so
@@ -32765,7 +32788,20 @@ fn remote_persistence_status(is_remote: bool, persistent: bool) -> Option<&'stat
     }
 }
 
+/// Test-only redirect for [`croft_cache_dir`], so the relay tests steer the
+/// relay rendezvous without repointing the process-global `$HOME` (#37):
+/// every concurrent test thread resolves `$HOME` at call time (the PDF
+/// rasteriser's scratch dir, the session paths), and a substituted value
+/// leaking across threads made unrelated tests fail inside the fake home.
+#[cfg(test)]
+pub static CACHE_DIR_OVERRIDE_FOR_TEST: std::sync::Mutex<Option<PathBuf>> =
+    std::sync::Mutex::new(None);
+
 fn croft_cache_dir() -> PathBuf {
+    #[cfg(test)]
+    if let Some(dir) = CACHE_DIR_OVERRIDE_FOR_TEST.lock().unwrap().clone() {
+        return dir;
+    }
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12713,28 +12713,39 @@ fn relay_test_lock() -> &'static std::sync::Mutex<()> {
 const TEST_RELAY_KEY: &str = "0123456789abcdef";
 
 fn with_relay_home<T>(home: &std::path::Path, body: impl FnOnce() -> T) -> T {
-    let prev_key = std::env::var_os("CROFT_RELAY_KEY");
     // The cache dir is redirected through its test override instead of
     // repointing the process-global `$HOME` (#37): unrelated test threads
     // resolve `$HOME` at call time and a substituted value made them fail
     // inside the fake home. CROFT_RELAY_KEY stays an env var — it is
     // croft-specific and `relay_dir` is its only reader, so no unrelated
-    // reader can race on it.
+    // reader can race on it. The restore is RAII so a panicking `body`
+    // cannot leak the redirected globals into later relay tests.
+    struct RestoreRelayGlobals {
+        prev_key: Option<std::ffi::OsString>,
+    }
+    impl Drop for RestoreRelayGlobals {
+        fn drop(&mut self) {
+            *crate::app::CACHE_DIR_OVERRIDE_FOR_TEST.lock().unwrap() = None;
+            // SAFETY: relay tests hold relay_test_lock, serializing this
+            // mutation.
+            unsafe {
+                match self.prev_key.take() {
+                    Some(k) => std::env::set_var("CROFT_RELAY_KEY", k),
+                    None => std::env::remove_var("CROFT_RELAY_KEY"),
+                }
+            }
+        }
+    }
+    let _restore = RestoreRelayGlobals {
+        prev_key: std::env::var_os("CROFT_RELAY_KEY"),
+    };
     *crate::app::CACHE_DIR_OVERRIDE_FOR_TEST.lock().unwrap() =
         Some(home.join(".cache").join("croft"));
     // SAFETY: relay tests hold relay_test_lock, serializing this mutation.
     unsafe {
         std::env::set_var("CROFT_RELAY_KEY", TEST_RELAY_KEY);
     }
-    let out = body();
-    *crate::app::CACHE_DIR_OVERRIDE_FOR_TEST.lock().unwrap() = None;
-    unsafe {
-        match prev_key {
-            Some(k) => std::env::set_var("CROFT_RELAY_KEY", k),
-            None => std::env::remove_var("CROFT_RELAY_KEY"),
-        }
-    }
-    out
+    body()
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12695,10 +12695,13 @@ fn finder_drop_on_remote_view_with_no_target_reports_clear_status() {
 }
 
 fn relay_test_lock() -> &'static std::sync::Mutex<()> {
-    // The relay tests mutate $HOME, so share the crate-wide HOME_LOCK rather
-    // than a private mutex — otherwise they could race the file_finder / zoxide
-    // $HOME tests running on another thread of the same binary.
-    &crate::HOME_LOCK
+    // The relay tests share the cache-dir test override, the
+    // CROFT_RELAY_KEY env var, and real relay directories, so they still
+    // serialize against each other — but no test mutates `$HOME` any more
+    // (#37), so the old crate-wide HOME_LOCK is gone and this lock is
+    // private to the relay family.
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    &LOCK
 }
 
 /// Point `$HOME` (hence `croft_cache_dir`) at a temp dir and set a fixed
@@ -12710,19 +12713,22 @@ fn relay_test_lock() -> &'static std::sync::Mutex<()> {
 const TEST_RELAY_KEY: &str = "0123456789abcdef";
 
 fn with_relay_home<T>(home: &std::path::Path, body: impl FnOnce() -> T) -> T {
-    let prev_home = std::env::var_os("HOME");
     let prev_key = std::env::var_os("CROFT_RELAY_KEY");
-    // SAFETY: relay tests hold relay_test_lock, serializing env mutation.
+    // The cache dir is redirected through its test override instead of
+    // repointing the process-global `$HOME` (#37): unrelated test threads
+    // resolve `$HOME` at call time and a substituted value made them fail
+    // inside the fake home. CROFT_RELAY_KEY stays an env var — it is
+    // croft-specific and `relay_dir` is its only reader, so no unrelated
+    // reader can race on it.
+    *crate::app::CACHE_DIR_OVERRIDE_FOR_TEST.lock().unwrap() =
+        Some(home.join(".cache").join("croft"));
+    // SAFETY: relay tests hold relay_test_lock, serializing this mutation.
     unsafe {
-        std::env::set_var("HOME", home);
         std::env::set_var("CROFT_RELAY_KEY", TEST_RELAY_KEY);
     }
     let out = body();
+    *crate::app::CACHE_DIR_OVERRIDE_FOR_TEST.lock().unwrap() = None;
     unsafe {
-        match prev_home {
-            Some(h) => std::env::set_var("HOME", h),
-            None => std::env::remove_var("HOME"),
-        }
         match prev_key {
             Some(k) => std::env::set_var("CROFT_RELAY_KEY", k),
             None => std::env::remove_var("CROFT_RELAY_KEY"),
@@ -25194,5 +25200,32 @@ fn copy_mode_closes_instead_of_hijacking_another_pane() {
     assert!(
         app.terminals[1].selection().is_none(),
         "the sibling pane must not inherit a painted selection"
+    );
+}
+
+/// #37: a failed external reload was silently discarded — the sweep tried,
+/// the re-read died (file replaced by a directory), and nothing said so.
+/// The tab keeps its last good view and the status line reports it.
+#[test]
+fn a_failed_external_reload_reports_in_the_status_line() {
+    let tmp = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("f.txt");
+    std::fs::write(&f, "one\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open_pinned(&f).unwrap();
+    std::fs::remove_file(&f).unwrap();
+    std::fs::create_dir(&f).unwrap();
+    assert!(
+        app.reload_open_file_after_external_change(),
+        "a failed reload is redraw-worthy, not an empty sweep"
+    );
+    assert!(
+        app.status.contains("Reload failed"),
+        "the status line must name the failure; got: {}",
+        app.status
+    );
+    assert_eq!(
+        app.editor.lines[0], "one",
+        "the last good buffer survives the failed reload"
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,14 +57,6 @@ use anyhow::Result;
 use clap::Parser;
 use cli::Cli;
 
-/// Process-wide lock serializing tests that mutate shared environment state
-/// (notably `$HOME`). Cargo runs a binary's tests on multiple threads in one
-/// process, so any test that calls `set_var`/`remove_var` on `HOME` races every
-/// other test reading it (`file_finder`, `zoxide`, the relay tests). Each such
-/// test must hold this lock for its whole body.
-#[cfg(test)]
-pub(crate) static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 fn main() -> Result<()> {
     let cli = Cli::parse();
     cli.run()

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "Language servers for the workspace's evident languages now start the moment croft opens (a Cargo.toml at the root starts rust-analyzer, and so on) instead of at the first file open, so the server's cold indexing overlaps with you browsing the tree — the long gap before hover, definitions and diagnostics answered on the first .rs file is gone.",
+    summary: "A file that changes on disk but cannot be re-read (replaced by a directory, permissions yanked, a PDF whose re-render dies) no longer fails silently: the tab keeps its last good view and the status line says the reload failed, instead of letting stale content read as current.",
 }];

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -1218,11 +1218,17 @@ pub struct ExternalReloadReport {
     pub reloaded: Vec<PathBuf>,
     /// Paths of dirty tabs flagged as conflicts (not reloaded, not saved).
     pub conflicts: Vec<PathBuf>,
+    /// Paths whose disk copy changed but whose reload FAILED (the file
+    /// became unreadable, was replaced by a directory, a PDF's re-render
+    /// died). The tab keeps its last good view; dropping these on the
+    /// floor left the user staring at stale content with no indication
+    /// the sweep even tried (#37).
+    pub failed: Vec<PathBuf>,
 }
 
 impl ExternalReloadReport {
     pub fn is_empty(&self) -> bool {
-        self.reloaded.is_empty() && self.conflicts.is_empty()
+        self.reloaded.is_empty() && self.conflicts.is_empty() && self.failed.is_empty()
     }
 }
 
@@ -8821,7 +8827,12 @@ impl EditorTabs {
                         report.conflicts.push(p);
                     }
                 }
-                ExternalChange::Unchanged | ExternalChange::ReloadFailed => {}
+                ExternalChange::ReloadFailed => {
+                    if let Some(p) = path {
+                        report.failed.push(p);
+                    }
+                }
+                ExternalChange::Unchanged => {}
             }
         }
         report
@@ -13812,6 +13823,32 @@ mod tests {
             "the next save must prompt again for the changed buffer"
         );
         assert_eq!(std::fs::read_to_string(tmp.path()).unwrap(), "cafe\n");
+    }
+
+    #[test]
+    fn a_failed_external_reload_is_reported_not_swallowed() {
+        // #37: `ReloadFailed` was dropped on the floor — the user's file is
+        // replaced on disk by something unreadable (here: a directory), the
+        // sweep tries and fails to reload, and nothing said so.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, "one\n").unwrap();
+        let mut tabs = EditorTabs::new();
+        tabs.open_pinned(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        let report = tabs.reload_externally_changed_tabs(&|_| false);
+        assert_eq!(
+            report.failed,
+            vec![path.clone()],
+            "the failure must surface in the report"
+        );
+        assert!(!report.is_empty(), "a failed reload is not an empty sweep");
+        assert_eq!(
+            tabs.iter_tabs().next().unwrap().lines[0],
+            "one",
+            "the last good buffer survives the failed reload"
+        );
     }
 
     #[test]

--- a/src/widgets/file_finder.rs
+++ b/src/widgets/file_finder.rs
@@ -469,10 +469,19 @@ pub fn is_path_under_noise_dir(path: &Path) -> bool {
 ///      `~/.croft/lsp.log` but `~/Library/Logs/*` is a reasonable
 ///      Cmd+P target too).
 fn macos_blocked_paths() -> Vec<PathBuf> {
-    let Some(home) = std::env::var_os("HOME") else {
-        return Vec::new();
-    };
-    let home = PathBuf::from(home);
+    match std::env::var_os("HOME") {
+        Some(home) => macos_blocked_paths_for(&PathBuf::from(home)),
+        None => Vec::new(),
+    }
+}
+
+/// The pure half of [`macos_blocked_paths`], taking the home directory as
+/// an argument so tests never repoint the process-global `$HOME` (#37):
+/// the env var is resolved at call time by every concurrent reader (the
+/// PDF rasteriser's cache dir, the session paths), and a substituted value
+/// leaking across test threads made unrelated tests fail on paths inside
+/// the fake home.
+fn macos_blocked_paths_for(home: &Path) -> Vec<PathBuf> {
     let lib = home.join("Library");
     [
         "Containers",
@@ -504,9 +513,14 @@ fn macos_blocked_paths() -> Vec<PathBuf> {
 }
 
 pub fn build_file_index(root: &Path) -> Vec<FileEntry> {
+    build_file_index_with_blocked(root, macos_blocked_paths())
+}
+
+/// [`build_file_index`] with the blocked-path set injected, so tests drive
+/// the macOS exclusion rules against a fake home without mutating `$HOME`.
+fn build_file_index_with_blocked(root: &Path, blocked: Vec<PathBuf>) -> Vec<FileEntry> {
     let collected: Arc<Mutex<Vec<FileEntry>>> = Arc::new(Mutex::new(Vec::new()));
     let root_buf = root.to_path_buf();
-    let blocked = macos_blocked_paths();
     let walker = WalkBuilder::new(root)
         .git_ignore(true)
         .require_git(false)
@@ -1012,18 +1026,11 @@ mod tests {
         let logs = fake_home.join("Library").join("Logs");
         std::fs::create_dir_all(&logs).unwrap();
         std::fs::write(logs.join("app.log"), b"").unwrap();
-        // Serialize with every other $HOME-mutating test in this binary.
-        let _guard = crate::HOME_LOCK.lock().unwrap();
-        let saved = std::env::var_os("HOME");
-        // SAFETY: guarded by HOME_LOCK; the value is restored below.
-        unsafe {
-            std::env::set_var("HOME", fake_home);
-        }
-        let entries = build_file_index(fake_home);
-        match saved {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
+        // The blocked set is injected instead of repointing `$HOME` (#37):
+        // concurrent tests resolve the env var at call time, and a
+        // substituted value made unrelated readers (the PDF rasteriser's
+        // cache dir) fail on paths inside the fake home.
+        let entries = build_file_index_with_blocked(fake_home, macos_blocked_paths_for(fake_home));
         let names: Vec<&str> = entries.iter().map(|e| e.rel.as_str()).collect();
         assert!(
             names.contains(&"Library/Logs/app.log"),


### PR DESCRIPTION
Fixes #37. Both defects.

## 1. No test mutates `$HOME` any more

The race: `HOME_LOCK` serialised the mutators against each other but not against *readers*, and `$HOME` is resolved at call time by unrelated code on sibling test threads (the PDF rasteriser's scratch dir, session paths) — a substituted value made those fail inside the fake home.

- **file_finder** — the test set `$HOME` because `build_file_index` → `macos_blocked_paths()` read it internally. The blocked-path set is now injectable (`macos_blocked_paths_for(home)` pure + `build_file_index_with_blocked`), the issue's prescribed shape (the `collapse_home` treatment): the env-reading wrapper stays thin and untested, the logic takes the value as an argument.
- **relay tests** — `with_relay_home` pointed `$HOME` at a tempdir to steer `croft_cache_dir()`. That function now has a `cfg(test)` override (`CACHE_DIR_OVERRIDE_FOR_TEST`), so the tests redirect exactly the one path they steer. `CROFT_RELAY_KEY` stays an env var: it is croft-specific and `relay_dir` is its only reader, so no unrelated reader can race on it. All 26 relay tests green with zero `$HOME` mutation.
- **`HOME_LOCK` is deleted.** With zero mutators left there is nothing to serialise; the relay family keeps a private lock for its genuinely shared state (the override, the key, real relay dirs).

## 2. A failed external reload is reported, not swallowed (v0.1.697)

`reload_externally_changed_tabs` dropped `ExternalChange::ReloadFailed` on the floor: file changed on disk, re-read failed (replaced by a directory, permissions yanked, a PDF re-render dying), and nothing was said — stale content read as current. The report now carries a `failed` bucket, counted by `is_empty`, merged across split groups, and surfaced in the status line ("Reload failed for {p}; keeping the last good view", with plural and mixed-with-reloaded forms). Conflicts keep the modal and outrank everything. This composes with #72, whose failed-reload path already preserves a PDF reader's page.

Tests (red→green): widget-level `a_failed_external_reload_is_reported_not_swallowed` (file → directory, report names it, buffer survives) and app-level `a_failed_external_reload_reports_in_the_status_line` (the sweep returns redraw-worthy and the status names the failure).

Full suite green (3050 + 6, 0 failed); clippy zero warnings; fmt clean. Release notes replaced for 0.1.697.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External file reload failures are now reported clearly in the status message.
  * When a changed file cannot be reloaded, the tab preserves its last valid view instead of displaying stale or invalid content.
  * Reload conflicts continue to take priority and open the conflict prompt.

* **Documentation**
  * Updated release notes to describe the improved failed-reload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->