### PR TITLE
feat(quick-pick): make picker result rows mouse clickable (v0.1.748)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.747"
+version = "0.1.748"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.747"
+version = "0.1.748"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -19,7 +19,7 @@ On macOS, the `Cmd` chords below only reach croft after you run a one-time setup
 | `Ctrl+Shift+j` | Maximize the terminal pane (press again to restore the split) |
 | `Cmd+\` | Split the editor into two side-by-side columns; each keeps its own tabs, scroll, and cursor. Closing the last tab in a column collapses the split |
 | `Cmd+Opt+←` / `Cmd+Opt+→` | Move focus to the left / right editor group while split (or click a column) |
-| `Ctrl+p` / `Cmd+p` | Quick Open: fuzzy-search workspace files and jump to one (auto-reveals it in the Explorer) |
+| `Ctrl+p` / `Cmd+p` | Quick Open: fuzzy-search workspace files and jump to one (auto-reveals it in the Explorer). Results are mouse-friendly: click a row to open it, wheel to move the selection, and the same goes for all the quick-pick popups (Command Palette, Go to Symbol, branch and directory pickers) |
 | `Ctrl+p` / `Cmd+p`, then `#` | Go to Symbol in Workspace: the query goes to every running language server as a `workspace/symbol` search; Enter opens the picked symbol's file at its definition (also Command Palette "Go to Symbol in Workspace") |
 | `Ctrl+Shift+p` / `Cmd+Shift+p` | Command Palette: fuzzy-search every named command and run it, with its keybinding shown alongside |
 | `Ctrl+Shift+e` / `Cmd+Shift+e` | Jump to the Explorer sidebar |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -19,7 +19,7 @@ On macOS, the `Cmd` chords below only reach croft after you run a one-time setup
 | `Ctrl+Shift+j` | Maximize the terminal pane (press again to restore the split) |
 | `Cmd+\` | Split the editor into two side-by-side columns; each keeps its own tabs, scroll, and cursor. Closing the last tab in a column collapses the split |
 | `Cmd+Opt+←` / `Cmd+Opt+→` | Move focus to the left / right editor group while split (or click a column) |
-| `Ctrl+p` / `Cmd+p` | Quick Open: fuzzy-search workspace files and jump to one (auto-reveals it in the Explorer). Results are mouse-friendly: click a row to open it, wheel to move the selection, and the same goes for all the quick-pick popups (Command Palette, Go to Symbol, branch and directory pickers) |
+| `Ctrl+p` / `Cmd+p` | Quick Open: fuzzy-search workspace files and jump to one (auto-reveals it in the Explorer). Results are mouse-friendly: click a row to open it, wheel to move the selection, and the same goes for all the quick-pick popups (Command Palette, Go to Symbol, the branch and directory pickers, and the Debug: Attach to Python Process list) |
 | `Ctrl+p` / `Cmd+p`, then `#` | Go to Symbol in Workspace: the query goes to every running language server as a `workspace/symbol` search; Enter opens the picked symbol's file at its definition (also Command Palette "Go to Symbol in Workspace") |
 | `Ctrl+Shift+p` / `Cmd+Shift+p` | Command Palette: fuzzy-search every named command and run it, with its keybinding shown alongside |
 | `Ctrl+Shift+e` / `Cmd+Shift+e` | Jump to the Explorer sidebar |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23702,27 +23702,7 @@ impl App {
             (KeyCode::Esc, _) => {
                 self.close_file_finder();
             }
-            (KeyCode::Enter, _) => {
-                let path = finder.selected_entry().map(|e| e.path.clone());
-                if let Some(path) = path {
-                    self.close_file_finder();
-                    match self.editor.open_preview(&path) {
-                        Ok(()) => {
-                            self.sync_open_file_poll_mtime();
-                            // VS Code's `explorer.autoReveal` analogue:
-                            // expand every parent dir of the picked file
-                            // and park the cursor on its row so the user
-                            // sees where in the workspace the file lives.
-                            self.tree.reveal_path(&path);
-                            self.focus_pane(Pane::Editor);
-                            self.status = format!("Opened {}", self.status_path(&path));
-                        }
-                        Err(e) => {
-                            self.status = format!("Open failed: {e}");
-                        }
-                    }
-                }
-            }
+            (KeyCode::Enter, _) => self.open_file_finder_selection(),
             (KeyCode::Up, _) => finder.select_prev(),
             (KeyCode::Down, _) => finder.select_next(),
             (KeyCode::PageUp, _) => {
@@ -23759,6 +23739,33 @@ impl App {
         }
     }
 
+    /// Open the highlighted result and dismiss the finder: Enter's action,
+    /// shared with a mouse click on a result row.
+    fn open_file_finder_selection(&mut self) {
+        let Some(finder) = self.file_finder.as_ref() else {
+            return;
+        };
+        let path = finder.selected_entry().map(|e| e.path.clone());
+        if let Some(path) = path {
+            self.close_file_finder();
+            match self.editor.open_preview(&path) {
+                Ok(()) => {
+                    self.sync_open_file_poll_mtime();
+                    // VS Code's `explorer.autoReveal` analogue:
+                    // expand every parent dir of the picked file
+                    // and park the cursor on its row so the user
+                    // sees where in the workspace the file lives.
+                    self.tree.reveal_path(&path);
+                    self.focus_pane(Pane::Editor);
+                    self.status = format!("Opened {}", self.status_path(&path));
+                }
+                Err(e) => {
+                    self.status = format!("Open failed: {e}");
+                }
+            }
+        }
+    }
+
     fn handle_file_finder_mouse(&mut self, m: MouseEvent) {
         let Some(finder) = self.file_finder.as_mut() else {
             return;
@@ -23779,6 +23786,13 @@ impl App {
                 if !inside =>
             {
                 self.close_file_finder();
+            }
+            // Click a row to open it, the way VS Code's quick-pick behaves.
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(idx) = finder.row_index_at(m.row) {
+                    finder.selected = idx;
+                    self.open_file_finder_selection();
+                }
             }
             _ => {}
         }
@@ -23848,13 +23862,7 @@ impl App {
         };
         match (key.code, key.modifiers) {
             (KeyCode::Esc, _) => self.close_command_palette(),
-            (KeyCode::Enter, _) => {
-                let item = palette.selected_item();
-                self.close_command_palette();
-                if let Some(item) = item {
-                    self.run_palette_item(item);
-                }
-            }
+            (KeyCode::Enter, _) => self.run_command_palette_selection(),
             (KeyCode::Up, _) => palette.select_prev(),
             (KeyCode::Down, _) => palette.select_next(),
             (KeyCode::PageUp, _) => {
@@ -23880,6 +23888,19 @@ impl App {
         }
     }
 
+    /// Run the highlighted command and dismiss the palette: Enter's action,
+    /// shared with a mouse click on a result row.
+    fn run_command_palette_selection(&mut self) {
+        let Some(palette) = self.command_palette.as_ref() else {
+            return;
+        };
+        let item = palette.selected_item();
+        self.close_command_palette();
+        if let Some(item) = item {
+            self.run_palette_item(item);
+        }
+    }
+
     fn handle_command_palette_mouse(&mut self, m: MouseEvent) {
         let Some(palette) = self.command_palette.as_mut() else {
             return;
@@ -23900,6 +23921,13 @@ impl App {
                 if !inside =>
             {
                 self.close_command_palette();
+            }
+            // Click a row to run it, the way VS Code's quick-pick behaves.
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(idx) = palette.row_index_at(m.row) {
+                    palette.selected = idx;
+                    self.run_command_palette_selection();
+                }
             }
             _ => {}
         }
@@ -23962,16 +23990,16 @@ impl App {
         match (key.code, key.modifiers) {
             (KeyCode::Esc, _) => self.close_go_to_symbol(),
             (KeyCode::Enter, _) => {
-                // Resolve the target before closing (close drops the picker).
-                let target = if picker.is_line_mode() {
-                    picker.line_target().map(|n| (n as u32 - 1, 0))
+                if picker.is_line_mode() {
+                    // Resolve the target before closing (close drops the picker).
+                    let target = picker.line_target().map(|n| (n as u32 - 1, 0));
+                    let path = picker.path.clone();
+                    self.close_go_to_symbol();
+                    if let Some((line, col)) = target {
+                        self.go_to_definition(path, line, col);
+                    }
                 } else {
-                    picker.selected_target()
-                };
-                let path = picker.path.clone();
-                self.close_go_to_symbol();
-                if let Some((line, col)) = target {
-                    self.go_to_definition(path, line, col);
+                    self.jump_to_go_to_symbol_selection();
                 }
             }
             (KeyCode::Up, _) => picker.select_prev(),
@@ -23999,6 +24027,23 @@ impl App {
         }
     }
 
+    /// Jump to the highlighted symbol and dismiss the picker: Enter's action
+    /// outside line mode, shared with a mouse click on a result row (a click
+    /// names a concrete row, so it always means the symbol, never a `:N`
+    /// line query).
+    fn jump_to_go_to_symbol_selection(&mut self) {
+        let Some(picker) = self.go_to_symbol.as_ref() else {
+            return;
+        };
+        // Resolve the target before closing (close drops the picker).
+        let target = picker.selected_target();
+        let path = picker.path.clone();
+        self.close_go_to_symbol();
+        if let Some((line, col)) = target {
+            self.go_to_definition(path, line, col);
+        }
+    }
+
     fn handle_go_to_symbol_mouse(&mut self, m: MouseEvent) {
         let Some(picker) = self.go_to_symbol.as_mut() else {
             return;
@@ -24019,6 +24064,13 @@ impl App {
                 if !inside =>
             {
                 self.close_go_to_symbol();
+            }
+            // Click a row to jump to it, the way VS Code's quick-pick behaves.
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(idx) = picker.row_index_at(m.row) {
+                    picker.selected = idx;
+                    self.jump_to_go_to_symbol_selection();
+                }
             }
             _ => {}
         }
@@ -24169,15 +24221,7 @@ impl App {
         };
         match (key.code, key.modifiers) {
             (KeyCode::Esc, _) => self.close_workspace_symbols(),
-            (KeyCode::Enter, _) => {
-                let target = picker
-                    .selected_item()
-                    .map(|i| (i.path.clone(), i.line, i.character));
-                self.close_workspace_symbols();
-                if let Some((path, line, character)) = target {
-                    self.go_to_definition(path, line, character);
-                }
-            }
+            (KeyCode::Enter, _) => self.jump_to_workspace_symbol_selection(),
             (KeyCode::Up, _) => picker.select_prev(),
             (KeyCode::Down, _) => picker.select_next(),
             (KeyCode::PageUp, _) => {
@@ -24210,6 +24254,21 @@ impl App {
         }
     }
 
+    /// Jump to the highlighted workspace symbol and dismiss the picker:
+    /// Enter's action, shared with a mouse click on a result row.
+    fn jump_to_workspace_symbol_selection(&mut self) {
+        let Some(picker) = self.workspace_symbols.as_ref() else {
+            return;
+        };
+        let target = picker
+            .selected_item()
+            .map(|i| (i.path.clone(), i.line, i.character));
+        self.close_workspace_symbols();
+        if let Some((path, line, character)) = target {
+            self.go_to_definition(path, line, character);
+        }
+    }
+
     fn handle_workspace_symbols_mouse(&mut self, m: MouseEvent) {
         let Some(picker) = self.workspace_symbols.as_mut() else {
             return;
@@ -24230,6 +24289,13 @@ impl App {
                 if !inside =>
             {
                 self.close_workspace_symbols();
+            }
+            // Click a row to jump to it, the way VS Code's quick-pick behaves.
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(idx) = picker.row_index_at(m.row) {
+                    picker.selected = idx;
+                    self.jump_to_workspace_symbol_selection();
+                }
             }
             _ => {}
         }
@@ -24294,13 +24360,7 @@ impl App {
         };
         match (key.code, key.modifiers) {
             (KeyCode::Esc, _) => self.close_process_picker(),
-            (KeyCode::Enter, _) => {
-                let target = picker.selected_target().cloned();
-                self.close_process_picker();
-                if let Some(target) = target {
-                    self.attach_to_python_target(target);
-                }
-            }
+            (KeyCode::Enter, _) => self.attach_process_picker_selection(),
             (KeyCode::Up, _) => picker.select_prev(),
             (KeyCode::Down, _) => picker.select_next(),
             (KeyCode::PageUp, _) => {
@@ -24314,6 +24374,19 @@ impl App {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Attach to the highlighted process and dismiss the picker: Enter's
+    /// action, shared with a mouse click on a result row.
+    fn attach_process_picker_selection(&mut self) {
+        let Some(picker) = self.process_picker.as_ref() else {
+            return;
+        };
+        let target = picker.selected_target().cloned();
+        self.close_process_picker();
+        if let Some(target) = target {
+            self.attach_to_python_target(target);
         }
     }
 
@@ -24337,6 +24410,13 @@ impl App {
                 if !inside =>
             {
                 self.close_process_picker();
+            }
+            // Click a row to attach to it, the way VS Code's quick-pick behaves.
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(idx) = picker.row_index_at(m.row) {
+                    picker.selected = idx;
+                    self.attach_process_picker_selection();
+                }
             }
             _ => {}
         }
@@ -25054,18 +25134,7 @@ impl App {
             (KeyCode::Esc, _) => {
                 self.close_zoxide_jump();
             }
-            (KeyCode::Enter, _) => {
-                let path = jump.selected_path().map(|p| p.to_path_buf());
-                if let Some(path) = path {
-                    let add = self.zoxide_add_folder;
-                    self.close_zoxide_jump();
-                    if add {
-                        self.add_workspace_folder(path);
-                    } else {
-                        self.change_workspace_root(path);
-                    }
-                }
-            }
+            (KeyCode::Enter, _) => self.apply_zoxide_jump_selection(),
             (KeyCode::Up, _) => jump.select_prev(),
             (KeyCode::Down, _) => jump.select_next(),
             (KeyCode::PageUp, _) => {
@@ -25098,6 +25167,24 @@ impl App {
         }
     }
 
+    /// Jump to (or add) the highlighted directory and dismiss the popup:
+    /// Enter's action, shared with a mouse click on a result row.
+    fn apply_zoxide_jump_selection(&mut self) {
+        let Some(jump) = self.zoxide_jump.as_ref() else {
+            return;
+        };
+        let path = jump.selected_path().map(|p| p.to_path_buf());
+        if let Some(path) = path {
+            let add = self.zoxide_add_folder;
+            self.close_zoxide_jump();
+            if add {
+                self.add_workspace_folder(path);
+            } else {
+                self.change_workspace_root(path);
+            }
+        }
+    }
+
     fn handle_zoxide_jump_mouse(&mut self, m: MouseEvent) {
         let Some(jump) = self.zoxide_jump.as_mut() else {
             return;
@@ -25118,6 +25205,13 @@ impl App {
                 if !inside =>
             {
                 self.close_zoxide_jump();
+            }
+            // Click a row to jump to it, the way VS Code's quick-pick behaves.
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(idx) = jump.row_index_at(m.row) {
+                    jump.selected = idx;
+                    self.apply_zoxide_jump_selection();
+                }
             }
             _ => {}
         }
@@ -25297,6 +25391,13 @@ impl App {
                 if !inside =>
             {
                 self.close_branch_picker();
+            }
+            // Click a row to act on it, the way VS Code's quick-pick behaves.
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(idx) = picker.row_index_at(m.row) {
+                    picker.selected = idx;
+                    self.apply_branch_picker_selection();
+                }
             }
             _ => {}
         }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11316,6 +11316,154 @@ fn esc_closes_the_file_finder_modal() {
     );
 }
 
+/// Issue #205: Cmd+P search results must be mouse clickable. A left click on
+/// a result row confirms that row (the way VS Code's quick-pick behaves):
+/// it opens the clicked file, not the keyboard-selected one, and dismisses
+/// the finder.
+#[test]
+fn clicking_a_file_finder_row_opens_that_file() {
+    use crossterm::event::{MouseButton, MouseEventKind};
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("alpha.rs"), "").unwrap();
+    std::fs::write(tmp.path().join("beta.rs"), "").unwrap();
+    std::fs::write(tmp.path().join("gamma.rs"), "").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.handle_key(key(KeyCode::Char('p'), KeyModifiers::SUPER))
+        .unwrap();
+    let backend = ratatui::backend::TestBackend::new(120, 40);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    term.draw(|frame| app.render(frame)).unwrap();
+    let finder = app.file_finder.as_ref().unwrap();
+    assert!(
+        finder.results.len() >= 3,
+        "the three seeded files must all be indexed"
+    );
+    // The list body starts three rows below the popup top (border, prompt,
+    // separator). Row 1 of the list is the SECOND result - clicking it must
+    // open that entry, not the keyboard selection parked on row 0.
+    let col = finder.last_rect.x + 4;
+    let row = finder.last_rect.y + 3 + 1;
+    let expected = finder.results[1].entry.path.clone();
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), col, row));
+    assert!(
+        app.file_finder.is_none(),
+        "a click on a result row must confirm the pick and dismiss the finder"
+    );
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(expected.as_path()),
+        "the clicked row's file must be the one that opens"
+    );
+}
+
+/// A click inside the popup but off the result rows (the query prompt line)
+/// must neither open a file nor dismiss the finder - only clicks OUTSIDE the
+/// popup close it, and only clicks ON a row confirm it.
+#[test]
+fn clicking_the_file_finder_prompt_line_is_inert() {
+    use crossterm::event::{MouseButton, MouseEventKind};
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("alpha.rs"), "").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.handle_key(key(KeyCode::Char('p'), KeyModifiers::SUPER))
+        .unwrap();
+    let backend = ratatui::backend::TestBackend::new(120, 40);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    term.draw(|frame| app.render(frame)).unwrap();
+    let finder = app.file_finder.as_ref().unwrap();
+    let col = finder.last_rect.x + 4;
+    let prompt_row = finder.last_rect.y + 1;
+    app.handle_mouse(mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        col,
+        prompt_row,
+    ));
+    assert!(
+        app.file_finder.is_some(),
+        "a click on the query line must not dismiss the finder"
+    );
+    assert_eq!(
+        app.editor.path, None,
+        "a click on the query line must not open anything"
+    );
+}
+
+/// A click on an empty list row (inside the popup, below the last result)
+/// maps to no result and must be inert rather than opening some file or
+/// closing the popup.
+#[test]
+fn clicking_below_the_last_file_finder_result_is_inert() {
+    use crossterm::event::{MouseButton, MouseEventKind};
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("alpha.rs"), "").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.handle_key(key(KeyCode::Char('p'), KeyModifiers::SUPER))
+        .unwrap();
+    let backend = ratatui::backend::TestBackend::new(120, 40);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    term.draw(|frame| app.render(frame)).unwrap();
+    let finder = app.file_finder.as_ref().unwrap();
+    let results = finder.results.len();
+    let col = finder.last_rect.x + 4;
+    // One row past the last result, still inside the popup body.
+    let row = finder.last_rect.y + 3 + results as u16;
+    assert!(
+        row < finder.last_rect.y + finder.last_rect.height - 1,
+        "the empty row must land inside the popup for this test to mean anything"
+    );
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), col, row));
+    assert!(
+        app.file_finder.is_some(),
+        "a click on an empty list row must not dismiss the finder"
+    );
+    assert_eq!(
+        app.editor.path, None,
+        "a click on an empty list row must not open anything"
+    );
+}
+
+/// The command palette shares the quick-pick anatomy, so its rows must be
+/// clickable too: a left click on a result row runs that command and
+/// dismisses the palette.
+#[test]
+fn clicking_a_command_palette_row_runs_that_command() {
+    use crossterm::event::{MouseButton, MouseEventKind};
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.handle_key(key(
+        KeyCode::Char('p'),
+        KeyModifiers::SUPER | KeyModifiers::SHIFT,
+    ))
+    .unwrap();
+    assert!(
+        app.command_palette.is_some(),
+        "Cmd+Shift+P must open the palette"
+    );
+    for c in "keyboard shortcuts reference".chars() {
+        app.handle_key(key(KeyCode::Char(c), KeyModifiers::NONE))
+            .unwrap();
+    }
+    let backend = ratatui::backend::TestBackend::new(120, 40);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    term.draw(|frame| app.render(frame)).unwrap();
+    let palette = app.command_palette.as_ref().unwrap();
+    assert!(
+        !palette.results.is_empty(),
+        "the query must keep the Help: Keyboard Shortcuts Reference command"
+    );
+    let col = palette.last_rect.x + 4;
+    let row = palette.last_rect.y + 3;
+    app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), col, row));
+    assert!(
+        app.command_palette.is_none(),
+        "a click on a palette row must run the command and dismiss the palette"
+    );
+    assert!(
+        app.shortcuts_modal.is_some(),
+        "the clicked command (Help: Keyboard Shortcuts Reference) must actually run"
+    );
+}
+
 #[test]
 fn typing_in_file_finder_fuzzy_filters_the_result_list() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Feature,
