### PR TITLE
fix(collab): assert relay steal-prevention directly, harden liveness probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft"
-version = "0.1.698"
+version = "0.1.699"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft"
-version = "0.1.698"
+version = "0.1.699"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/collab.rs
+++ b/src/collab.rs
@@ -1851,18 +1851,49 @@ mod tests {
     /// `ensure_relay` and `relay_serve` are attach-or-create: a live relay on
     /// the socket short-circuits both instead of being stolen from (a second
     /// bind would strand the first relay's clients mid-session).
+    ///
+    /// The invariant is asserted DIRECTLY — a fresh connect after both calls
+    /// must still land on THIS listener's accept queue (#30). The old proxy
+    /// assert (`!is_alive` after dropping the listener) claimed a global
+    /// property instead: that no process anywhere holds a listening fd for
+    /// the path. On macOS `bind` cannot set CLOEXEC atomically, so a
+    /// concurrent test thread's fork/spawn can inherit the listener fd in
+    /// that window and keep the socket connectable after the drop — a
+    /// hygiene accident of the parallel suite, not a steal, and the flake
+    /// this test was known for. Routing-through-accept is immune: an
+    /// inherited duplicate shares OUR queue, while a thief that rebound the
+    /// path would swallow the fresh connect and accept() would come up dry.
     #[test]
     fn a_live_relay_is_not_stolen_from() {
         use std::os::unix::net::UnixListener;
         let dir = tempfile::tempdir().unwrap();
         let socket = dir.path().join("c.collab.sock");
         let listener = UnixListener::bind(&socket).unwrap();
+        listener.set_nonblocking(true).unwrap();
 
         ensure_relay(&socket).expect("alive socket short-circuits");
         relay_serve(&socket).expect("alive socket short-circuits");
-        // The original listener still owns the socket path.
-        drop(listener);
-        assert!(!crate::session::is_alive(&socket));
+
+        // Drain the probe connections the two calls queued on us, then
+        // prove a fresh connect still routes here: the path was not rebound.
+        while listener.accept().is_ok() {}
+        let _probe = std::os::unix::net::UnixStream::connect(&socket)
+            .expect("the listener still owns the path");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            match listener.accept() {
+                Ok(_) => break,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "the fresh connect never reached this listener: the \
+                         socket path was rebound out from under it"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                Err(e) => panic!("accept failed: {e}"),
+            }
+        }
     }
 
     /// Start a relay on a temp socket and connect a session to it in `role`.

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "Attaching to a persistent session can no longer strand you on a blank screen: the session handshake now carries versions both ways and a skewed (or pre-0.1.698) server shows a plain-text banner with continue / restart / detach choices; an attach from a size-less terminal still repaints the session; and a client that stops draining is evicted after five seconds instead of freezing every other participant.",
+    summary: "Session and relay liveness probes now distinguish a dead peer from a probe that could not run: a box out of file descriptors no longer reads as \"nothing listening\", which could send the attach and relay paths down a spawn against a live server.",
 }];

--- a/src/session.rs
+++ b/src/session.rs
@@ -242,7 +242,20 @@ pub(crate) fn write_meta_preserving_created(socket: &Path, workspace: &Path) -> 
 // lsof/peer check if the session count ever grows large.
 #[cfg(unix)]
 pub(crate) fn is_alive(socket: &Path) -> bool {
-    std::os::unix::net::UnixStream::connect(socket).is_ok()
+    match std::os::unix::net::UnixStream::connect(socket) {
+        Ok(_) => true,
+        // "Nothing is listening" and "the probe itself could not run" are
+        // different answers (#30): a box out of file descriptors must not
+        // read as a dead session — a false "dead" sends ensure_relay /
+        // attach_or_create down the spawn path against a live server.
+        // Resource exhaustion reports alive (the conservative side: worst
+        // case the caller attaches and gets a clean connect error), every
+        // true refusal reports dead.
+        Err(e) => matches!(
+            e.raw_os_error(),
+            Some(libc::EMFILE) | Some(libc::ENFILE) | Some(libc::EAGAIN) | Some(libc::ENOMEM)
+        ),
+    }
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
Fixes #30.

The issue's discipline held: two theories were already refuted, so this starts from what the failing assert actually CLAIMS. `assert!(!is_alive(&socket))` after dropping the listener is a proxy — it asserts that no process anywhere holds a listening fd for the path, which is a much stronger property than "ensure_relay and relay_serve did not steal the socket".

## The mechanism the proxy is vulnerable to

On macOS, `bind` cannot set `CLOEXEC` atomically (no `SOCK_CLOEXEC`); Rust's std sets it with a separate `ioctl` after `socket()`. A concurrent test thread's fork/spawn in that window — the parallel suite spawns shells, servers and PTYs constantly — inherits a duplicate of the listening fd. Dropping the test's listener then closes only one of two handles: the socket stays connectable, `is_alive` returns true, and the test fails with no steal having occurred. This fits every observation: connect succeeding on a "closed" socket, load dependence, isolation-cleanliness, and both sightings being on the Mac (Linux's atomic `SOCK_CLOEXEC` has no window — this box cannot reproduce it). Stated as the consistent explanation, not a proven capture; the fix below is immune either way, so the next occurrence — if any — would fail loudly with the routing message instead of the ambiguous liveness one.

## Fix

- **The test now asserts the invariant directly** (v0.1.699): after both calls short-circuit, it drains the probe connections they queued, makes one fresh connect, and requires `accept()` on the ORIGINAL listener to yield it — proof the path still routes here. An inherited fd duplicate shares this listener's queue (immune); a thief that rebound the path swallows the fresh connect and the accept comes up dry. Verified red with a simulated thief (staging + rename, `bind_socket_0600`'s exact shape): "the fresh connect never reached this listener". The `!is_alive`-after-drop proxy assert is gone.
- **The issue's hardening candidate ships too**: `session::is_alive` now distinguishes "nothing is listening" from "the probe could not run" — `EMFILE`/`ENFILE`/`EAGAIN`/`ENOMEM` report alive (the conservative side: worst case a caller attaches and gets a clean connect error) instead of sending `ensure_relay`/`attach_or_create` down the spawn path against a live server.

Full suite green (3056 + 6, 0 failed); the reworked test 5/5 solo; clippy zero warnings; fmt clean. Release notes replaced for 0.1.699.
