### PR TITLE
fix(editor): show the caret on blank lines and at end-of-line in soft-wrap mode (v0.1.715)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.714"
+version = "0.1.715"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.714"
+version = "0.1.715"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Feature,
-    summary: "Dragging files onto the Explorer's pinned sticky rows now drops into the pinned directory itself — previously the drop silently targeted whatever row the band covered — and drag-selection no longer extends onto rows hidden under the band.",
+    kind: NoteKind::Fix,
+    summary: "The blinking caret no longer disappears on blank lines or at the end of a line in soft-wrap mode (Markdown), so you can always see where you are typing.",
 }];

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -14789,6 +14789,41 @@ mod tests {
     }
 
     #[test]
+    fn cursor_screen_pos_wrap_zero_width_column_rejects_out_of_pane_cells() {
+        // A pane narrow enough leaves a zero-width wrap column, where
+        // wrap_segments degenerates to one whole-line segment: a caret deep
+        // in the line would compute a cell far past the pane's right edge
+        // (across the scrollbar column and beyond). The right-edge clamp
+        // must reject it, not paint it. With any nonzero column width the
+        // segments are capped at that width, so this degenerate layout is
+        // the only way an accepted caret can reach the clamp.
+        let mut e = editor_with("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        e.wrap_override = Some(true);
+        e.focused = true;
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 8,
+            height: 5,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e).render(area, &mut buf);
+        let (_, start, end) = e.text_row(0).expect("a text row");
+        assert_eq!(
+            (start, end),
+            (0, 40),
+            "expected the zero-width degenerate one-segment layout"
+        );
+        e.cursor_row = 0;
+        e.cursor_col = 20;
+        assert_eq!(
+            e.cursor_screen_pos(),
+            None,
+            "a caret cell past the pane edge must not be painted"
+        );
+    }
+
+    #[test]
     fn cursor_screen_pos_returns_none_when_scrolled_off() {
         let mut e = editor_with_lines(50);
         e.last_inner = Rect {

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -8401,12 +8401,20 @@ impl Editor {
                             || (self.cursor_col == *end
                                 && *end == self.line_char_len(*line))))
             })?;
-            let (_, start, end) = self.text_row(idx)?;
+            let (_, start, _) = self.text_row(idx)?;
+            // The caret is valid on every cell of the segment AND one past
+            // its last cell (end of line / blank line — where the user is
+            // about to type). Bail only when the cell would fall outside the
+            // text column: past the pane edge or onto the vertical scrollbar.
             let visible_col = self.cursor_col - start;
-            if end == start || visible_col >= end - start {
+            let x = text_x as usize + visible_col;
+            let right = (self.last_inner.x + self.last_inner.width)
+                .saturating_sub(u16::from(self.last_scrollbar.width > 0))
+                as usize;
+            if x >= right {
                 return None;
             }
-            return Some((text_x + visible_col as u16, self.last_inner.y + idx as u16));
+            return Some((x as u16, self.last_inner.y + idx as u16));
         }
         // Non-wrap: one row per line, horizontally scrolled by `scroll_col`;
         // comment boxes shift the rows below them, so map through the