-    summary: "Quick-pick results are now mouse-clickable: clicking a row in Quick Open (Cmd+P), the Command Palette, Go to Symbol, the branch and directory pickers, and the process attach list opens or runs that row, exactly like pressing Enter on it.",
+    summary: "Quick-pick results are now mouse-clickable: clicking a row in Quick Open (Cmd+P), the Command Palette, Go to Symbol, the branch and directory pickers, and the Python process attach list performs exactly the action Enter would on that row.",
 }];

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Fix,
-    summary: "An AI pair note that cannot anchor (no live session serves the file) is now reported in the output panel instead of vanishing silently, and the test suite's pair and commit-graph timing checks were stabilized with bounded polling on loaded runners.",
+    kind: NoteKind::Feature,
+    summary: "Quick-pick results are now mouse-clickable: clicking a row in Quick Open (Cmd+P), the Command Palette, Go to Symbol, the branch and directory pickers, and the process attach list opens or runs that row, exactly like pressing Enter on it.",
 }];

--- a/src/widgets/branch_picker.rs
+++ b/src/widgets/branch_picker.rs
@@ -206,6 +206,21 @@ impl BranchPicker {
             self.selected -= 1;
         }
     }
+
+    /// The row index at screen row `y`, if `y` lands on a visible row
+    /// (an existing branch or the synthetic "create" row). The list body
+    /// starts three rows below `last_rect.y` (top border, the query prompt,
+    /// then the separator) and runs `last_inner_height` rows, so this stays
+    /// in lock-step with [`render_branch_picker`]. Used to map a mouse click
+    /// to a row.
+    pub fn row_index_at(&self, y: u16) -> Option<usize> {
+        let list_top = self.last_rect.y.saturating_add(3);
+        if y < list_top || y - list_top >= self.last_inner_height {
+            return None;
+        }
+        let idx = self.scroll + (y - list_top) as usize;
+        (idx < self.row_count()).then_some(idx)
+    }
 }
 
 /// Draw the picker into `rect`. Placement is decided by the caller in

