### PR TITLE
fix(explorer): sticky band vs drag-and-drop and drag-selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.713"
+version = "0.1.714"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.713"
+version = "0.1.714"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -28036,8 +28036,12 @@ impl App {
                             // range-extend from the initial anchor — just like
                             // VS Code's drag-to-select.
                             if self.tree_drag.as_ref().is_none_or(|d| !d.armed)
+                                && self.tree.sticky_row_at(m.row).is_none()
                                 && let Some(idx) = self.tree.node_at_y(m.row)
                             {
+                                // Never extend the selection onto rows the
+                                // sticky band covers — they are invisible
+                                // under it (#126).
                                 self.tree.select(idx);
                             }
                         }
@@ -33279,7 +33283,10 @@ fn drag_target_index(
     y: u16,
     drag_paths: &[PathBuf],
 ) -> Option<usize> {
-    let idx = tree.node_at_y(y)?;
+    // The sticky band wins the row resolution: a drop on a pinned ancestor
+    // targets THAT directory, not whatever row the band covers (#126 — files
+    // used to land in the covered row's directory, silently).
+    let idx = tree.sticky_row_at(y).or_else(|| tree.node_at_y(y))?;
     let node = tree.nodes.get(idx)?;
     let dir_idx = if node.is_dir {
         idx

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -26136,3 +26136,67 @@ fn replace_all_skips_files_open_with_unsaved_changes() {
         app.status
     );
 }
+
+#[test]
+fn drag_target_over_the_sticky_band_is_the_pinned_directory() {
+    use crossterm::event::{MouseButton, MouseEventKind};
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("outer/inner")).unwrap();
+    for i in 0..25 {
+        std::fs::write(tmp.path().join(format!("outer/inner/f{i:02}.rs")), "x\n").unwrap();
+    }
+    std::fs::write(tmp.path().join("loose.txt"), "x\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    let outer = app
+        .tree
+        .nodes
+        .iter()
+        .position(|n| n.path.ends_with("outer"))
+        .unwrap();
+    app.tree.selected = outer;
+    app.tree.expand_selected();
+    let inner = app
+        .tree
+        .nodes
+        .iter()
+        .position(|n| n.path.ends_with("inner"))
+        .unwrap();
+    app.tree.selected = inner;
+    app.tree.expand_selected();
+    // Scroll deep so the band pins ancestors, selection far below.
+    let deep = app
+        .tree
+        .nodes
+        .iter()
+        .position(|n| n.path.ends_with("f20.rs"))
+        .unwrap();
+    app.tree.selected = deep;
+    app.tree.scroll = deep.saturating_sub(3);
+    let backend = ratatui::backend::TestBackend::new(120, 20);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    term.draw(|f| app.render(f)).unwrap();
+    let (band_y, pinned_idx) = {
+        let rows = app.tree.sticky_rows_for_test();
+        // The MIDDLE pinned row ("outer") is where the behaviors diverge:
+        // the outermost is the workspace root (dropping a root-level file
+        // into its own parent is correctly refused), and the deepest
+        // ("inner") coincides with the covered rows' parent, where the old
+        // sticky-blind resolution accidentally agreed.
+        assert!(rows.len() >= 3, "band must pin root/outer/inner here");
+        rows[1]
+    };
+    let loose = tmp.path().join("loose.txt");
+    let target = drag_target_index(&app.tree, band_y, std::slice::from_ref(&loose))
+        .expect("a pinned directory is a valid drop target");
+    assert_eq!(
+        target, pinned_idx,
+        "the drop target under the band is the PINNED directory, not the covered row"
+    );
+    let covered = app.tree.node_at_y(band_y);
+    assert_ne!(
+        covered,
+        Some(target),
+        "precondition: the band actually covers a different row there"
+    );
+    let _ = MouseEventKind::Down(MouseButton::Left); // silence unused import paths on some cfgs
+}

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Feature,
-    summary: "Workspace Replace All grew up: expanding the Replace row focuses it, every result previews the match crossed out with its replacement beside it, a confirmation counts occurrences and files before anything is rewritten, and files with unsaved changes are skipped by name.",
+    summary: "Dragging files onto the Explorer's pinned sticky rows now drops into the pinned directory itself — previously the drop silently targeted whatever row the band covered — and drag-selection no longer extends onto rows hidden under the band.",
 }];

--- a/src/widgets/file_tree.rs
+++ b/src/widgets/file_tree.rs
@@ -528,6 +528,12 @@ impl FileTree {
         (0..self.nodes.len()).collect()
     }
 
+    /// Test-only view of the band painted this frame.
+    #[cfg(test)]
+    pub fn sticky_rows_for_test(&self) -> &[(u16, usize)] {
+        &self.sticky_rows
+    }
+
     /// Map a click on the sticky band to the pinned directory's node index.
     pub fn sticky_row_at(&self, y: u16) -> Option<usize> {
         self.sticky_rows


### PR DESCRIPTION
Fixes #126.

The integration hunt's first find: #117's sticky-band click fixes covered both mouse-Down arms, but two more tree mouse paths still resolved rows through `node_at_y` alone —

- **Drag-and-drop**: `drag_target_index` now resolves `sticky_row_at` first, so dropping files on a pinned ancestor targets THAT directory. Previously the drop silently landed in the directory of whatever row the band covered — a wrong-directory file move with no feedback.
- **Drag-selection extend**: the held-button motion path skips rows under the band instead of extending the selection onto rows that cannot be seen.

## Test

`drag_target_over_the_sticky_band_is_the_pinned_directory` renders a deep tree with the band pinning root/outer/inner and resolves a drop on the **middle** pinned row — chosen deliberately: the outermost is the root (own-parent drops are refused by existing validation) and the deepest coincides with the covered rows' parent, where the old resolution accidentally agreed. Verified green → red (fix neutralized) → green.

v0.1.714; release note replaced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drag-and-drop behavior in the Explorer when interacting with pinned directory rows.
  - Drops on the sticky directory band now target the pinned directory instead of an underlying tree row.
  - Drag selection no longer extends into rows hidden beneath the sticky band.

- **Tests**
  - Added regression coverage to verify correct drop targeting and sticky-row behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->