### PR TITLE
test(terminal): align the hyperlink test's PTY wait with the suite's 8s

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4808,13 +4808,15 @@ fn cmd_clicking_a_non_web_hyperlink_refuses_instead_of_opening() {
                 .map(|c| (r, c))
         })
     };
+    // 8s like the suite's other shell-startup waits (#165): a 5s cap
+    // missed under full parallel load while dozens of test shells spawn.
     let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(5000) && linked_cell(&app).is_none()
+    while started.elapsed() < std::time::Duration::from_millis(8000) && linked_cell(&app).is_none()
     {
         std::thread::sleep(std::time::Duration::from_millis(20));
     }
     term.draw(|f| app.render(f)).unwrap();
-    let (row_idx, col) = linked_cell(&app).expect("shell must print the linked text within 5s");
+    let (row_idx, col) = linked_cell(&app).expect("shell must print the linked text within 8s");
 
     let inner = app.terminal().last_inner;
     app.handle_mouse(crossterm::event::MouseEvent {


### PR DESCRIPTION
Fixes #165.

The hyperlink-refusal test waited at most 5 seconds for the test shell to print the linked text; every other shell-startup wait in the suite uses 8 seconds, and under a fully loaded parallel run (dozens of PTY shells spawning concurrently) the 5-second cap was observed missing once. Aligned to the suite's 8s convention with the mechanism documented at the wait.

Test-only; no version bump (the docs-only precedent). The test passes standalone and in the full suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell startup reliability by allowing additional time for startup operations to complete.
  * Updated timeout diagnostics to reflect the longer wait period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->