### PR TITLE
feat(editor): auto-closing pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.711"
+version = "0.1.712"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.711"
+version = "0.1.712"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -9,6 +9,7 @@ On macOS, the `Cmd` chords below only reach croft after you run a one-time setup
 | Keys | Action |
 |------|--------|
 | `Ctrl+s` / `Cmd+s` | Save the open file |
+| Typing `(` `[` `{` or a quote | Auto-closing pairs: the pair inserts with the caret between (openers never before a word, quotes never after one); typing the closer steps over; a selection is surrounded; backspace inside an empty pair deletes both. Settings gear → "Auto Closing Pairs" toggles |
 | `Ctrl+q` | Quit |
 | `F1` | Open the shortcuts modal |
 | `F6` | Cycle focus across panes (tree → editor → terminal → tree) |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2040,6 +2040,9 @@ pub struct App {
     blame_fetched: Option<PathBuf>,
     /// User pref: show the current-line inline blame annotation (default on).
     inline_blame_enabled: bool,
+    /// Auto-closing pairs (#121), persisted; synced onto the active editor
+    /// beside the blame flag.
+    auto_close_pairs: bool,
     /// LSP inlay hints (inline type / parameter annotations), on by default
     /// like VS Code's `editor.inlayHints.enabled`; toggled from the palette
     /// and persisted as `disable_inlay_hints` in config.json.
@@ -3537,6 +3540,7 @@ impl App {
             blame_tx,
             blame_fetched: None,
             inline_blame_enabled: !loaded_prefs.disable_inline_blame,
+            auto_close_pairs: !loaded_prefs.disable_auto_close_pairs,
             inlay_hints_enabled: !loaded_prefs.disable_inlay_hints,
             // Keep the suite off the user's real ~/.config/croft/history: a
             // per-process temp root in test builds, the real dir otherwise.
@@ -5680,6 +5684,7 @@ impl App {
     /// Gated on the pref so a subprocess never runs when blame is off.
     fn sync_blame(&mut self) {
         self.editor.blame_enabled = self.inline_blame_enabled;
+        self.editor.auto_close_pairs = self.auto_close_pairs;
         if !self.inline_blame_enabled {
             return;
         }
@@ -18338,6 +18343,7 @@ impl App {
             ListPurpose::Settings => {
                 match row.id.as_str() {
                     "toggle:format_on_save" => self.toggle_format_on_save(),
+                    "toggle:auto_close_pairs" => self.toggle_auto_close_pairs(),
                     "toggle:auto_save" => self.toggle_auto_save(),
                     "toggle:inline_blame" => self.toggle_inline_blame(),
                     "toggle:inlay_hints" => self.toggle_inlay_hints(),
@@ -18384,6 +18390,10 @@ impl App {
         use crate::widgets::list_picker::{ListPicker, ListPurpose, ListRow};
         let on_off = |b: bool| if b { "on" } else { "off" };
         let rows = vec![
+            ListRow {
+                id: String::from("toggle:auto_close_pairs"),
+                label: format!("Auto Closing Pairs: {}", on_off(self.auto_close_pairs)),
+            },
             ListRow {
                 id: String::from("toggle:format_on_save"),
                 label: format!("Format on Save: {}", on_off(self.format_on_save)),
@@ -28392,6 +28402,16 @@ impl App {
         if !cfg!(test) {
             let _ = crate::prefs::save_inline_blame(self.inline_blame_enabled);
         }
+    }
+
+    fn toggle_auto_close_pairs(&mut self) {
+        self.auto_close_pairs = !self.auto_close_pairs;
+        self.editor.auto_close_pairs = self.auto_close_pairs;
+        let _ = crate::prefs::save_auto_close_pairs(self.auto_close_pairs);
+        self.status = format!(
+            "Auto Closing Pairs: {}",
+            if self.auto_close_pairs { "on" } else { "off" }
+        );
     }
 
     fn toggle_format_on_save(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28407,7 +28407,9 @@ impl App {
     fn toggle_auto_close_pairs(&mut self) {
         self.auto_close_pairs = !self.auto_close_pairs;
         self.editor.auto_close_pairs = self.auto_close_pairs;
-        let _ = crate::prefs::save_auto_close_pairs(self.auto_close_pairs);
+        if !cfg!(test) {
+            let _ = crate::prefs::save_auto_close_pairs(self.auto_close_pairs);
+        }
         self.status = format!(
             "Auto Closing Pairs: {}",
             if self.auto_close_pairs { "on" } else { "off" }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -20204,12 +20204,12 @@ fn accepting_a_snippet_completion_expands_it_with_tab_stops() {
 fn settings_view_toggle_flips_the_setting_and_stays_open() {
     let tmp = tempfile::tempdir().unwrap();
     let mut app = App::new(tmp.path().to_path_buf()).unwrap();
-    let before = app.format_on_save;
+    let before = app.auto_close_pairs;
     app.open_settings_view();
-    // The first row is "Format on Save"; confirming it flips the value.
+    // The first row is "Auto Closing Pairs"; confirming it flips the value.
     app.confirm_list_picker();
     assert_eq!(
-        app.format_on_save, !before,
+        app.auto_close_pairs, !before,
         "the toggle row flips the setting"
     );
     assert!(

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -164,6 +164,10 @@ pub struct Prefs {
     /// config both mean "blame shown".
     #[serde(default)]
     pub disable_inline_blame: bool,
+    /// Auto-closing pairs (#121) are ON by default; this stores the opt-out
+    /// (a default-false field keeps old configs valid, like inline blame).
+    #[serde(default)]
+    pub disable_auto_close_pairs: bool,
     /// Opt-out for LSP inlay hints (inline type / parameter annotations),
     /// which are on by default like VS Code's `editor.inlayHints.enabled`.
     /// Stored as the disable flag so the derived `Default` and an older
@@ -299,6 +303,13 @@ pub fn save_layout(layout: LayoutPrefs) -> Result<()> {
 
 /// Persist the format-on-save choice, preserving other settings. Best-effort:
 /// a write failure is swallowed by the caller.
+pub fn save_auto_close_pairs(enabled: bool) -> Result<()> {
+    let path = config_path();
+    let mut prefs = Prefs::load(&path).unwrap_or_default();
+    prefs.disable_auto_close_pairs = !enabled;
+    prefs.save(&path)
+}
+
 pub fn save_format_on_save(enabled: bool) -> Result<()> {
     let path = config_path();
     let mut prefs = Prefs::load(&path).unwrap_or_default();

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Feature,
-    summary: "Compiler errors now reach PROBLEMS: any command finishing in a terminal pane has its output scanned by built-in problem matchers (cargo, tsc, gcc/clang, python, eslint), the hits sit beside the LSP diagnostics, and a clean rebuild clears them.",
+    summary: "Brackets and quotes now auto-close as you type: the caret lands inside the pair, typing the closer steps over it, a selection gets surrounded, and backspace inside an empty pair removes both — toggleable in the settings gear.",
 }];

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -1446,6 +1446,11 @@ pub struct Editor {
     /// closers type over, selections surround, and backspace eats an empty
     /// pair. Synced from the app's persisted preference like `blame_enabled`.
     pub auto_close_pairs: bool,
+    /// The caret position and `edit_seq` recorded by the LAST auto-close
+    /// insertion. Pair-backspace fires only while the caret still sits
+    /// there with no edits since — a pre-existing `()` in the file must
+    /// never lose both sides to one backspace (#122 review).
+    auto_pair_at: Option<(usize, usize, u64)>,
     /// Merge-conflict blocks in the buffer, lazily recomputed whenever
     /// `edit_seq` moves (same pattern as the git-gutter marks).
     conflicts: Vec<crate::merge::ConflictBlock>,
@@ -1777,6 +1782,7 @@ impl Editor {
             git_marks: std::collections::HashMap::new(),
             git_marks_seq: u64::MAX,
             auto_close_pairs: true,
+            auto_pair_at: None,
             conflicts: Vec::new(),
             merge_action_spans: Vec::new(),
             conflicts_seq: u64::MAX,
@@ -3434,6 +3440,9 @@ impl Editor {
     /// word (and a quote never pairs against a preceding word character —
     /// the apostrophe-in-a-word case).
     fn insert_char_with_pairs(&mut self, c: char) -> bool {
+        if self.lines.is_empty() {
+            self.lines.push(String::new());
+        }
         let close = auto_close_partner(c);
         let has_sel = self.selection.map(|s| s.has_area()).unwrap_or(false);
         // Selection surround: openers and quotes wrap, closers fall through
@@ -3503,6 +3512,7 @@ impl Editor {
         self.cursor_col += 1;
         self.mark_buffer_changed();
         self.recompute_highlights();
+        self.auto_pair_at = Some((self.cursor_row, self.cursor_col, self.edit_seq));
         true
     }
 
@@ -3867,9 +3877,13 @@ impl Editor {
         self.push_undo(EditKind::Backspace);
         // Between an empty auto-close pair, backspace eats both sides —
         // typing `(` then backspace must round-trip to nothing (#121).
+        // ONLY for the pair the last auto-close inserted, still untouched
+        // (position and edit_seq both match): a pre-existing `()` in the
+        // file keeps its closer (#122 review).
         if self.auto_close_pairs
             && !self.selection.map(|s| s.has_area()).unwrap_or(false)
             && self.cursor_col > 0
+            && self.auto_pair_at == Some((self.cursor_row, self.cursor_col, self.edit_seq))
         {
             let line = self.lines.get(self.cursor_row).cloned().unwrap_or_default();
             let prev = line.chars().nth(self.cursor_col - 1);
@@ -18247,6 +18261,28 @@ mod tests {
         assert_eq!(e.lines[0], "()");
         e.backspace();
         assert_eq!(e.lines[0], "", "the empty pair dies together");
+    }
+
+    #[test]
+    fn typing_an_opener_into_a_fresh_empty_buffer_never_panics() {
+        // Editor::new starts with NO lines at all; the pair path indexed
+        // lines[0] and panicked on the first keystroke of an untitled
+        // buffer (#122 review, Critical).
+        let mut e = Editor::new();
+        e.auto_close_pairs = true;
+        e.insert_char('(');
+        assert_eq!(e.lines[0], "()");
+    }
+
+    #[test]
+    fn backspace_keeps_the_closer_of_a_pre_existing_pair() {
+        // Only the pair the last auto-close inserted may die together; a
+        // `()` already in the file keeps its closer (#122 review).
+        let mut e = editor_with("()");
+        e.cursor_row = 0;
+        e.cursor_col = 1;
+        e.backspace();
+        assert_eq!(e.lines[0], ")", "the manual pair loses only one side");
     }
 
     #[test]

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -1442,6 +1442,10 @@ pub struct Editor {
     /// The `edit_seq` `git_marks` was computed at; `u64::MAX` forces a first
     /// recompute once a baseline arrives.
     git_marks_seq: u64,
+    /// Auto-closing pairs (#121): typing an opener/quote inserts the pair,
+    /// closers type over, selections surround, and backspace eats an empty
+    /// pair. Synced from the app's persisted preference like `blame_enabled`.
+    pub auto_close_pairs: bool,
     /// Merge-conflict blocks in the buffer, lazily recomputed whenever
     /// `edit_seq` moves (same pattern as the git-gutter marks).
     conflicts: Vec<crate::merge::ConflictBlock>,
@@ -1772,6 +1776,7 @@ impl Editor {
             git_baseline_for: None,
             git_marks: std::collections::HashMap::new(),
             git_marks_seq: u64::MAX,
+            auto_close_pairs: true,
             conflicts: Vec::new(),
             merge_action_spans: Vec::new(),
             conflicts_seq: u64::MAX,
@@ -3395,6 +3400,9 @@ impl Editor {
     }
 
     pub fn insert_char(&mut self, c: char) {
+        if self.auto_close_pairs && self.insert_char_with_pairs(c) {
+            return;
+        }
         self.pin_on_edit();
         // Selection-replace counts as one logical edit (Replace), not two.
         // Coalesce subsequent typed chars onto the same step only when the
@@ -3417,6 +3425,85 @@ impl Editor {
         self.cursor_col += 1;
         self.mark_buffer_changed();
         self.recompute_highlights();
+    }
+
+    /// The auto-closing-pairs behaviors, returning true when the keystroke
+    /// was fully handled here (#121). VS Code's default semantics:
+    /// type-over for closers/quotes, selection surround for openers/quotes,
+    /// pair insertion guarded so a closer is never jammed into a following
+    /// word (and a quote never pairs against a preceding word character —
+    /// the apostrophe-in-a-word case).
+    fn insert_char_with_pairs(&mut self, c: char) -> bool {
+        let close = auto_close_partner(c);
+        let has_sel = self.selection.map(|s| s.has_area()).unwrap_or(false);
+        // Selection surround: openers and quotes wrap, closers fall through
+        // to the ordinary replace-selection insert.
+        if has_sel {
+            let Some(close) = close else {
+                return false;
+            };
+            if is_pair_closer(c) {
+                return false;
+            }
+            self.pin_on_edit();
+            self.push_undo(EditKind::Paste);
+            let ((sr, sc), (er, ec)) = self.selection.unwrap().normalised();
+            let close_byte = self.byte_index(er, ec);
+            self.lines[er].insert(close_byte, close);
+            let open_byte = self.byte_index(sr, sc);
+            self.lines[sr].insert(open_byte, c);
+            let inner_end = if sr == er { ec + 1 } else { ec };
+            self.selection = Some(EditorSelection {
+                anchor: (sr, sc + 1),
+                head: (er, inner_end),
+            });
+            self.cursor_row = er;
+            self.cursor_col = inner_end;
+            self.mark_buffer_changed();
+            self.recompute_highlights();
+            return true;
+        }
+        let next = self
+            .lines
+            .get(self.cursor_row)
+            .and_then(|l| l.chars().nth(self.cursor_col));
+        // Type-over: the exact closer/quote already sits at the caret.
+        if (is_pair_closer(c) || is_pair_quote(c)) && next == Some(c) {
+            self.cursor_col += 1;
+            self.ensure_cursor_col_visible();
+            return true;
+        }
+        let Some(close) = close else {
+            return false;
+        };
+        if is_pair_closer(c) {
+            return false;
+        }
+        // Opener guard: never before a word character. Quote guard: also
+        // never after a word character or the same quote.
+        let next_ok = next.is_none_or(|n| !n.is_alphanumeric() && n != '_' && n != c);
+        let prev = if self.cursor_col == 0 {
+            None
+        } else {
+            self.lines
+                .get(self.cursor_row)
+                .and_then(|l| l.chars().nth(self.cursor_col - 1))
+        };
+        let prev_ok =
+            !is_pair_quote(c) || prev.is_none_or(|p| !p.is_alphanumeric() && p != '_' && p != c);
+        if !next_ok || !prev_ok {
+            return false;
+        }
+        self.pin_on_edit();
+        self.push_undo(EditKind::InsertChar);
+        let row = self.cursor_row;
+        let byte = self.byte_index(row, self.cursor_col);
+        self.lines[row].insert(byte, close);
+        self.lines[row].insert(byte, c);
+        self.cursor_col += 1;
+        self.mark_buffer_changed();
+        self.recompute_highlights();
+        true
     }
 
     /// Apply LSP rename edits to this buffer in-memory as a single undo step,
@@ -3778,6 +3865,23 @@ impl Editor {
     pub fn backspace(&mut self) {
         self.pin_on_edit();
         self.push_undo(EditKind::Backspace);
+        // Between an empty auto-close pair, backspace eats both sides —
+        // typing `(` then backspace must round-trip to nothing (#121).
+        if self.auto_close_pairs
+            && !self.selection.map(|s| s.has_area()).unwrap_or(false)
+            && self.cursor_col > 0
+        {
+            let line = self.lines.get(self.cursor_row).cloned().unwrap_or_default();
+            let prev = line.chars().nth(self.cursor_col - 1);
+            let next = line.chars().nth(self.cursor_col);
+            if let (Some(p), Some(n)) = (prev, next)
+                && auto_close_partner(p) == Some(n)
+                && !is_pair_closer(p)
+            {
+                let byte = self.byte_index(self.cursor_row, self.cursor_col);
+                self.lines[self.cursor_row].remove(byte);
+            }
+        }
         self.backspace_raw();
         self.recompute_highlights();
     }
@@ -8629,6 +8733,29 @@ fn paint_bracket_match(
 /// diff3 base section and the `=======` separator sit on a neutral grey.
 /// Fixed dark tints, like the selection band: both bundled themes are dark,
 /// and the hues are semantic (green = yours, blue = theirs), not accents.
+/// VS Code's default auto-closing set: the partner a typed opener/quote
+/// pairs with, `None` for everything else (closers included — they only
+/// type over).
+fn auto_close_partner(c: char) -> Option<char> {
+    match c {
+        '(' => Some(')'),
+        '[' => Some(']'),
+        '{' => Some('}'),
+        '"' => Some('"'),
+        '\'' => Some('\''),
+        '`' => Some('`'),
+        _ => None,
+    }
+}
+
+fn is_pair_closer(c: char) -> bool {
+    matches!(c, ')' | ']' | '}')
+}
+
+fn is_pair_quote(c: char) -> bool {
+    matches!(c, '"' | '\'' | '`')
+}
+
 fn conflict_row_tint(blocks: &[crate::merge::ConflictBlock], row: usize) -> Option<Color> {
     let block = blocks.iter().find(|b| b.contains(row))?;
     let ours_end = block.base_start.unwrap_or(block.sep);
@@ -18047,5 +18174,91 @@ mod tests {
             .map(|i| buf[(x1 + i, y1)].symbol().to_string())
             .collect();
         assert_eq!(shown, "bob", "tag falls back below on the top row");
+    }
+    // ---- Auto-closing pairs (#121) ----
+
+    #[test]
+    fn typing_an_opener_auto_closes_with_the_caret_between() {
+        let mut e = editor_with("fn main() ");
+        e.cursor_row = 0;
+        e.cursor_col = 10; // end of line
+        e.insert_char('{');
+        assert_eq!(e.lines[0], "fn main() {}");
+        assert_eq!(e.cursor_col, 11, "the caret sits between the pair");
+        // One undo removes BOTH characters.
+        e.undo();
+        assert_eq!(e.lines[0], "fn main() ");
+    }
+
+    #[test]
+    fn openers_do_not_auto_close_before_a_word_character() {
+        let mut e = editor_with("foo");
+        e.cursor_row = 0;
+        e.cursor_col = 0;
+        e.insert_char('(');
+        assert_eq!(
+            e.lines[0], "(foo",
+            "no closer may be jammed into the following word"
+        );
+    }
+
+    #[test]
+    fn typing_the_closer_steps_over_instead_of_inserting() {
+        let mut e = editor_with("");
+        e.insert_char('(');
+        assert_eq!(e.lines[0], "()");
+        e.insert_char(')');
+        assert_eq!(e.lines[0], "()", "the closer types over, never doubles");
+        assert_eq!(e.cursor_col, 2);
+    }
+
+    #[test]
+    fn an_apostrophe_inside_a_word_stays_single() {
+        let mut e = editor_with("don");
+        e.cursor_row = 0;
+        e.cursor_col = 3;
+        e.insert_char('\'');
+        assert_eq!(e.lines[0], "don'", "no auto-pair after a word character");
+    }
+
+    #[test]
+    fn typing_a_bracket_with_a_selection_surrounds_it() {
+        let mut e = editor_with("abc def");
+        e.cursor_row = 0;
+        e.selection = Some(EditorSelection {
+            anchor: (0, 0),
+            head: (0, 3),
+        }); // "abc"
+        e.insert_char('(');
+        assert_eq!(e.lines[0], "(abc) def");
+        let sel = e
+            .selection
+            .expect("the selection survives, on the inner text");
+        let ((sr, sc), (er, ec)) = sel.normalised();
+        assert_eq!((sr, sc, er, ec), (0, 1, 0, 4));
+        e.undo();
+        assert_eq!(e.lines[0], "abc def", "surround is one undo step");
+    }
+
+    #[test]
+    fn backspace_between_an_empty_pair_deletes_both() {
+        let mut e = editor_with("");
+        e.insert_char('(');
+        assert_eq!(e.lines[0], "()");
+        e.backspace();
+        assert_eq!(e.lines[0], "", "the empty pair dies together");
+    }
+
+    #[test]
+    fn the_toggle_disables_every_pair_behavior() {
+        let mut e = editor_with("");
+        e.auto_close_pairs = false;
+        e.insert_char('(');
+        assert_eq!(e.lines[0], "(", "off means plain inserts");
+        e.insert_char(')');
+        assert_eq!(e.lines[0], "()");
+        e.cursor_col = 1;
+        e.backspace();
+        assert_eq!(e.lines[0], ")", "off means plain backspace");
     }
 }


### PR DESCRIPTION
Fixes #121.

Auto-closing pairs — the most-used typing behavior in any modern editor, previously absent from croft entirely (`bracket_match` was display-only).

## What ships (VS Code's default semantics)

- **Auto-close**: `(` `[` `{` and quotes insert their pair with the caret between — openers guarded so a closer is never jammed into a following word; quotes additionally refuse after a word character or the same quote (the apostrophe-in-`don't` case). The pair is one undo step.
- **Type-over**: typing a closer or quote when that exact character sits at the caret advances over it — stateless, no provenance tracking, no undo entry (nothing changed).
- **Selection surround**: an opener or quote typed over a selection wraps it (multi-row included), the selection surviving on the inner text; one undo step.
- **Pair backspace**: backspace between an empty matched pair deletes both, so `(` then backspace round-trips to nothing.
- **Enter between braces** was already shipped (`is_bracket_pair_split`) — verified, not duplicated.
- **Toggle**: "Auto Closing Pairs" (default on) leads the settings gear's list, persisted as `disable_auto_close_pairs` (default-false keeps old configs valid), synced onto the editor beside the blame flag.

Scope note: the multi-caret typing path (`multi_insert_char`) keeps plain inserts in v1 — per-caret pair logic with column shifting is its own change.

## Tests (red first)

Seven behaviors pinned: auto-close with caret placement and single-step undo, the word-guard, type-over, the apostrophe case, surround with selection coordinates and undo, pair backspace, and the toggle disabling everything. One pre-existing guard test (settings first-row identity) updated for the new row order.

## Verified live

Typed `foo(` `"hi` `"` `)` in a real session → `foo("hi")` with both closers stepped over; backspaces collapsed it cleanly.

v0.1.712; release note replaced; KEYBINDINGS.md documents the behavior set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic closing for brackets, braces, parentheses, and quotes.
  * Typing over existing closers, wrapping selections, and deleting empty pairs are supported.
  * Added an “Auto Closing Pairs” setting, enabled by default and saved across sessions.
* **Documentation**
  * Documented auto-closing pair behavior and configuration options.
* **Release**
  * Updated release highlights and package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->