### PR TITLE
fix(pair,scm): make flaky timing tests deterministic, report dropped pair notes (v0.1.747)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.746"
+version = "0.1.747"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.746"
+version = "0.1.747"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8403,7 +8403,7 @@ fn a_graph_refresh_swallowed_by_an_inflight_fetch_refires_when_the_reply_drains(
     let tmp = tempfile::tempdir().unwrap();
     let mut app = App::new(tmp.path().to_path_buf()).unwrap();
     // Settle any startup fetch so the latch state is ours alone.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
     while app.graph_fetch_inflight {
         app.sync_explorer_panels();
         assert!(
@@ -8413,18 +8413,29 @@ fn a_graph_refresh_swallowed_by_an_inflight_fetch_refires_when_the_reply_drains(
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
 
-    // A fetch is mid-flight for the old root when a trigger arrives.
+    // A fetch is mid-flight for the old root when the trigger arrives; the
+    // root change has cleared the panel back to "Loading".
+    app.commit_graph.clear();
     app.graph_fetch_inflight = true;
     app.refresh_commit_graph();
     // The stale reply lands: dropped by the root tag.
     app.graph_tx
         .send((std::path::PathBuf::from("/since-left/root"), Vec::new()))
         .unwrap();
-    app.sync_explorer_panels();
-    assert!(
-        app.graph_fetch_inflight,
-        "the trigger swallowed during flight must re-fire once the stale reply drains"
-    );
+    // The re-fire is the contract, but the inflight latch is transient: the
+    // drain that re-fires can also drain the re-fired worker's reply in the
+    // SAME call (an empty root answers in microseconds), legitimately
+    // clearing the latch again. Poll the resolved outcome instead: the
+    // cleared panel must leave "Loading" with rows for the CURRENT root.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while !app.commit_graph.is_loaded() {
+        app.sync_explorer_panels();
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the trigger swallowed during flight must re-fire once the stale reply drains"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
 }
 
 #[test]

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -1525,6 +1525,14 @@ fn apply_fence_event(state: &Mutex<PairState>, event: FenceEvent) {
             // an edit gets. Still no live doc = the owner never served the
             // file: nothing to anchor to (mirrors the edit-drop path).
             if !wait_live(state, &file) {
+                diag(
+                    state,
+                    crate::output::OutputLevel::Warn,
+                    &format!(
+                        "[pair] no live croft session serves {file}; note dropped \
+                         (start croft in this workspace first)"
+                    ),
+                );
                 return;
             }
             let mut st = state.lock().unwrap();
@@ -2172,6 +2180,24 @@ mod tests {
         assert_eq!(system_prompt(&Provider::Claude), PAIR_SYSTEM_PROMPT);
     }
 
+    /// Bounded poll toward `expected` through a contention-lossy accessor,
+    /// returning the last value read. The host's UI-tick reads are
+    /// deliberately imprecise under momentary pump contention
+    /// (`notes_snapshot` serves its stale cache on a contended try_lock,
+    /// `is_busy` answers busy on a lost `lock_briefly` race), so a one-shot
+    /// read of a state-final value can flake on a starved runner. The
+    /// deadline only bounds a real regression.
+    fn settle<T: PartialEq>(expected: &T, mut read: impl FnMut() -> T) -> T {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        loop {
+            let got = read();
+            if &got == expected || Instant::now() >= deadline {
+                return got;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     /// A relay plus a pumping owner session that serves `demo.txt`,
     /// collecting every owner-side event for the assertions.
     struct OwnerHarness {
@@ -2474,7 +2500,10 @@ mod tests {
             assert!(Instant::now() < deadline, "TurnDone never arrived");
             std::thread::sleep(Duration::from_millis(5));
         }
-        assert!(!host.is_busy(), "consumed: the seat is idle again");
+        assert!(
+            !settle(&false, || host.is_busy()),
+            "consumed: the seat is idle again"
+        );
         drop(host);
     }
 
@@ -2489,12 +2518,20 @@ mod tests {
             return;
         }
         let harness = OwnerHarness::start("hello world");
-        // A child that exits immediately: the first send hits a dead stdin.
+        // A child whose stdin is dead by the time Died is observable: it
+        // closes stdin BEFORE stdout, so stdout's EOF (what fires Died)
+        // proves the write end already has no reader. A child that merely
+        // exits (`-c pass`) races process teardown: on a starved runner the
+        // reader sees stdout close while the process, and with it stdin's
+        // read end, is still winding down, and the send lands in the pipe
+        // buffer instead of failing. The sleep keeps the pid alive for the
+        // host's grace-kill teardown, like the real CLI's linger.
         let mut cmd = Command::new("python3");
-        cmd.arg("-c").arg("pass");
+        cmd.arg("-c")
+            .arg("import os,time; os.close(0); os.close(1); time.sleep(60)");
         let mut host =
             crate::pair_host::PairHost::spawn_cmd(&harness.socket, "nav", None, cmd).unwrap();
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(60);
         loop {
             if host
                 .poll()
@@ -2519,7 +2556,10 @@ mod tests {
             None,
             "a failed yield keeps no baseline"
         );
-        assert!(!host.is_busy(), "a failed yield keeps no busy latch");
+        assert!(
+            !settle(&false, || host.is_busy()),
+            "a failed yield keeps no busy latch"
+        );
         drop(host);
     }
 
@@ -4125,9 +4165,10 @@ mod tests {
         assert_eq!(note.0, "demo.txt");
         assert_eq!(note.1, 1, "anchored to the fenced row");
         assert!(note.2.contains("second line could be tighter"));
+        let expected = vec![(1, 1, "second line could be tighter".to_string())];
         assert_eq!(
-            host.notes_snapshot("demo.txt"),
-            vec![(1, 1, "second line could be tighter".to_string())],
+            settle(&expected, || host.notes_snapshot("demo.txt")),
+            expected,
             "(id, row, body): the first note of the seat gets id 1"
         );
         drop(host); // must not hang: the shutdown grace-kill path
@@ -4246,15 +4287,28 @@ mod tests {
             assert!(Instant::now() < deadline, "no TurnDone");
             std::thread::sleep(Duration::from_millis(10));
         }
-        let before = host.notes_snapshot("demo.txt");
-        assert_eq!(before.len(), 1, "the scripted note landed");
+        // The reader applies NoteEnd before it sends the TurnEnd, so note
+        // state is final here; the snapshot accessor is not exact under
+        // contention (see `settle`), so poll it to the resolved value.
+        let deadline = Instant::now() + Duration::from_secs(60);
+        let before = loop {
+            let snap = host.notes_snapshot("demo.txt");
+            if snap.len() == 1 {
+                break snap;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the scripted note landed: {snap:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        };
 
         // A follow-up turn targeting the same file: begin_turn runs
         // synchronously inside send_yield_turn.
         host.send_yield_turn("demo.txt", "hello world\nsecond line")
             .unwrap();
         assert_eq!(
-            host.notes_snapshot("demo.txt"),
+            settle(&before, || host.notes_snapshot("demo.txt")),
             before,
             "open boxes survive the next turn"
         );

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -1537,6 +1537,17 @@ fn apply_fence_event(state: &Mutex<PairState>, event: FenceEvent) {
             }
             let mut st = state.lock().unwrap();
             let Some(lines) = st.doc_lines(&file) else {
+                // The file left the live session between wait_live releasing
+                // the lock and this reacquisition: same outcome, same warning.
+                drop(st);
+                diag(
+                    state,
+                    crate::output::OutputLevel::Warn,
+                    &format!(
+                        "[pair] no live croft session serves {file}; note dropped \
+                         (start croft in this workspace first)"
+                    ),
+                );
                 return;
             };
             let offset = note_offset(&lines, row);
@@ -4143,13 +4154,23 @@ mod tests {
             crate::pair_host::PairHost::spawn_cmd(&harness.socket, "navigator", None, cmd).unwrap();
         host.send_task("@demo.txt look this over").unwrap();
 
+        // The reader queues NoteAdded (events channel) before TurnEnd (turn
+        // channel), but poll() drains events FIRST: the poll that surfaces
+        // TurnDone may have drained events before the note was queued, so
+        // wait until BOTH landed; the deadline bounds a real regression.
         let deadline = Instant::now() + Duration::from_secs(60);
         let mut events: Vec<crate::pair_host::PairEvent> = Vec::new();
-        while !events
+        while !(events
             .iter()
             .any(|e| matches!(e, crate::pair_host::PairEvent::TurnDone { .. }))
+            && events
+                .iter()
+                .any(|e| matches!(e, crate::pair_host::PairEvent::NoteAdded { .. })))
         {
-            assert!(Instant::now() < deadline, "no TurnDone; saw {events:?}");
+            assert!(
+                Instant::now() < deadline,
+                "no TurnDone + NoteAdded; saw {events:?}"
+            );
             events.extend(host.poll());
             std::thread::sleep(Duration::from_millis(10));
         }

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "An AI pair note that cannot anchor (no live session serves the file) is now reported in the output panel instead of vanishing silently, and the test suite's pair and commit-graph timing checks were made immune to loaded-runner scheduling.",
+    summary: "An AI pair note that cannot anchor (no live session serves the file) is now reported in the output panel instead of vanishing silently, and the test suite's pair and commit-graph timing checks were stabilized with bounded polling on loaded runners.",
 }];

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Feature,
-    summary: "XML now renders pretty, exactly like JSON: .xml, .xsd, .xsl/.xslt, .plist, and SVG-as-text files get real tree-sitter syntax highlighting - tags, attributes, and values in the theme's colors - with the status bar reporting the XML language mode.",
+    kind: NoteKind::Fix,
+    summary: "An AI pair note that cannot anchor (no live session serves the file) is now reported in the output panel instead of vanishing silently, and the test suite's pair and commit-graph timing checks were made immune to loaded-runner scheduling.",
 }];

--- a/src/widgets/commit_graph.rs
+++ b/src/widgets/commit_graph.rs
@@ -213,6 +213,12 @@ impl CommitGraphPanel {
         }
     }
 
+    /// Whether a fetched graph has landed since the last [`Self::clear`]
+    /// (false = the section still says "Loading").
+    pub fn is_loaded(&self) -> bool {
+        self.loaded
+    }
+
     pub fn clear(&mut self) {
         self.rows.clear();
         self.loaded = false;


### PR DESCRIPTION
## What

Root-cause fixes for the two tracked CI flakes, plus one small product fix they surfaced.

### #190 - pair event-ordering tests

Diagnosis (reproduced under CPU starvation: 12 busy loops on 4 cores, 8 concurrent test instances):

- `a_failed_yield_leaves_no_look_behind` failed 1/24 loaded runs at `unwrap_err`: the send to the dead child **succeeded**. The child (`python3 -c pass`) races process teardown - the reader can observe stdout EOF (which fires `Died`) while the process, and with it stdin's read end, is still winding down, so the write lands in the pipe buffer instead of failing with EPIPE. The child now closes stdin *before* stdout and lingers: stdout EOF then proves the sink is already dead, by program order rather than scheduling luck.
- `notes_survive_a_new_turn_on_the_same_file` (the CI failure) read `notes_snapshot` once immediately after TurnDone. The reader thread applies `NoteEnd` before it sends `TurnEnd`, so note state IS final there - but `notes_snapshot` is a UI-tick accessor that serves its stale cache on a contended `try_lock` (semantics already pinned by `ui_reads_answer_instantly_while_the_pilot_mutex_is_held`). Same class for `is_busy`, which answers busy on a lost `lock_briefly` race. One-shot reads of state-final values through deliberately lossy accessors are the flake; they now poll to the resolved value via a bounded `settle()` helper (60s deadline bounds only a real regression). Applied across the noted tests and the identical patterns in `pair_host_emits_note_added_and_snapshots_rows` and the finish-window test.
- Product fix the digging surfaced: a note that cannot anchor because no live session serves the file was **silently dropped** (`NoteEnd`'s `wait_live` failure path returned without a trace). It now emits the same output-panel diagnostic as the edit-drop path.

### #195 - commit-graph swallowed-refresh test

The test asserted the **transient** `graph_fetch_inflight` latch right after one `sync_explorer_panels()`. The drain that re-fires the queued refresh keeps draining `graph_rx` in the same `while try_recv` loop - and the re-fired worker on an empty root answers in microseconds, so a descheduled main thread legitimately drains that fresh reply too and clears the latch again. Correct behavior, wrong assertion. The test now polls the resolved outcome: the cleared panel must leave "Loading" with rows for the current root (new `is_loaded()` accessor on the graph widget).

## Verification

- Red-first: with the drain's re-fire gutted, the rewritten #195 test fails at its deadline; restored, it passes. The #190 yield failure was reproduced pre-fix under load (1/24 runs).
- Post-fix load soak: 120 runs of the two pair tests and 12 of the graph test under the same starvation harness, zero failures.
- Full suite 3269 + 6 green; clippy zero.

Closes #190. Closes #195.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when AI pair notes are dropped because no active session is serving the file.
  * Improved reliability when handling stale fetch responses and commit-graph updates.
  * Stabilized pair-session status and note snapshot reporting under busy or delayed conditions.

* **Release**
  * Updated the application version to 0.1.747.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->