### PR TITLE
docs(readme): reload the shell between rustup and cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Per-platform setup (Nerd Font, terminal keybindings, optional dependencies) live
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+Then open a new terminal — or run `. "$HOME/.cargo/env"` in the current one — so `cargo` is on `PATH`.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
Fixes #91.

The README's "Install Rust" step is immediately followed by `cargo install`, but a fresh rustup install only adds `~/.cargo/bin` to `PATH` for future shells — in the shell that just ran the installer, `cargo` is not found. Rustup's own installer output says to restart the shell or source `$HOME/.cargo/env`.

Adds one line between the two commands: open a new terminal, or run `. "$HOME/.cargo/env"` in the current one.

Docs-only change — no version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added post-installation instructions to reopen the terminal or reload Cargo’s environment so the `cargo` command is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->