### PR TITLE
fix(terminal): fail safe when the foreground sample fails on a live pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.729"
+version = "0.1.730"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.729"
+version = "0.1.730"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "The terminal-session store can no longer lose your other workspaces' saved pane layouts: an existing store file that cannot be read or parsed refuses updates (with the failure shown beside the action's status) instead of being silently replaced, concurrent windows serialize their saves, and writes land atomically.",
+    summary: "A momentary failure to sample the terminal's foreground process can no longer make croft treat a busy pane as idle: the check retries and then fails safe, so a workspace re-root never types a cd into a running application, and task panes are never reused mid-command.",
 }];

--- a/src/widgets/terminal.rs
+++ b/src/widgets/terminal.rs
@@ -3006,9 +3006,10 @@ impl PtyTerminal {
     pub fn foreground_is_shell(&self) -> bool {
         match (self.master.process_group_leader(), self.shell_pid) {
             (Some(fg), Some(pid)) => fg == pid,
-            (None, Some(_)) if self.input_seen => {
+            _ if self.input_seen => {
                 // A pane that has received input CAN be running a launched
-                // app, so a failed tcgetpgrp sample must not read as
+                // app, so an UNRESOLVABLE sample (failed tcgetpgrp, or a
+                // spawn that never reported a shell pid) must not read as
                 // "shell owns it" — under scheduler load the sample
                 // transiently fails while a foreground command runs, and
                 // the old blanket `true` let a cd seed reach that app

--- a/src/widgets/terminal.rs
+++ b/src/widgets/terminal.rs
@@ -3006,6 +3006,25 @@ impl PtyTerminal {
     pub fn foreground_is_shell(&self) -> bool {
         match (self.master.process_group_leader(), self.shell_pid) {
             (Some(fg), Some(pid)) => fg == pid,
+            (None, Some(_)) if self.input_seen => {
+                // A pane that has received input CAN be running a launched
+                // app, so a failed tcgetpgrp sample must not read as
+                // "shell owns it" — under scheduler load the sample
+                // transiently fails while a foreground command runs, and
+                // the old blanket `true` let a cd seed reach that app
+                // (#155). Retry once (the failure window is brief), then
+                // answer FALSE: every consumer fails safe on false (seed
+                // suppressed, task pane not reused, no prompt arrows).
+                std::thread::sleep(std::time::Duration::from_millis(5));
+                match (self.master.process_group_leader(), self.shell_pid) {
+                    (Some(fg), Some(pid)) => fg == pid,
+                    _ => false,
+                }
+            }
+            // Startup window: no input has ever been written, so nothing
+            // user-facing can own the tty yet — a missing group is the
+            // shell's own rc still claiming it, and a seed queues as
+            // type-ahead (#94).
             _ => true,
         }
     }


### PR DESCRIPTION
Fixes #155.

`foreground_is_shell` answered TRUE whenever `tcgetpgrp` sampled `None` — the deliberate carve-out for the startup window, where nothing user-facing can own the tty yet and a cd seed queues as harmless type-ahead (#94). But the same blanket default fired on a **live** pane whenever the sample transiently failed under scheduler load while a foreground command was running: `cwd_seed_is_safe` then reported safe and a workspace re-root could type its `cd` straight into the running application. The suite reproduced this roughly one loaded run in two as `change_workspace_root_skips_cd_when_terminal_runs_a_foreground_app` failing with the plain (unsuppressed) status.

The fix splits the arm: a pane that has **ever received input** retries the sample once (5ms — the failure window is brief) and then answers FALSE. Every consumer fails safe on false — the cd seed is suppressed with its "(terminal busy; shell not moved)" status, task panes are not reused mid-command, prompt-click arrows stay off. The never-touched startup pane keeps the type-ahead carve-out unchanged.

The race itself has no deterministic in-process reproduction (it needs the kernel sample to fail mid-command), so the evidence is the mechanism plus the suite: both prior-behavior tests (startup seed and busy suppress) pass, and the full loaded suite ran green. Clippy zero, fmt clean. v0.1.730, release note replaced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal activity detection by retrying foreground-process checks when needed.
  * Busy terminal panes are no longer incorrectly treated as idle after a failed check.
  * Prevented unsafe directory-change commands and accidental reuse of task panes while commands are still running.
  * Preserved safe startup behavior before a terminal has received input.

* **Documentation**
  * Updated release notes to reflect the terminal safety improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->