### PR TITLE
fix(status): workspace-relative transient paths, middle-elide over-long messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.703"
+version = "0.1.704"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.703"
+version = "0.1.704"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11797,6 +11797,27 @@ impl App {
             .map(|s| s.content.chars().count() as u16)
             .collect();
         let right_total: u16 = widths.iter().sum();
+        // The right cluster paints OVER the left paragraph, so an over-long
+        // transient loses exactly its tail — for "Opened <deep path>" that
+        // was the filename, the one informative part (#100). Middle-elide
+        // the transient (always the last span) into the room that survives.
+        if !self.status.is_empty() {
+            let left_fixed: u16 = spans
+                .iter()
+                .take(spans.len().saturating_sub(1))
+                .map(|s| s.content.chars().count() as u16)
+                .sum();
+            let avail = status_rect
+                .width
+                .saturating_sub(right_total)
+                .saturating_sub(left_fixed)
+                .saturating_sub(1);
+            if let Some(last) = spans.last_mut()
+                && last.content.chars().count() as u16 > avail
+            {
+                *last = Span::raw(elide_middle(&self.status, avail as usize));
+            }
+        }
 
         // Black theme: drop the navy status strip to a near-black seam (a hair
         // lighter than the #000000 editor so the bar still reads as distinct),
@@ -13488,7 +13509,9 @@ impl App {
         }
         // Arm the `Cmd+K` leader (VS Code's two-key chord prefix). The next
         // keystroke is interpreted by `handle_cmd_k_chord`, checked at the top
-        // of this fn. Cmd is SUPER on macOS, Ctrl on Linux/Termux.
+        // of this fn. Cmd is SUPER everywhere; Ctrl doubles as Cmd only on
+        // Termux — on desktop Linux a bare Ctrl+K stays the editor's
+        // kill-to-end-of-line (see `is_cmd_k_leader_key`).
         if is_cmd_k_leader_key(key) {
             self.cmd_k_leader = Some(std::time::Instant::now());
             return Ok(());
@@ -18817,10 +18840,10 @@ impl App {
         match self.editor.open_pinned(&path) {
             Ok(()) => {
                 self.focus_pane(Pane::Editor);
-                self.status = format!("Opened {}", path.display());
+                self.status = format!("Opened {}", self.status_path(&path));
             }
             Err(e) => {
-                self.status = format!("Open {} failed: {e}", path.display());
+                self.status = format!("Open {} failed: {e}", self.status_path(&path));
             }
         }
     }
@@ -18897,7 +18920,11 @@ impl App {
                 self.editor.cursor_col = match_col;
                 self.editor.scroll_col = 0;
                 self.editor.ensure_cursor_col_visible();
-                self.status = format!("Opened {} at line {}", hit.path.display(), hit.line_no);
+                self.status = format!(
+                    "Opened {} at line {}",
+                    self.status_path(&hit.path),
+                    hit.line_no
+                );
                 self.focus_pane(Pane::Editor);
             }
             Err(e) => {
@@ -22414,7 +22441,7 @@ impl App {
                             // sees where in the workspace the file lives.
                             self.tree.reveal_path(&path);
                             self.focus_pane(Pane::Editor);
-                            self.status = format!("Opened {}", path.display());
+                            self.status = format!("Opened {}", self.status_path(&path));
                         }
                         Err(e) => {
                             self.status = format!("Open failed: {e}");
@@ -30372,6 +30399,19 @@ impl App {
         });
     }
 
+    /// Workspace-relative rendering for status transients and prompt
+    /// labels: tabs and breadcrumbs already speak root-relative, and an
+    /// absolute path under a deep root pushed the one informative part —
+    /// the filename — off the visible end of the bar (#100). Paths outside
+    /// the root (`~/.ssh/config`, files opened by absolute path) keep
+    /// their absolute form.
+    fn status_path(&self, path: &Path) -> String {
+        path.strip_prefix(&self.workspace_root)
+            .unwrap_or(path)
+            .display()
+            .to_string()
+    }
+
     fn open_rename_prompt(&mut self, path: PathBuf) {
         let parent = path
             .parent()
@@ -30381,7 +30421,7 @@ impl App {
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_default();
-        let label = format!("Rename {}", path.display());
+        let label = format!("Rename {}", self.status_path(&path));
         self.prompt = Some(Prompt {
             label,
             buffer: current,
@@ -30478,7 +30518,7 @@ impl App {
                 match crate::widgets::file_tree::rename_in(&parent, &old_path, &new_name) {
                     Ok(new_path) => {
                         self.prompt = None;
-                        self.status = format!("Renamed to {}", new_path.display());
+                        self.status = format!("Renamed to {}", self.status_path(&new_path));
                         if let Some(idx) = self.tree.index_of_dir(&parent) {
                             self.tree.refresh_children(idx);
                             if let Some(new_idx) =
@@ -30629,6 +30669,27 @@ fn mode_reassert_seq() -> Vec<u8> {
 /// too, mirroring VS Code's Linux keymap so the Super-only chords stay
 /// reachable. `termux` is threaded in explicitly to keep the decision pure
 /// and testable.
+/// Shrink `s` to at most `max` chars by cutting the middle, keeping roughly
+/// a third of the head and two thirds of the tail — for path-shaped
+/// messages the tail carries the filename, the part worth keeping. Never
+/// appends a trailing ellipsis (the cut is interior by construction).
+fn elide_middle(s: &str, max: usize) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= max {
+        return s.to_string();
+    }
+    if max < 3 {
+        return chars.iter().take(max).collect();
+    }
+    let keep = max - 1; // one cell for the ellipsis
+    let head = keep / 3;
+    let tail = keep - head;
+    let mut out: String = chars[..head].iter().collect();
+    out.push('\u{2026}');
+    out.extend(&chars[chars.len() - tail..]);
+    out
+}
+
 fn cmd_active(mods: KeyModifiers, termux: bool) -> bool {
     mods.contains(KeyModifiers::SUPER) || (termux && mods.contains(KeyModifiers::CONTROL))
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -17878,6 +17878,54 @@ fn welcome_logo_shrinks_before_the_release_note_card_clips() {
     );
 }
 
+#[test]
+fn status_transient_keeps_its_tail_when_longer_than_the_bar() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    // A transient whose informative part is the tail, longer than the room
+    // left of the right cluster at 140 cols. The right cluster paints over
+    // the left paragraph, so an unelided message loses exactly its tail —
+    // for "Opened <deep absolute path>" that was the filename (#100).
+    let deep: String = "directory-segment/".repeat(7);
+    app.status = format!("Opened /{deep}main.rs");
+    let backend = ratatui::backend::TestBackend::new(140, 40);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    term.draw(|f| app.render(f)).unwrap();
+    let buf = term.backend().buffer().clone();
+    let a = buf.area;
+    let last_row: String = (a.x..a.x + a.width)
+        .map(|x| buf[(x, a.y + a.height - 1)].symbol().to_string())
+        .collect();
+    assert!(
+        last_row.contains("main.rs"),
+        "an over-long status transient must middle-elide so its tail stays \
+         visible; the bar showed: {last_row:?}"
+    );
+    assert!(
+        last_row.contains("Ln 1, Col 1"),
+        "the right cluster must still paint: {last_row:?}"
+    );
+}
+
+#[test]
+fn status_path_speaks_workspace_relative_inside_the_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = App::new(tmp.path().to_path_buf()).unwrap();
+    let inside = tmp.path().join("src").join("main.rs");
+    assert_eq!(
+        app.status_path(&inside),
+        format!("src{}main.rs", std::path::MAIN_SEPARATOR),
+        "paths under the workspace root must render root-relative, like tabs \
+         and breadcrumbs"
+    );
+    let outside = std::path::Path::new("/etc/hosts");
+    assert_eq!(
+        app.status_path(outside),
+        "/etc/hosts",
+        "paths outside the root keep their absolute form"
+    );
+}
+
 /// Render the app at 140x50 and clone the buffer for color probing.
 fn render_buf(app: &mut App) -> ratatui::buffer::Buffer {
     let backend = ratatui::backend::TestBackend::new(140, 50);

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "This very panel no longer cuts its highlights off mid-sentence in small windows: the release-note card is sized before the logo, so the logo shrinks to its minimum before the note may clip.",
+    summary: "Status-bar messages keep their point visible: \"Opened\", \"Renamed to\" and the rename prompt now show workspace-relative paths, and an over-long message elides its middle instead of losing its tail under the position readout.",
 }];


### PR DESCRIPTION
Fixes #100.

## Fix, in two layers

1. **Root-relative paths where the root is known** — new `App::status_path`: paths under the workspace root render root-relative (matching tabs and breadcrumbs), paths outside it (`~/.ssh/config`) keep their absolute form. Applied to the "Opened", "Open failed", "Opened … at line", "Renamed to" transients and the F2 rename prompt label (the popup previously titled itself with an absolute path truncated before the filename — recorded on the issue).

2. **Middle-elision as the universal guard** — the status bar's right cluster paints over the left paragraph, so any over-long transient lost exactly its tail. The transient span is now middle-elided (`elide_middle`: ~⅓ head, ⅔ tail, interior `…`) into the room that survives left of the cluster. This also covers the editor-internal "Opened" messages (`src/widgets/editor.rs`), which have no workspace root in reach — their absolute paths now elide with the filename kept visible.

Also corrects a stale comment at the `Cmd+K` leader arming site that claimed Ctrl is the command surrogate on "Linux/Termux" — the predicate (and KEYBINDINGS.md) say Termux only; on desktop Linux bare Ctrl+K remains the editor's kill-to-end-of-line.

## Tests (red first)

- `status_transient_keeps_its_tail_when_longer_than_the_bar`: renders a deep "Opened …/main.rs" transient at 140 cols and asserts both the tail (`main.rs`) and the right cluster survive. Red before the elision (the bar showed the path cut dead at the position readout); green now.
- `status_path_speaks_workspace_relative_inside_the_root`: relative inside the root, absolute outside.

v0.1.704; release note replaced.
