### PR TITLE
fix(status): complete the workspace-relative sweep for prompt labels and path statuses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.705"
+version = "0.1.706"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.705"
+version = "0.1.706"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6667,7 +6667,9 @@ impl App {
             });
         }
         match self.open_at(&path, line as usize, col as usize) {
-            Ok(()) => self.status = format!("Jumped to {} line {}", path.display(), line + 1),
+            Ok(()) => {
+                self.status = format!("Jumped to {} line {}", self.status_path(&path), line + 1)
+            }
             Err(e) => self.status = format!("Go to definition failed: {e}"),
         }
     }
@@ -7010,7 +7012,7 @@ impl App {
         }
         // The restore is itself a new version worth keeping.
         self.record_history_snapshot(&file);
-        self.status = format!("Restored {}", file.display());
+        self.status = format!("Restored {}", self.status_path(&file));
     }
 
     /// Apply a `documentSymbol` reply to the OUTLINE panel, but only when its
@@ -8014,7 +8016,9 @@ impl App {
         };
         let line = loc.row;
         match self.open_at(&loc.path, loc.row, loc.col) {
-            Ok(()) => self.status = format!("Back to {} line {}", loc.path.display(), line + 1),
+            Ok(()) => {
+                self.status = format!("Back to {} line {}", self.status_path(&loc.path), line + 1)
+            }
             Err(e) => self.status = format!("Go back failed: {e}"),
         }
     }
