### PR TITLE
feat: rename the package to croft-software for the registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,8 +470,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "croft"
-version = "0.1.699"
+name = "croft-software"
+version = "0.1.700"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
-name = "croft"
-version = "0.1.699"
+name = "croft-software"
+version = "0.1.700"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"
 repository = "https://github.com/vitali87/croft"
 homepage = "https://croft.software"
 
+# The binary stays `croft` — the package is the suite name, the command is
+# the tool. `cargo install croft-software` puts `croft` on PATH.
 [[bin]]
 name = "croft"
 path = "src/main.rs"

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Fix,
-    summary: "Session and relay liveness probes now distinguish a dead peer from a probe that could not run: a box out of file descriptors no longer reads as \"nothing listening\", which could send the attach and relay paths down a spawn against a live server.",
+    kind: NoteKind::Feature,
+    summary: "The package is now named croft-software (the crate name `croft` was already taken on crates.io by an unrelated project) in preparation for publishing to the registry; the installed binary and every command stay `croft`.",
 }];

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1724,7 +1724,7 @@ fn cargo_zigbuild_command(source: &Path, triple: &str, jobs: &str) -> Command {
 /// drifts exactly one patch behind. `cargo zigbuild --locked` then refuses to
 /// build, and the installer silently falls back to a minutes-long
 /// from-scratch `cargo install` *on the remote host* (the thing the fast path
-/// exists to avoid). `cargo update -p croft --offline` rewrites only croft's
+/// exists to avoid). `cargo update -p croft-software --offline` rewrites only croft's
 /// own version line - it touches no dependency, needs no network, and so keeps
 /// `--locked`'s real guarantee (a reproducible dependency graph) fully intact.
 ///
@@ -3561,7 +3561,7 @@ Host !blocked *.internal
 
         let lock = std::fs::read_to_string(root.join("Cargo.lock")).unwrap();
         let lock_version = lock
-            .split("name = \"croft\"")
+            .split("name = \"croft-software\"")
             .nth(1)
             .and_then(|after| {
                 after.lines().find_map(|l| {
@@ -3574,7 +3574,7 @@ Host !blocked *.internal
 
         assert_eq!(
             lock_version, toml_version,
-            "Cargo.lock croft version {lock_version} drifted from Cargo.toml {toml_version}; run `cargo update -p croft`"
+            "Cargo.lock croft version {lock_version} drifted from Cargo.toml {toml_version}; run `cargo update -p croft-software`"
         );
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1732,7 +1732,7 @@ fn cargo_zigbuild_command(source: &Path, triple: &str, jobs: &str) -> Command {
 /// build, preserving the old fall-back behaviour rather than blocking install.
 fn sync_workspace_lock(source: &Path, log: impl Fn(String)) {
     match cross_tool_command("cargo")
-        .args(["update", "-p", "croft", "--offline"])
+        .args(["update", "-p", "croft-software", "--offline"])
         .current_dir(source)
         .output()
     {


### PR DESCRIPTION
Progresses #29.

The package is renamed to `croft-software` — the suite name, matching croft.software — in preparation for publishing to crates.io, where the name `croft` is held by an unrelated project. The installed binary and every command stay `croft`: `[[bin]] name` is independent of the package name, so `cargo install croft-software` puts `croft` on PATH and nothing user-facing changes.

Swept references: the Cargo.lock drift-guard test now parses the `croft-software` lock entry and its message names `cargo update -p croft-software`; the lockfile is regenerated. `cargo publish --dry-run` passes end-to-end (packages, compiles from the packaged source, aborts only at upload). The actual publish is not part of this PR — it requires a crates.io token and is permanent, so it happens as its own explicit step.

Full suite green (3056 + 6, 0 failed); clippy zero warnings; fmt clean. Release notes replaced for 0.1.700.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the installable package to `croft-software`.
  * The installed command remains `croft`, preserving existing command-line usage.
* **Documentation**
  * Updated installation and package references to reflect the new package name.
* **Release**
  * Updated the package version to `0.1.700`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->