### PR TITLE
docs: prefer the crates.io install command now the package is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,16 @@ Then open a new terminal â€” or run `. "$HOME/.cargo/env"` in the current one â€
 ## Install
 
 ```bash
+cargo install croft-software --locked
+```
+
+This compiles the latest [crates.io](https://crates.io/crates/croft-software) release into `~/.cargo/bin/croft`. Re-run to upgrade. To track the latest `main` instead:
+
+```bash
 cargo install --git https://github.com/vitali87/croft.git --locked
 ```
 
-This compiles croft from the latest `main` into `~/.cargo/bin/croft`. Re-run to upgrade. To build from source instead:
+Or to build from a source checkout:
 
 ```bash
 git clone https://github.com/vitali87/croft.git

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -9,7 +9,7 @@ There is **no required setup command** on Android. After `cargo install`, croft 
 ## Install
 
 ```bash
-cargo install --git https://github.com/vitali87/croft.git --locked
+cargo install croft-software --locked
 ```
 
 This builds croft into `~/.cargo/bin/croft` inside Termux. Re-run to upgrade.

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -8,7 +8,7 @@ croft has no separate "Windows" target. Inside WSL2 you are running real Linux, 
 
 ```bash
 # inside your WSL2 distro (Ubuntu, Debian, etc.)
-cargo install --git https://github.com/vitali87/croft.git --locked
+cargo install croft-software --locked
 ```
 
 The one thing WSL does **not** change is the terminal. A WSL shell renders into whatever Windows terminal emulator is hosting it, and that choice decides whether you get croft's full icon/image UI or the degraded text fallback:


### PR DESCRIPTION
## Summary

`croft-software` v0.1.701 is now published on crates.io (#96), so the registry install is the primary path. This updates every user-facing install command:

- **README.md** — `cargo install croft-software --locked` first, with the `--git` command kept as the way to track the latest `main`, and the source-checkout build unchanged.
- **docs/WINDOWS.md** — the WSL2 snippet uses the registry command.
- **docs/ANDROID.md** — the Termux install uses the registry command.

Internal `cargo install --path` machinery in `src/remote*.rs` is unrelated and untouched.

Docs-only change: no version bump per the release policy.

## Verification

- `cargo publish --dry-run` and the real publish both completed; the sparse index reports `0.1.701 live`.
- `cargo install croft-software --locked` verification build from the registry is running; result recorded on #96.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to prioritize the latest published `croft-software` release.
  - Added guidance on binary location and upgrading installed versions.
  - Documented installation directly from the latest GitHub `main` branch.
  - Updated Android and Windows instructions to use the published package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->