--- a/src/widgets/command_palette.rs
+++ b/src/widgets/command_palette.rs
@@ -878,6 +878,20 @@ impl CommandPalette {
         self.results.get(self.selected).cloned()
     }
 
+    /// The result index at screen row `y`, if `y` lands on a visible row.
+    /// The list body starts three rows below `last_rect.y` (top border, the
+    /// query prompt, then the separator) and runs `last_inner_height` rows,
+    /// so this stays in lock-step with [`render_command_palette`]. Used to
+    /// map a mouse click to a result row.
+    pub fn row_index_at(&self, y: u16) -> Option<usize> {
+        let list_top = self.last_rect.y.saturating_add(3);
+        if y < list_top || y - list_top >= self.last_inner_height {
+            return None;
+        }
+        let idx = self.scroll + (y - list_top) as usize;
+        (idx < self.results.len()).then_some(idx)
+    }
+
     /// Re-rank the command list against the current query, over built-ins AND
     /// injected extension commands. An empty query shows every command in
     /// declaration order (built-ins first, then extensions); otherwise rows are

--- a/src/widgets/file_finder.rs
+++ b/src/widgets/file_finder.rs
@@ -180,6 +180,20 @@ impl FileFinder {
         self.results.get(self.selected).map(|r| &r.entry)
     }
 
