### PR TITLE
feat(search): workspace Replace All polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.712"
+version = "0.1.713"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.712"
+version = "0.1.713"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -157,8 +157,8 @@ All three live under `~/.config/croft/` (XDG-resolved, so the same paths on macO
 | Click `Aa` / `ab` / `.*` (inset at the right of the search field) | Toggle case-sensitive / whole-word / regex; active toggles show an accent chip |
 | Click the header refresh icon | Re-run the current query |
 | Click the header clear icon | Clear the search query and results |
-| Click the left chevron (`▸`/`▾`) | Expand / collapse the Replace row |
-| Type in Replace, then `Enter` or click the replace-all icon | Replace every match across all result files with the Replace text (regex mode honours `$1` capture references); the search re-runs afterward |
+| Click the left chevron (`▸`/`▾`) | Expand / collapse the Replace row (expanding focuses it); while a replacement is typed, every result row previews the match crossed out with the expanded replacement beside it |
+| Type in Replace, then `Enter` or click the replace-all icon | Raise the Replace All confirmation — "Replace N occurrence(s) across M file(s)?" — then `Enter`/`Y` rewrites on disk, `Esc` cancels (regex mode honours `$1` capture references); files open with unsaved changes are skipped and named, and the search re-runs afterward |
 | Click the `...` icon | Expand / collapse the "files to include" and "files to exclude" glob inputs |
 | Type globs into include / exclude | Restrict the search to / from matching files (comma-separated, VS Code style; a bare `*.rs` matches at any depth). Editing re-runs the search live |
 | `Tab` | Cycle focus through the visible inputs (search → replace → include → exclude) |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2929,9 +2929,10 @@ pub struct App {
     build_diag_files_by_pane: std::collections::HashMap<u64, Vec<PathBuf>>,
     /// True while the "Discard All Changes" confirmation modal is up.
     pub pending_discard_all: bool,
-    /// The Replace All confirmation (#123): `(occurrences, files)` counted
-    /// without writing; the modal shows them, Enter/Y commits, Esc cancels.
-    pending_replace_all: Option<(usize, usize)>,
+    /// The Replace All confirmation (#123): `(occurrences, files, dirty
+    /// files to be skipped)` counted without writing; the modal shows them,
+    /// Enter/Y commits, Esc cancels.
+    pending_replace_all: Option<(usize, usize, usize)>,
     /// Cached workspace file index. Built lazily on first Cmd+P and
     /// shared across reopens so repeated invocations are instant.
     file_finder_index: Option<std::sync::Arc<Vec<crate::widgets::file_finder::FileEntry>>>,
@@ -5414,6 +5415,7 @@ impl App {
     /// Clears the live result list so streamed `Hits` events accumulate
     /// from zero rather than appending to leftover hits from the prior query.
     fn submit_search_query(&mut self) {
+        self.search.complete = false;
         self.search.hits.clear();
         self.search.selected = 0;
         self.search.scroll = 0;
@@ -5464,7 +5466,12 @@ impl App {
                         applied = true;
                     }
                 }
-                SearchEvent::Done(_, _) => {}
+                SearchEvent::Done(q, opts) => {
+                    if q == self.search.query && opts == self.search.opts {
+                        self.search.complete = true;
+                        applied = true;
+                    }
+                }
             }
         }
         applied
@@ -12723,12 +12730,22 @@ impl App {
     /// The Replace All confirmation modal (#123): counts up front, commits
     /// on Enter/Y, cancels on Esc/N — the discard-all popup's shape.
     fn render_replace_all_confirm(&self, frame: &mut ratatui::Frame) {
-        let Some((occurrences, files)) = self.pending_replace_all else {
+        let Some((occurrences, files, skipped)) = self.pending_replace_all else {
             return;
         };
         let area = frame.area();
         let width = area.width.saturating_sub(8).clamp(50, 96);
-        let height: u16 = 7;
+        let prompt = format!(
+            "Replace {occurrences} occurrence(s) across {files} file(s) with \"{}\"?",
+            self.search.replace
+        );
+        // The prompt interpolates arbitrary user text: derive the height
+        // from its wrapped row count so the Enter/Esc hint can never fall
+        // below the border (#124 review).
+        let inner_w = width.saturating_sub(2);
+        let prompt_rows = wrap_cells_variable_width(&prompt, inner_w, inner_w).len() as u16;
+        let skipped_rows = u16::from(skipped > 0);
+        let height: u16 = 6 + prompt_rows + skipped_rows;
         let rect = Rect {
             x: (area.width.saturating_sub(width)) / 2 + area.x,
             y: (area.height.saturating_sub(height)) / 2 + area.y,
@@ -12750,19 +12767,21 @@ impl App {
         frame.render_widget(ratatui::widgets::Clear, rect);
         let inner = block.inner(rect);
         frame.render_widget(block, rect);
-        let lines = vec![
-            Line::from(format!(
-                "Replace {occurrences} occurrence(s) across {files} file(s) with \"{}\"?",
-                self.search.replace
-            )),
+        let mut lines = vec![
+            Line::from(prompt),
             Line::from(""),
-            Line::from("Files are rewritten on disk; open files with unsaved changes are skipped."),
-            Line::from(""),
-            Line::from(Span::styled(
-                "Enter / Y replaces \u{00b7} Esc cancels",
-                Style::default().fg(Color::Rgb(0x9a, 0xa4, 0xb8)),
-            )),
+            Line::from("Files are rewritten on disk."),
         ];
+        if skipped > 0 {
+            lines.push(Line::from(format!(
+                "{skipped} open file(s) with unsaved changes will be skipped."
+            )));
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Enter / Y replaces \u{00b7} Esc cancels",
+            Style::default().fg(Color::Rgb(0x9a, 0xa4, 0xb8)),
+        )));
         frame.render_widget(
             Paragraph::new(lines).wrap(ratatui::widgets::Wrap { trim: false }),
             inner,
@@ -14308,24 +14327,39 @@ impl App {
             self.status = String::from("Replace All: enter a search term first");
             return;
         }
+        if !self.search.complete {
+            // Hits stream in batches; replacing before Done would silently
+            // miss files found after confirmation (#124 review).
+            self.status =
+                String::from("Replace All: search still running — retry when it finishes");
+            return;
+        }
         // Count first, write only after the modal confirms: a workspace-wide
         // disk rewrite is exactly what the confirm-destructive rule is for
-        // (#123 — Enter used to commit instantly).
-        let (occurrences, files) = self.search.count_replacements();
-        if occurrences == 0 {
+        // (#123 — Enter used to commit instantly). Dirty-open files are
+        // excluded from the count too: the confirmed action skips them, and
+        // counting them made the modal overpromise.
+        let dirty = self.dirty_open_paths();
+        let (occurrences, files) = self.search.count_replacements(&dirty);
+        let skipped = self
+            .search
+            .hits
+            .iter()
+            .map(|h| &h.path)
+            .filter(|p| dirty.contains(*p))
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        if occurrences == 0 && skipped == 0 {
             self.status = String::from("Replace All: nothing to replace");
             return;
         }
-        self.pending_replace_all = Some((occurrences, files));
+        self.pending_replace_all = Some((occurrences, files, skipped));
     }
 
-    /// The confirmed Replace All: writes every hit file EXCEPT ones open
-    /// with unsaved edits — a disk write under a dirty buffer forces that
-    /// tab into conflict divergence, so those are skipped and named.
-    fn confirm_pending_replace_all(&mut self) {
-        self.pending_replace_all = None;
-        let dirty: std::collections::HashSet<PathBuf> = self
-            .editor
+    /// Every path open with unsaved edits, across the active group and all
+    /// inactive split leaves.
+    fn dirty_open_paths(&self) -> std::collections::HashSet<PathBuf> {
+        self.editor
             .editors
             .iter()
             .chain(
@@ -14336,7 +14370,15 @@ impl App {
             )
             .filter(|e| e.dirty)
             .filter_map(|e| e.path.clone())
-            .collect();
+            .collect()
+    }
+
+    /// The confirmed Replace All: writes every hit file EXCEPT ones open
+    /// with unsaved edits — a disk write under a dirty buffer forces that
+    /// tab into conflict divergence, so those are skipped and named.
+    fn confirm_pending_replace_all(&mut self) {
+        self.pending_replace_all = None;
+        let dirty = self.dirty_open_paths();
         let (n, skipped) = self.search.replace_all_skipping(&dirty);
         self.status = if skipped.is_empty() {
             format!("Replace All: replaced {n} occurrence(s)")

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2929,6 +2929,9 @@ pub struct App {
     build_diag_files_by_pane: std::collections::HashMap<u64, Vec<PathBuf>>,
     /// True while the "Discard All Changes" confirmation modal is up.
     pub pending_discard_all: bool,
+    /// The Replace All confirmation (#123): `(occurrences, files)` counted
+    /// without writing; the modal shows them, Enter/Y commits, Esc cancels.
+    pending_replace_all: Option<(usize, usize)>,
     /// Cached workspace file index. Built lazily on first Cmd+P and
     /// shared across reopens so repeated invocations are instant.
     file_finder_index: Option<std::sync::Arc<Vec<crate::widgets::file_finder::FileEntry>>>,
@@ -3841,6 +3844,7 @@ impl App {
             build_diagnostics: std::collections::HashMap::new(),
             build_diag_files_by_pane: std::collections::HashMap::new(),
             pending_discard_all: false,
+            pending_replace_all: None,
             file_finder_index: None,
             file_finder_index_rx: Some(file_finder_index_rx),
             file_finder_index_dirty: false,
@@ -12233,6 +12237,7 @@ impl App {
         self.render_discard_confirm(frame);
         self.render_revert_hunk_confirm(frame);
         self.render_discard_all_confirm(frame);
+        self.render_replace_all_confirm(frame);
         self.render_broadcast_confirm(frame);
         // Terminal-pane inline image: sync after the panes have painted so
         // last_inner and the scroll offset are this frame's (all gating —
@@ -12715,6 +12720,55 @@ impl App {
 
     /// Confirmation modal for "Discard All Changes" — reverts every tracked
     /// edit to HEAD, so it gets the same red Y/N gate as a single discard.
+    /// The Replace All confirmation modal (#123): counts up front, commits
+    /// on Enter/Y, cancels on Esc/N — the discard-all popup's shape.
+    fn render_replace_all_confirm(&self, frame: &mut ratatui::Frame) {
+        let Some((occurrences, files)) = self.pending_replace_all else {
+            return;
+        };
+        let area = frame.area();
+        let width = area.width.saturating_sub(8).clamp(50, 96);
+        let height: u16 = 7;
+        let rect = Rect {
+            x: (area.width.saturating_sub(width)) / 2 + area.x,
+            y: (area.height.saturating_sub(height)) / 2 + area.y,
+            width,
+            height,
+        };
+        let warn = Color::Rgb(0xe7, 0xa7, 0x3c);
+        let block = ratatui::widgets::Block::default()
+            .borders(ratatui::widgets::Borders::ALL)
+            .border_style(Style::default().fg(warn))
+            .style(Style::default().bg(Color::Rgb(0x1e, 0x1e, 0x1e)))
+            .title(ratatui::text::Span::styled(
+                " REPLACE ALL? ",
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(warn)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        frame.render_widget(ratatui::widgets::Clear, rect);
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
+        let lines = vec![
+            Line::from(format!(
+                "Replace {occurrences} occurrence(s) across {files} file(s) with \"{}\"?",
+                self.search.replace
+            )),
+            Line::from(""),
+            Line::from("Files are rewritten on disk; open files with unsaved changes are skipped."),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Enter / Y replaces \u{00b7} Esc cancels",
+                Style::default().fg(Color::Rgb(0x9a, 0xa4, 0xb8)),
+            )),
+        ];
+        frame.render_widget(
+            Paragraph::new(lines).wrap(ratatui::widgets::Wrap { trim: false }),
+            inner,
+        );
+    }
+
     fn render_discard_all_confirm(&self, frame: &mut ratatui::Frame) {
         if !self.pending_discard_all {
             return;
@@ -13725,6 +13779,18 @@ impl App {
             self.handle_list_picker_key(key);
             return Ok(());
         }
+        if self.pending_replace_all.is_some() {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                    self.confirm_pending_replace_all();
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                    self.cancel_pending_replace_all();
+                }
+                _ => {}
+            }
+            return Ok(());
+        }
         if self.pending_discard_all {
             match key.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
@@ -14242,13 +14308,60 @@ impl App {
             self.status = String::from("Replace All: enter a search term first");
             return;
         }
-        let n = self.search.replace_all_on_disk();
-        if n == 0 {
+        // Count first, write only after the modal confirms: a workspace-wide
+        // disk rewrite is exactly what the confirm-destructive rule is for
+        // (#123 — Enter used to commit instantly).
+        let (occurrences, files) = self.search.count_replacements();
+        if occurrences == 0 {
             self.status = String::from("Replace All: nothing to replace");
-        } else {
-            self.status = format!("Replace All: replaced {n} occurrence(s)");
+            return;
         }
+        self.pending_replace_all = Some((occurrences, files));
+    }
+
+    /// The confirmed Replace All: writes every hit file EXCEPT ones open
+    /// with unsaved edits — a disk write under a dirty buffer forces that
+    /// tab into conflict divergence, so those are skipped and named.
+    fn confirm_pending_replace_all(&mut self) {
+        self.pending_replace_all = None;
+        let dirty: std::collections::HashSet<PathBuf> = self
+            .editor
+            .editors
+            .iter()
+            .chain(
+                self.editor_layout
+                    .inactive_leaf_tabs()
+                    .into_iter()
+                    .flat_map(|tabs| tabs.editors.iter()),
+            )
+            .filter(|e| e.dirty)
+            .filter_map(|e| e.path.clone())
+            .collect();
+        let (n, skipped) = self.search.replace_all_skipping(&dirty);
+        self.status = if skipped.is_empty() {
+            format!("Replace All: replaced {n} occurrence(s)")
+        } else {
+            let names: Vec<String> = skipped
+                .iter()
+                .take(2)
+                .map(|p| self.status_path(p))
+                .collect();
+            let more = skipped.len().saturating_sub(names.len());
+            let list = if more > 0 {
+                format!("{} and {more} more", names.join(", "))
+            } else {
+                names.join(", ")
+            };
+            format!(
+                "Replace All: replaced {n} occurrence(s); skipped {list} (unsaved changes — save first)"
+            )
+        };
         self.submit_search_query();
+    }
+
+    fn cancel_pending_replace_all(&mut self) {
+        self.pending_replace_all = None;
+        self.status = String::from("Replace All cancelled");
     }
 
     fn handle_remote_key(&mut self, key: KeyEvent) {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -26050,10 +26050,18 @@ fn replace_all_requires_confirmation_and_esc_cancels() {
     app.search.run_query();
     assert_eq!(app.search.hits.len(), 2, "precondition: two hits");
 
+    // A still-streaming search refuses: hits arriving after confirmation
+    // would be silently missed.
+    app.search.complete = false;
+    app.run_search_replace_all();
+    assert!(app.pending_replace_all.is_none());
+    assert!(app.status.contains("still running"));
+
+    app.search.complete = true;
     app.run_search_replace_all();
     assert_eq!(
         app.pending_replace_all,
-        Some((2, 1)),
+        Some((2, 1, 0)),
         "Enter must raise the modal with counts, not write"
     );
     let disk = std::fs::read_to_string(tmp.path().join("a.txt")).unwrap();
@@ -26099,7 +26107,13 @@ fn replace_all_skips_files_open_with_unsaved_changes() {
     app.search.query = String::from("beta");
     app.search.replace = String::from("delta");
     app.search.run_query();
+    app.search.complete = true;
     app.run_search_replace_all();
+    assert_eq!(
+        app.pending_replace_all,
+        Some((1, 1, 1)),
+        "the modal counts exclude the dirty file and name the skip"
+    );
     app.handle_key(crossterm::event::KeyEvent::new(
         KeyCode::Enter,
         KeyModifiers::NONE,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -26038,3 +26038,87 @@ fn build_scan_installs_problems_replaces_per_pane_and_merges_with_lsp() {
     assert!(app.problems.groups().is_empty());
     assert!(app.status.contains("Cleared 1 build diagnostic"));
 }
+
+#[test]
+fn replace_all_requires_confirmation_and_esc_cancels() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "beta one\nbeta two\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.search.root = tmp.path().to_path_buf();
+    app.search.query = String::from("beta");
+    app.search.replace = String::from("delta");
+    app.search.run_query();
+    assert_eq!(app.search.hits.len(), 2, "precondition: two hits");
+
+    app.run_search_replace_all();
+    assert_eq!(
+        app.pending_replace_all,
+        Some((2, 1)),
+        "Enter must raise the modal with counts, not write"
+    );
+    let disk = std::fs::read_to_string(tmp.path().join("a.txt")).unwrap();
+    assert!(
+        disk.contains("beta"),
+        "nothing is written before confirmation"
+    );
+
+    app.handle_key(crossterm::event::KeyEvent::new(
+        KeyCode::Esc,
+        KeyModifiers::NONE,
+    ))
+    .unwrap();
+    assert!(app.pending_replace_all.is_none());
+    assert!(app.status.contains("cancelled"));
+    let disk = std::fs::read_to_string(tmp.path().join("a.txt")).unwrap();
+    assert!(disk.contains("beta"), "Esc leaves the files alone");
+
+    app.run_search_replace_all();
+    app.handle_key(crossterm::event::KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    ))
+    .unwrap();
+    let disk = std::fs::read_to_string(tmp.path().join("a.txt")).unwrap();
+    assert_eq!(disk, "delta one\ndelta two\n", "Enter commits the rewrite");
+    assert!(app.status.contains("replaced 2 occurrence"));
+}
+
+#[test]
+fn replace_all_skips_files_open_with_unsaved_changes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let clean = tmp.path().join("clean.txt");
+    let dirty = tmp.path().join("dirty.txt");
+    std::fs::write(&clean, "beta here\n").unwrap();
+    std::fs::write(&dirty, "beta there\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open_pinned(&dirty).unwrap();
+    app.editor.insert_char('x'); // unsaved edit
+    assert!(app.editor.dirty);
+
+    app.search.root = tmp.path().to_path_buf();
+    app.search.query = String::from("beta");
+    app.search.replace = String::from("delta");
+    app.search.run_query();
+    app.run_search_replace_all();
+    app.handle_key(crossterm::event::KeyEvent::new(
+        KeyCode::Enter,
+        KeyModifiers::NONE,
+    ))
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&clean).unwrap(),
+        "delta here\n",
+        "the clean file is rewritten"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&dirty).unwrap(),
+        "beta there\n",
+        "the dirty-open file is untouched on disk"
+    );
+    assert!(
+        app.status.contains("skipped dirty.txt") && app.status.contains("unsaved"),
+        "the skip is named; was {:?}",
+        app.status
+    );
+}

--- a/src/collab.rs
+++ b/src/collab.rs
@@ -2183,7 +2183,15 @@ mod tests {
             "a healthy idle channel must not read as dead"
         );
         drop(peer); // the relay dies
-        let _ = session.poll(|_| None);
+        // The hangup is the KERNEL's to deliver: on a loaded box a single
+        // nonblocking poll can land before the EOF is readable and observe
+        // nothing (#125, twice on CI). Poll until the latch flips or a real
+        // deadline passes — the state-gated wait #109/#110 established.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !session.disconnected() && std::time::Instant::now() < deadline {
+            let _ = session.poll(|_| None);
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
         assert!(
             session.disconnected(),
             "EOF from the relay must mark the session disconnected"

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Feature,
-    summary: "Brackets and quotes now auto-close as you type: the caret lands inside the pair, typing the closer steps over it, a selection gets surrounded, and backspace inside an empty pair removes both — toggleable in the settings gear.",
+    summary: "Workspace Replace All grew up: expanding the Replace row focuses it, every result previews the match crossed out with its replacement beside it, a confirmation counts occurrences and files before anything is rewritten, and files with unsaved changes are skipped by name.",
 }];

--- a/src/widgets/editor_find.rs
+++ b/src/widgets/editor_find.rs
@@ -40,7 +40,10 @@ pub fn line_matches(line: &str, opts: SearchOpts, needle: &str) -> Vec<(usize, u
     let mut col_chars = 0usize;
     for (chunk, is_match) in split_for_highlight(line, needle, opts) {
         let chunk_chars = chunk.chars().count();
-        if is_match {
+        // Zero-width matches are invisible: nothing to paint, count, or
+        // step to — the find bar's layer skips them even though the split
+        // now reports them (the workspace replace preview needs them).
+        if is_match && chunk_chars > 0 {
             out.push((col_chars, chunk_chars));
         }
         col_chars = col_chars.saturating_add(chunk_chars);
@@ -268,7 +271,10 @@ pub fn replace_all_in_lines(
         // Byte offset of the current segment in `line`, for captures_at.
         let mut pos = 0usize;
         for (chunk, is_match) in &segs {
-            if !is_match {
+            if !is_match || chunk.is_empty() {
+                // Zero-width matches stay unreplaced in the find bar (the
+                // highlighter shows nothing there); the empty chunk still
+                // contributes no text.
                 new.push_str(chunk);
             } else {
                 total += 1;

--- a/src/widgets/search.rs
+++ b/src/widgets/search.rs
@@ -683,6 +683,25 @@ pub fn replace_in_text(
     Some((out, count))
 }
 
+/// Expand the replacement for ONE matched slice — regex capture references
+/// (`$1`, `${name}`) honoured in regex mode, verbatim otherwise. Drives the
+/// result rows' inline old→new preview (#123).
+pub fn expand_replacement(
+    matched: &str,
+    query: &str,
+    replacement: &str,
+    opts: SearchOpts,
+) -> String {
+    let Some(re) = build_replace_regex(query, opts) else {
+        return replacement.to_string();
+    };
+    if opts.use_regex {
+        re.replace(matched, replacement).into_owned()
+    } else {
+        replacement.to_string()
+    }
+}
+
 /// Replace every match in the file at `path` on disk, writing the result back
 /// only when at least one replacement was made. Returns the number of matches
 /// replaced, or `None` when the file can't be read, the pattern can't compile,
@@ -1096,7 +1115,12 @@ impl SearchPanel {
     /// falls back to the Query field.
     pub fn toggle_replace(&mut self) {
         self.replace_open = !self.replace_open;
-        if !self.replace_open && self.field == SearchField::Replace {
+        if self.replace_open {
+            // VS Code focuses the revealed input; leaving focus in the
+            // query made the next keystrokes silently extend the search
+            // (#123).
+            self.focus_field(SearchField::Replace);
+        } else if self.field == SearchField::Replace {
             self.focus_field(SearchField::Query);
         }
     }
@@ -1228,6 +1252,59 @@ impl SearchPanel {
             }
         }
         total
+    }
+
+    /// Count what Replace All WOULD do — `(occurrences, files)` — without
+    /// writing anything. Feeds the confirmation modal (#123).
+    pub fn count_replacements(&self) -> (usize, usize) {
+        let needle = self.query.trim();
+        if needle.is_empty() {
+            return (0, 0);
+        }
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+        let mut occurrences = 0usize;
+        let mut files = 0usize;
+        for hit in &self.hits {
+            if !seen.insert(hit.path.clone()) {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&hit.path) else {
+                continue;
+            };
+            if let Some((_, n)) = replace_in_text(&content, needle, &self.replace, self.opts)
+                && n > 0
+            {
+                occurrences += n;
+                files += 1;
+            }
+        }
+        (occurrences, files)
+    }
+
+    /// Replace All, skipping `skip` (files open with unsaved edits — a disk
+    /// write under a dirty buffer forces the tab into conflict divergence).
+    /// Returns `(occurrences replaced, the skipped hit files)`.
+    pub fn replace_all_skipping(&self, skip: &HashSet<PathBuf>) -> (usize, Vec<PathBuf>) {
+        let needle = self.query.trim();
+        if needle.is_empty() {
+            return (0, Vec::new());
+        }
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+        let mut total = 0usize;
+        let mut skipped = Vec::new();
+        for hit in &self.hits {
+            if !seen.insert(hit.path.clone()) {
+                continue;
+            }
+            if skip.contains(&hit.path) {
+                skipped.push(hit.path.clone());
+                continue;
+            }
+            if let Some(n) = replace_in_file(&hit.path, needle, &self.replace, self.opts) {
+                total += n;
+            }
+        }
+        (total, skipped)
     }
 
     /// Run the current query, store the results, and reset selection.
@@ -1733,7 +1810,7 @@ impl Widget for &mut SearchPanel {
                     fill_right: replace_fill_right,
                     lead_glyph: Some(&crate::icons::SEARCH_REPLACE.to_string()),
                     text: &self.replace,
-                    placeholder: "Replace",
+                    placeholder: "Replace (Tab switches)",
                     selection: if self.field == SearchField::Replace {
                         self.active_selection()
                     } else {
@@ -1977,7 +2054,28 @@ impl Widget for &mut SearchPanel {
                     Style::default().fg(Color::Rgb(0xeb, 0xcb, 0x8b)),
                 ),
             ];
+            // Inline replace preview (#123): while a replacement is typed,
+            // each match renders dim and crossed out with the expanded
+            // replacement (capture refs honoured) in green beside it — the
+            // bad-pattern catch before Replace All commits anything.
+            let preview = self.replace_open && !self.replace.is_empty();
             for (chunk, is_match) in split_for_highlight(&hit.line_text, needle, self.opts) {
+                if is_match && preview {
+                    let new_text = expand_replacement(&chunk, needle, &self.replace, self.opts);
+                    spans.push(Span::styled(
+                        chunk,
+                        Style::default()
+                            .fg(Color::Rgb(0x8b, 0x93, 0xa5))
+                            .add_modifier(Modifier::CROSSED_OUT),
+                    ));
+                    spans.push(Span::styled(
+                        new_text,
+                        Style::default()
+                            .fg(Color::Rgb(0xb6, 0xee, 0xc4))
+                            .add_modifier(Modifier::BOLD),
+                    ));
+                    continue;
+                }
                 spans.push(Span::styled(
                     chunk,
                     if is_match {
@@ -3570,5 +3668,37 @@ mod tests {
             panel.results_start_offset, 5,
             "collapsed layout starts results at the 5-row offset"
         );
+    }
+    #[test]
+    fn expand_replacement_honours_capture_references_in_regex_mode() {
+        let opts = SearchOpts {
+            use_regex: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            expand_replacement("beta_42", r"beta_(\d+)", "id-$1", opts),
+            "id-42",
+            "regex mode expands $1 against the matched slice"
+        );
+        let literal = SearchOpts::default();
+        assert_eq!(
+            expand_replacement("beta", "beta", "x$1y", literal),
+            "x$1y",
+            "literal mode inserts the replacement verbatim"
+        );
+    }
+
+    #[test]
+    fn toggling_replace_open_focuses_the_replace_input() {
+        let mut panel = SearchPanel::new(PathBuf::from("/tmp"));
+        assert_eq!(panel.field, SearchField::Query);
+        panel.toggle_replace();
+        assert_eq!(
+            panel.field,
+            SearchField::Replace,
+            "revealing the row must focus it — typing used to extend the query"
+        );
+        panel.toggle_replace();
+        assert_eq!(panel.field, SearchField::Query, "collapsing returns focus");
     }
 }

--- a/src/widgets/search.rs
+++ b/src/widgets/search.rs
@@ -412,9 +412,14 @@ fn split_for_highlight_regex(line: &str, needle: &str, opts: SearchOpts) -> Vec<
         if m.start() > last {
             out.push((line[last..m.start()].to_string(), false));
         }
-        // Empty matches (`.*` against an empty position) would loop
-        // forever; advance past them.
+        // Zero-width matches (`\b`, `^`) still count as match positions —
+        // the replace preview inserts the expansion there, mirroring what
+        // `replace_in_text` writes — and `last` must advance regardless, or
+        // the text before the NEXT match re-emits and the row doubles
+        // ("foofoo" for `\b` on "foo"; #124 review).
         if m.end() == m.start() {
+            out.push((String::new(), true));
+            last = m.end();
             continue;
         }
         out.push((line[m.start()..m.end()].to_string(), true));
@@ -794,6 +799,10 @@ pub struct SearchPanel {
     /// Which input field currently receives typed characters. Tab cycles
     /// through the visible fields; clicking an input focuses it directly.
     pub field: SearchField,
+    /// True once the worker's `Done` for the CURRENT query has drained:
+    /// Replace All refuses while hits are still streaming, or files found
+    /// after confirmation would be silently missed (#124 review).
+    pub complete: bool,
     /// Selection range within the currently focused field's text.
     pub field_selection: Option<(usize, usize)>,
 
@@ -871,6 +880,7 @@ impl SearchPanel {
             replace_open: false,
             details_open: false,
             field: SearchField::Query,
+            complete: false,
             field_selection: None,
             chevron_x: 0,
             chevron_y: 0,
@@ -1256,7 +1266,7 @@ impl SearchPanel {
 
     /// Count what Replace All WOULD do — `(occurrences, files)` — without
     /// writing anything. Feeds the confirmation modal (#123).
-    pub fn count_replacements(&self) -> (usize, usize) {
+    pub fn count_replacements(&self, skip: &HashSet<PathBuf>) -> (usize, usize) {
         let needle = self.query.trim();
         if needle.is_empty() {
             return (0, 0);
@@ -1266,6 +1276,11 @@ impl SearchPanel {
         let mut files = 0usize;
         for hit in &self.hits {
             if !seen.insert(hit.path.clone()) {
+                continue;
+            }
+            if skip.contains(&hit.path) {
+                // The confirmed action will not touch these; counting them
+                // made the modal overpromise (#124 review).
                 continue;
             }
             let Ok(content) = std::fs::read_to_string(&hit.path) else {
@@ -3700,5 +3715,23 @@ mod tests {
         );
         panel.toggle_replace();
         assert_eq!(panel.field, SearchField::Query, "collapsing returns focus");
+    }
+    #[test]
+    fn zero_width_regex_matches_advance_and_mark_positions() {
+        let opts = SearchOpts {
+            use_regex: true,
+            ..Default::default()
+        };
+        let segs = split_for_highlight("foo", r"\b", opts);
+        // Two boundary positions, the text emitted exactly once between
+        // them — the old code re-emitted it and rows doubled ("foofoo").
+        assert_eq!(
+            segs,
+            vec![
+                (String::new(), true),
+                (String::from("foo"), false),
+                (String::new(), true),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Fixes #123. Fixes #125.

Workspace Replace All polish — four gaps found by driving the existing flow live, each fixed with its own test.

## What ships

- **Confirmation before the rewrite**: Enter (or the replace-all icon) now counts first — `count_replacements` reads every unique hit file without writing — and raises a modal: "Replace N occurrence(s) across M file(s) with …?". `Enter`/`Y` commits, `Esc` cancels. Previously Enter rewrote every hit file on disk instantly, against croft's own confirm-destructive rule (observed live: 4 occurrences gone the moment Enter landed).
- **Inline preview**: while a replacement is typed, every result row renders the match crossed out and dim with the expanded replacement beside it in green — `expand_replacement` honours `$1`/`${name}` capture references per match in regex mode — the bad-pattern catch before anything commits.
- **Focus handoff**: expanding the Replace row focuses it (typing used to keep extending the query — observed: "betadelta", 0 matches); collapsing returns focus; the ghost text teaches the Tab switch.
- **Dirty-buffer safety**: the confirmed rewrite skips files open with unsaved edits anywhere (active group or split leaves, via `inactive_leaf_tabs`) and names them in the status — a disk write under a dirty buffer forces that tab into conflict divergence. Clean and closed files rewrite as before.

## Tests

App-level: the confirm flow (modal raised with counts, nothing written; Esc leaves disk alone; Enter commits) and the dirty-skip (clean file rewritten, dirty-open file untouched and named). Widget-level: toggle-focuses-replace and `expand_replacement` capture semantics.

## Verified live

Toggle → typing landed in the replace input directly; rows previewed `beta`→`delta` inline; Enter raised the modal with "4 occurrence(s) across 1 file(s)"; Esc left the file intact ("Replace All cancelled"); Enter+Enter rewrote it ("replaced 4 occurrence(s)").

v0.1.713; release note replaced; KEYBINDINGS.md rows updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation before applying Replace All, with match and file counts.
  * Supports keyboard confirmation or cancellation.
  * Shows inline replacement previews, including regex capture substitutions.
  * Skips files with unsaved changes and reports which files were skipped.
  * Automatically re-runs the search after replacements.
* **Documentation**
  * Updated search sidebar guidance for Replace All behavior.
* **Chores**
  * Incremented the package version to 0.1.713.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Rider: CI failed the same run twice on `a_dead_relay_marks_the_session_disconnected` — a single nonblocking poll racing the kernel's EOF delivery (green 5/5 locally; this branch's added tests shifted CI's parallel scheduling into the window). Filed as #125 and hardened here with the #109/#110 state-gated wait: poll until the disconnect latch flips or a 5s deadline.