@@ -16288,7 +16292,7 @@ impl App {
                 match crate::git::clone_into(&parent, &value) {
                     Ok(dest) => {
                         self.log_git("clone", &Ok(format!("into {}", dest.display())));
-                        self.status = format!("Cloned into {}", dest.display());
+                        self.status = format!("Cloned into {}", self.status_path(&dest));
                         self.change_workspace_root(dest);
                     }
                     Err(err) => {
@@ -21204,7 +21208,10 @@ impl App {
                 dest_dir.display()
             )
         } else {
-            format!("Imported {total} items into {}", dest_dir.display())
+            format!(
+                "Imported {total} items into {}",
+                self.status_path(&dest_dir)
+            )
         };
     }
 
@@ -22127,7 +22134,7 @@ impl App {
         let col0 = fr.column.map(|c| c as usize).unwrap_or(1).saturating_sub(1);
         match self.open_at(&abs, line0, col0) {
             Ok(()) => {
-                self.status = format!("{}:{}", abs.display(), fr.line);
+                self.status = format!("{}:{}", self.status_path(&abs), fr.line);
                 true
             }
             Err(_) => false,
@@ -29922,7 +29929,7 @@ impl App {
                 self.focus_pane(Pane::Editor);
                 self.sync_open_file_poll_mtime();
                 self.poke_cursor();
-                self.status = format!("{}:{}", j.path.display(), j.line);
+                self.status = format!("{}:{}", self.status_path(&j.path), j.line);
             }
             Err(err) => {
                 self.status = format!("Could not open {}: {err}", j.path.display());
@@ -30402,16 +30409,20 @@ impl App {
                 errors.join("; ")
             );
         } else if placed.len() == 1 {
-            self.status = format!("{verb} 1 item to {}", dest_dir.display());
+            self.status = format!("{verb} 1 item to {}", self.status_path(dest_dir));
         } else {
-            self.status = format!("{verb} {} items to {}", placed.len(), dest_dir.display());
+            self.status = format!(
+                "{verb} {} items to {}",
+                placed.len(),
+                self.status_path(dest_dir)
+            );
         }
     }
 
     fn open_create_prompt(&mut self, kind: CreateKind, target_dir: PathBuf) {
         let label = match kind {
-            CreateKind::File => format!("New File in {}", target_dir.display()),
-            CreateKind::Folder => format!("New Folder in {}", target_dir.display()),
+            CreateKind::File => format!("New File in {}", self.status_path(&target_dir)),
+            CreateKind::Folder => format!("New Folder in {}", self.status_path(&target_dir)),
         };
         self.prompt = Some(Prompt {
             label,
@@ -30429,10 +30440,12 @@ impl App {
     /// the root (`~/.ssh/config`, files opened by absolute path) keep
     /// their absolute form.
     fn status_path(&self, path: &Path) -> String {
-        path.strip_prefix(&self.workspace_root)
-            .unwrap_or(path)
-            .display()
-            .to_string()
+        let rel = path.strip_prefix(&self.workspace_root).unwrap_or(path);
+        if rel.as_os_str().is_empty() {
+            String::from(".")
+        } else {
+            rel.display().to_string()
+        }
     }
 
     fn open_rename_prompt(&mut self, path: PathBuf) {
@@ -30508,8 +30521,10 @@ impl App {
                     Ok(path) => {
                         self.prompt = None;
                         self.status = match create_kind {
-                            CreateKind::File => format!("Created file {}", path.display()),
-                            CreateKind::Folder => format!("Created folder {}", path.display()),
+                            CreateKind::File => format!("Created file {}", self.status_path(&path)),
+                            CreateKind::Folder => {
+                                format!("Created folder {}", self.status_path(&path))
+                            }
                         };
                         if let Some(idx) = self.tree.index_of_dir(&target_dir) {
                             self.tree.refresh_children(idx);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7289,6 +7289,21 @@ fn change_workspace_root_skips_cd_when_terminal_runs_a_foreground_app() {
     std::fs::create_dir(&target_dir).unwrap();
     let mut app = App::new(tmp.path().to_path_buf()).unwrap();
 
+    // Wait out shell startup first: while rc files run, a startup child can
+    // own the tty and `!foreground_is_shell` is true for the WRONG reason —
+    // the sleep below hasn't even executed, and the re-root races the shell
+    // reclaiming the tty at its first prompt (the #94 window, from the
+    // suppress side). A shell AT ITS PROMPT makes the later false reading
+    // unambiguous.
+    let mut waited = 0u32;
+    while waited < 4000 && !app.terminal_mut().foreground_is_shell() {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        waited += 20;
+    }
+    assert!(
+        app.terminal_mut().foreground_is_shell(),
+        "precondition: the shell must reach its prompt before the test starts"
+    );
     // Put the active terminal into a long-lived foreground command so its
     // foreground process group is the command, not the shell.
     app.terminal_mut().write_input(b"sleep 10\n");
@@ -25560,5 +25575,26 @@ fn status_elision_never_fires_on_a_message_that_fits() {
         last_row.contains("type a label to copy"),
         "a transient that fits beside the right cluster must paint verbatim, \
          not elide; the bar showed: {last_row:?}"
+    );
+}
+
+#[test]
+fn create_prompt_labels_speak_workspace_relative() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(tmp.path().join("src")).unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.open_create_prompt(CreateKind::File, tmp.path().join("src"));
+    let label = app.prompt.as_ref().unwrap().label.clone();
+    assert_eq!(
+        label, "New File in src",
+        "the prompt title's one job is naming the target directory; a deep \
+         absolute workspace path truncates it out of the popup (#105)"
+    );
+    app.prompt = None;
+    app.open_create_prompt(CreateKind::Folder, tmp.path().to_path_buf());
+    let label = app.prompt.as_ref().unwrap().label.clone();
+    assert_eq!(
+        label, "New Folder in .",
+        "the workspace root itself reads as '.'"
     );
 }

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "Clicking a commit in the Source Control COMMITS graph opens its patch again: after switching from the Explorer, the Explorer's invisible section rectangles were still swallowing clicks on the rows the graph paints in.",
+    summary: "Every prompt title and path status now speaks workspace-relative: New File / New Folder, Created, Jumped to, Back to, Restored, Imported and paste/move messages no longer bury the name that matters inside a deep absolute path.",
 }];


### PR DESCRIPTION
Fixes #105.

Completes #100's sweep: every remaining prompt label and success-path status that printed an absolute workspace path now routes through `App::status_path` — `New File in …` / `New Folder in …` prompt titles (the observed gesture: the popup title truncated before the directory name), `Created file/folder`, the paste/move `{verb} N item(s) to …`, `Jumped to … line N`, `Back to … line N`, `Restored …`, `Imported N items into …`, the bare `path:line` statuses, and `Cloned into …` (usually outside the root, where the helper falls back to absolute by design).

`status_path` additionally renders the workspace root itself as `.` instead of an empty string.

Failure/error messages deliberately keep absolute paths — the status-bar middle-elision from #100 guards those, and the full path is the useful part when something went wrong.

## Tests (red first)

`create_prompt_labels_speak_workspace_relative`: asserts `New File in src` for a subdirectory and `New Folder in .` for the root. Red before the conversion (`New File in /tmp/<abs>/src`); green now, alongside the existing `status_path` unit test.

Also hardens `change_workspace_root_skips_cd_when_terminal_runs_a_foreground_app` against the #94 startup window from the suppress side: it now waits for the shell to reach its prompt before typing the foreground command, so `!foreground_is_shell` can only mean "the command owns the tty" — it flaked once under full-suite load (and once in isolation) when the re-root raced the shell reclaiming the tty between rc startup and the type-ahead `sleep` executing. Five consecutive isolated runs and a full suite pass green after the guard.

v0.1.706; release note replaced.