+    /// The result index at screen row `y`, if `y` lands on a visible row.
+    /// The list body starts three rows below `last_rect.y` (top border, the
+    /// query prompt, then the separator) and runs `last_inner_height` rows,
+    /// so this stays in lock-step with [`render_file_finder`]. Used to map
+    /// a mouse click to a result row.
+    pub fn row_index_at(&self, y: u16) -> Option<usize> {
+        let list_top = self.last_rect.y.saturating_add(3);
+        if y < list_top || y - list_top >= self.last_inner_height {
+            return None;
+        }
+        let idx = self.scroll + (y - list_top) as usize;
+        (idx < self.results.len()).then_some(idx)
+    }
+
     #[cfg(test)]
     pub fn selected_index(&self) -> usize {
         self.selected
@@ -811,6 +825,42 @@ fn split_dir_file(rel: &str, filename_start: usize) -> (&str, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The click hit-test starts three rows below the popup top (border,
+    /// prompt, separator), scrolls with the list, refuses the bottom border
+    /// (one past `last_inner_height`), and refuses empty rows past the last
+    /// result.
+    #[test]
+    fn row_index_at_maps_the_quick_pick_list_geometry() {
+        let entry = |name: &str| FileEntry {
+            path: std::path::PathBuf::from(name),
+            rel: name.to_string(),
+            rel_lower: name.to_lowercase(),
+            filename_start: 0,
+            filename_start_lower: 0,
+        };
+        let mut f = FileFinder::new(Arc::new(vec![entry("a.rs"), entry("b.rs"), entry("c.rs")]));
+        f.last_rect = Rect {
+            x: 10,
+            y: 5,
+            width: 60,
+            height: 10,
+        };
+        // inner height 8, minus prompt and separator = 6 list rows;
+        // the popup bottom border sits at y = 14.
+        f.last_inner_height = 6;
+        assert_eq!(f.row_index_at(7), None, "the separator is not a row");
+        assert_eq!(
+            f.row_index_at(8),
+            Some(0),
+            "the list starts below the separator"
+        );
+        assert_eq!(f.row_index_at(10), Some(2));
+        assert_eq!(f.row_index_at(11), None, "below the last result is empty");
+        assert_eq!(f.row_index_at(14), None, "the bottom border is not a row");
+        f.scroll = 2;
+        assert_eq!(f.row_index_at(8), Some(2), "scroll offsets the mapping");
+    }
 
     #[test]
     fn multi_root_index_survives_root_names_whose_lowercase_changes_byte_length() {

--- a/src/widgets/list_picker.rs
+++ b/src/widgets/list_picker.rs
@@ -154,11 +154,12 @@ impl ListPicker {
 
     /// The matched-row index at screen row `y`, if `y` lands on a visible row.
     /// The list body starts two rows below `last_rect.y` (the top border, then
-    /// the prompt row), so the renderer and this stay in lock-step. Used to map
-    /// a mouse click to a selectable row.
+    /// the prompt row) and ends above the bottom border, so the renderer and
+    /// this stay in lock-step. Used to map a mouse click to a selectable row.
     pub fn row_index_at(&self, y: u16) -> Option<usize> {
         let list_top = self.last_rect.y.saturating_add(2);
-        if y < list_top {
+        let list_height = self.last_rect.height.saturating_sub(3);
+        if y < list_top || y - list_top >= list_height {
             return None;
         }
         let idx = self.scroll + (y - list_top) as usize;

--- a/src/widgets/process_picker.rs
+++ b/src/widgets/process_picker.rs
@@ -53,6 +53,20 @@ impl ProcessPicker {
     pub fn selected_target(&self) -> Option<&PyTarget> {
         self.targets.get(self.selected)
     }
+
+    /// The target index at screen row `y`, if `y` lands on a visible row.
+    /// Unlike the query-line pickers this popup has no prompt or separator:
+    /// the list body starts one row below `last_rect.y` (just the top
+    /// border) and runs `last_inner_height` rows, in lock-step with
+    /// [`render_process_picker`]. Used to map a mouse click to a row.
+    pub fn row_index_at(&self, y: u16) -> Option<usize> {
+        let list_top = self.last_rect.y.saturating_add(1);
+        if y < list_top || y - list_top >= self.last_inner_height {
+            return None;
+        }
+        let idx = self.scroll + (y - list_top) as usize;
+        (idx < self.targets.len()).then_some(idx)
+    }
 }
 
 pub fn render_process_picker(
@@ -175,5 +189,31 @@ mod tests {
     fn empty_picker_has_no_selection() {
         let p = ProcessPicker::new(vec![]);
         assert_eq!(p.selected_target(), None);
+    }
+
+    /// This popup has no prompt or separator, so its click hit-test starts
+    /// one row below the popup top (the border), not three like the
+    /// query-line pickers. Rows outside the body (borders, or below the
+    /// last target) map to nothing.
+    #[test]
+    fn row_index_at_maps_the_borderless_list_geometry() {
+        let mut p = ProcessPicker::new(vec![target(1), target(2), target(3)]);
+        p.last_rect = Rect {
+            x: 10,
+            y: 5,
+            width: 40,
+            height: 8,
+        };
+        p.last_inner_height = 6;
+        assert_eq!(p.row_index_at(5), None, "top border is not a row");
+        assert_eq!(
+            p.row_index_at(6),
+            Some(0),
+            "first row sits under the border"
+        );
+        assert_eq!(p.row_index_at(8), Some(2));
+        assert_eq!(p.row_index_at(9), None, "below the last target is empty");
+        p.scroll = 1;
+        assert_eq!(p.row_index_at(6), Some(1), "scroll offsets the mapping");
     }
 }

--- a/src/widgets/symbol_picker.rs
+++ b/src/widgets/symbol_picker.rs
@@ -148,6 +148,20 @@ impl SymbolPicker {
         self.selected = self.selected.saturating_sub(1);
     }
 
+    /// The result index at screen row `y`, if `y` lands on a visible row.
+    /// The list body starts three rows below `last_rect.y` (top border, the
+    /// query prompt, then the separator) and runs `last_inner_height` rows,
+    /// so this stays in lock-step with [`render_symbol_picker`]. Used to map
+    /// a mouse click to a result row.
+    pub fn row_index_at(&self, y: u16) -> Option<usize> {
+        let list_top = self.last_rect.y.saturating_add(3);
+        if y < list_top || y - list_top >= self.last_inner_height {
+            return None;
+        }
+        let idx = self.scroll + (y - list_top) as usize;
+        (idx < self.results.len()).then_some(idx)
+    }
+
     /// Re-rank the symbol list against the query. Line mode (`:`) shows the
     /// symbols untouched (the list is irrelevant; Enter jumps to the line). An
     /// empty query lists every symbol in document order; otherwise rows are

--- a/src/widgets/symbol_picker.rs
+++ b/src/widgets/symbol_picker.rs
@@ -152,8 +152,13 @@ impl SymbolPicker {
     /// The list body starts three rows below `last_rect.y` (top border, the
     /// query prompt, then the separator) and runs `last_inner_height` rows,
     /// so this stays in lock-step with [`render_symbol_picker`]. Used to map
-    /// a mouse click to a result row.
+    /// a mouse click to a result row. Line mode (`:N`) renders a "Go to
+    /// line" hint in the list area while `results` still holds every
+    /// symbol, so clicks there map to nothing.
     pub fn row_index_at(&self, y: u16) -> Option<usize> {
+        if self.is_line_mode() {
+            return None;
+        }
         let list_top = self.last_rect.y.saturating_add(3);
         if y < list_top || y - list_top >= self.last_inner_height {
             return None;
@@ -420,6 +425,35 @@ mod tests {
     fn empty_query_lists_every_symbol_in_order() {
         let p = picker();
         assert_eq!(p.results, vec![0, 1, 2]);
+    }
+
+    /// In line mode (`:42`) the list area renders only a "Go to line" hint,
+    /// yet `results` still holds every symbol; a click there must map to
+    /// nothing rather than jump to an invisible symbol row.
+    #[test]
+    fn row_index_at_refuses_clicks_in_line_mode() {
+        let mut p = picker();
+        p.last_rect = Rect {
+            x: 10,
+            y: 5,
+            width: 60,
+            height: 10,
+        };
+        p.last_inner_height = 6;
+        assert_eq!(
+            p.row_index_at(8),
+            Some(0),
+            "outside line mode the first list row maps to the first symbol"
+        );
+        for c in [':', '4', '2'] {
+            p.push_char(c);
+        }
+        assert!(p.is_line_mode());
+        assert_eq!(
+            p.row_index_at(8),
+            None,
+            "line mode renders a hint, not rows; clicks must map to nothing"
+        );
     }
 
     #[test]

--- a/src/widgets/workspace_symbols.rs
+++ b/src/widgets/workspace_symbols.rs
@@ -131,6 +131,20 @@ impl WorkspaceSymbolPicker {
     pub fn select_prev(&mut self) {
         self.selected = self.selected.saturating_sub(1);
     }
+
+    /// The result index at screen row `y`, if `y` lands on a visible row.
+    /// The list body starts three rows below `last_rect.y` (top border, the
+    /// query prompt, then the separator) and runs `last_inner_height` rows,
+    /// so this stays in lock-step with [`render_workspace_symbols`]. Used to
+    /// map a mouse click to a result row.
+    pub fn row_index_at(&self, y: u16) -> Option<usize> {
+        let list_top = self.last_rect.y.saturating_add(3);
+        if y < list_top || y - list_top >= self.last_inner_height {
+            return None;
+        }
+        let idx = self.scroll + (y - list_top) as usize;
+        (idx < self.results.len()).then_some(idx)
+    }
 }
 
 /// A result path shown workspace-relative when possible, absolute otherwise.

--- a/src/widgets/zoxide_jump.rs
+++ b/src/widgets/zoxide_jump.rs
@@ -200,6 +200,20 @@ impl ZoxideJump {
         self.results.get(self.selected).map(|p| p.as_path())
     }
 
+    /// The result index at screen row `y`, if `y` lands on a visible row.
+    /// The list body starts three rows below `last_rect.y` (top border, the
+    /// query prompt, then the separator or approximate-match hint) and runs
+    /// `last_inner_height` rows, so this stays in lock-step with
+    /// [`render_zoxide_jump`]. Used to map a mouse click to a result row.
+    pub fn row_index_at(&self, y: u16) -> Option<usize> {
+        let list_top = self.last_rect.y.saturating_add(3);
+        if y < list_top || y - list_top >= self.last_inner_height {
+            return None;
+        }
+        let idx = self.scroll + (y - list_top) as usize;
+        (idx < self.results.len()).then_some(idx)
+    }
+
     #[cfg(test)]
     pub fn selected_index(&self) -> usize {
         self.selected


### PR DESCRIPTION
Closes #205.

## What

Quick-pick result rows are now mouse clickable. A left click on a row in any of these popups confirms that row, exactly like pressing Enter on it:

- Quick Open / Go to File (Cmd+P)
- Command Palette (Cmd+Shift+P)
- Go to Symbol in File
- Go to Symbol in Workspace
- Branch picker
- Zoxide directory jumper (Cmd+Z)
- Debug: Attach to Python Process

Clicks inside the popup but off the rows (the query prompt, the separator, the borders, empty space below the last result) stay inert; clicks outside still dismiss the popup, and the wheel still moves the selection.

## How

- Each picker widget gains a `row_index_at(y)` hit-test that mirrors its renderer's list geometry (three rows below the popup top for the query-line pickers, one row for the promptless process picker), bounded by the rendered list height and the result count. This is the same pattern the list picker already used.
- The Enter actions are extracted into shared `apply`/`confirm`/`open`-selection methods on `App`, so the keyboard and mouse paths run identical code and cannot drift. The go-to-symbol picker keeps its `:N` line-mode branch on the keyboard path only: a click names a concrete row, so it always means that symbol.
- The list picker's pre-existing hit-test also gains the bottom bound: a click on the popup's bottom border used to map to the first row past the visible window when the list was scrolled.

## Tests

- App-level: clicking the second Quick Open row opens that file (not the keyboard selection), clicking the prompt line or an empty list row is inert, and clicking a Command Palette row runs the clicked command.
- Widget-level: `row_index_at` geometry pinned for both anatomies (query-line picker with separator via the file finder; promptless list via the process picker), including scroll offset, border rows, and the empty tail.
- Full suite green: 3275 lib + 6 CLI tests, clippy at zero warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse-click support for selecting and activating rows in quick-pick interfaces, including file search, command palette, symbol search, process selection, branch selection, and directory jumping.
  * Added mouse-wheel interaction support documentation for quick-pick results.

* **Bug Fixes**
  * Improved click handling to ignore prompts, borders, empty rows, and other non-result areas.

* **Documentation**
  * Updated keyboard and mouse interaction guidance for Quick Open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->