@@ -14694,6 +14702,90 @@ mod tests {
         // text_x = inner.x + gutter + 1 = 5 + 2 + 1 = 8
         // cy = inner.y + (cursor_row - scroll) = 7 + 1 = 8
         assert_eq!(e.cursor_screen_pos(), Some((8 + 3, 8)));
+    }
+
+    #[test]
+    fn cursor_screen_pos_wrap_shows_caret_on_blank_line() {
+        // Regression: in soft-wrap mode (the Markdown default) the caret
+        // vanished on an empty line — the row's segment is (start 0, end 0)
+        // and the old guard bailed on `end == start`, so the user typed
+        // blind on every blank line.
+        let mut e = editor_with("hello\n\nworld");
+        e.wrap_override = Some(true);
+        e.focused = true;
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 30,
+            height: 6,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e).render(area, &mut buf);
+        e.cursor_row = 1;
+        e.cursor_col = 0;
+        let text_x = e.last_inner.x + e.last_gutter_width + 1;
+        assert_eq!(
+            e.cursor_screen_pos(),
+            Some((text_x, e.last_inner.y + 1)),
+            "the caret must be visible on a blank line in wrap mode"
+        );
+    }
+
+    #[test]
+    fn cursor_screen_pos_wrap_shows_caret_at_end_of_line() {
+        // Regression: typing at the end of a line in wrap mode hid the
+        // caret — `cursor_col == end == line length` is accepted by the
+        // row matcher but was then rejected by the old
+        // `visible_col >= end - start` guard.
+        let mut e = editor_with("hello\nworld");
+        e.wrap_override = Some(true);
+        e.focused = true;
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 30,
+            height: 6,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e).render(area, &mut buf);
+        e.cursor_row = 0;
+        e.cursor_col = 5;
+        let text_x = e.last_inner.x + e.last_gutter_width + 1;
+        assert_eq!(
+            e.cursor_screen_pos(),
+            Some((text_x + 5, e.last_inner.y)),
+            "the caret must be visible one past the last character in wrap mode"
+        );
+    }
+
+    #[test]
+    fn cursor_screen_pos_wrap_boundary_still_maps_to_next_row_start() {
+        // A caret on a wrap boundary belongs to the NEXT visual row's first
+        // cell, never one past the previous row's last cell.
+        let mut e = editor_with("aaaa bbbb cccc dddd eeee ffff gggg hhhh");
+        e.wrap_override = Some(true);
+        e.focused = true;
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 6,
+        };
+        let mut buf = ratatui::buffer::Buffer::empty(area);
+        (&mut e).render(area, &mut buf);
+        // Find the second visual row's start and put the caret exactly there
+        // (the first row's `end`).
+        let Some((_, start, _)) = e.text_row(1) else {
+            panic!("expected a wrapped second row");
+        };
+        e.cursor_row = 0;
+        e.cursor_col = start;
+        let text_x = e.last_inner.x + e.last_gutter_width + 1;
+        assert_eq!(
+            e.cursor_screen_pos(),
+            Some((text_x, e.last_inner.y + 1)),
+            "a wrap-boundary caret must land on the next row's first cell"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In soft-wrap mode (on by default for Markdown) the blinking caret disappears whenever it sits on a blank line or one past the last character of a line — exactly where you are about to type. The editor blinks the hardware caret by calling `frame.set_cursor_position` only when `cursor_screen_pos()` returns a cell; the wrap branch's guard

```rust
if end == start || visible_col >= end - start {
    return None;
}
```

rejects the two positions the row matcher just above deliberately accepts: an empty visual row (`start == end`, a blank line) and the end-of-line caret (`cursor_col == end == line_char_len`). Non-wrap files clamp against the text width instead, which is why only Markdown showed the bug.

## Fix

Replace the guard with the check it was standing in for: return `None` only when the caret cell would fall outside the text column — past the pane edge or onto the vertical scrollbar. Mid-segment cells are unaffected; the end-of-segment caret now lands on the cell after the last character, matching the non-wrap branch and VS Code. This also fixes a latent overflow where a zero-width wrap column could compute a caret cell far past the pane (the old guard let `visible_col` run up to the full segment length).

## Tests

Red/green: two regression tests (`cursor_screen_pos_wrap_shows_caret_on_blank_line`, `cursor_screen_pos_wrap_shows_caret_at_end_of_line`) failed with `None` before the fix and pass after; a third (`cursor_screen_pos_wrap_boundary_still_maps_to_next_row_start`) pins that a wrap-boundary caret still maps to the next row's first cell rather than one past the previous row. Full suite: 3113 passed, clippy clean, fmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caret positioning in wrapped Markdown text, including empty lines, line endings, and wrap boundaries.
  * Fixed caret visibility and placement when editing soft-wrapped content.
  * Added safeguards to prevent caret placement outside the available text area.

* **Release**
  * Updated the application version to 0.1.715.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->