### PR TITLE
fix(theme): make the light theme legible on every surface (v0.1.751)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.750"
+version = "0.1.751"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.750"
+version = "0.1.751"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -762,9 +762,9 @@ pub(crate) const BRAND_ORANGE: Color = Color::Rgb(0xe9, 0x7c, 0x41);
 /// Spans for the "cr<>ft" wordmark at the left of the status bar, styled to
 /// mirror the app logo: white letters with the `<>` (the stylised "o") in the
 /// brand orange, sitting on the bar's own background rather than a pill.
-fn brand_spans() -> Vec<Span<'static>> {
+fn brand_spans(theme: crate::theme::Theme) -> Vec<Span<'static>> {
     let letter = Style::default()
-        .fg(Color::White)
+        .fg(theme.ui(Color::White))
         .add_modifier(Modifier::BOLD);
     vec![
         Span::styled(" cr", letter),
@@ -4556,6 +4556,13 @@ impl App {
         }
         let hero = self.source_control.last_hero_area;
         if hero.width == 0 || hero.height == 0 {
+            return;
+        }
+        // The hero asset carries its own opaque dark backdrop; on a light
+        // theme it would sit as a dark slab on the white panel, so the
+        // panel keeps its text-only empty state instead.
+        if self.theme.is_light() {
+            self.overlays.hero.mark_hidden();
             return;
         }
         let Some((cw, ch)) = self.cell_pixel else {
@@ -9627,11 +9634,16 @@ impl App {
                 let canvas_h = (logo_h_cells as u32) * ch;
                 let bg = self.theme_bg_pixel();
                 let protocol = self.inline_protocol;
-                if let Ok(baked) = crate::iterm2_inline::fit_image(
+                // On a light background the asset's white "cr"/"ft"
+                // letters would vanish; the ink recolor turns just those
+                // pixels dark while the orange/teal strokes pass through.
+                let ink = self.theme.is_light().then_some((0x3b_u8, 0x3b_u8, 0x3b_u8));
+                if let Ok(baked) = crate::iterm2_inline::fit_image_with_ink(
                     crate::iterm2_inline::WELCOME_LOGO_PNG,
                     canvas_w,
                     canvas_h,
                     bg,
+                    ink,
                 ) && let Some(raw) = crate::iterm2_inline::build_inline_image(
                     protocol,
                     &baked,
@@ -9676,7 +9688,7 @@ impl App {
         let badge_y = logo_y + (logo_h_cells * 5) / 6;
         if badge_x + version_w + 2 <= area.x + area.width && badge_y + 2 < area_max_y {
             let badge_style = Style::default()
-                .fg(rgb_color(GRAD_TL))
+                .fg(self.theme.ui(rgb_color(GRAD_TL)))
                 .add_modifier(Modifier::BOLD);
             frame
                 .buffer_mut()
@@ -9700,7 +9712,7 @@ impl App {
                 badge_y + 1,
                 &version_label,
                 Style::default()
-                    .fg(Color::White)
+                    .fg(self.theme.ui(Color::White))
                     .add_modifier(Modifier::BOLD),
             );
             frame.buffer_mut().set_string(
@@ -9749,7 +9761,41 @@ impl App {
                 width: block_w,
                 height: box_h,
             };
-            paint_gradient_box(frame.buffer_mut(), box_rect);
+            if self.theme.is_light() {
+                // The brand gradient's teal leg washes out on white; paint
+                // the card border in the light widget-border grey instead.
+                let border = Style::default().fg(self.theme.ui(Color::Rgb(0x3b, 0x42, 0x52)));
+                let b = frame.buffer_mut();
+                for x in box_rect.x..box_rect.x + box_rect.width {
+                    b.set_string(x, box_rect.y, "\u{2500}", border);
+                    b.set_string(x, box_rect.y + box_rect.height - 1, "\u{2500}", border);
+                }
+                for y in box_rect.y..box_rect.y + box_rect.height {
+                    b.set_string(box_rect.x, y, "\u{2502}", border);
+                    b.set_string(box_rect.x + box_rect.width - 1, y, "\u{2502}", border);
+                }
+                b.set_string(box_rect.x, box_rect.y, "\u{256d}", border);
+                b.set_string(
+                    box_rect.x + box_rect.width - 1,
+                    box_rect.y,
+                    "\u{256e}",
+                    border,
+                );
+                b.set_string(
+                    box_rect.x,
+                    box_rect.y + box_rect.height - 1,
+                    "\u{2570}",
+                    border,
+                );
+                b.set_string(
+                    box_rect.x + box_rect.width - 1,
+                    box_rect.y + box_rect.height - 1,
+                    "\u{256f}",
+                    border,
+                );
+            } else {
+                paint_gradient_box(frame.buffer_mut(), box_rect);
+            }
 
             // Inner content area: 1-cell inset from each border. The width
             // comes from the same helper the height measure used, so the
@@ -9771,7 +9817,7 @@ impl App {
                 header_y,
                 "> ",
                 Style::default()
-                    .fg(rgb_color(GRAD_TR))
+                    .fg(self.theme.ui(rgb_color(GRAD_TR)))
                     .add_modifier(Modifier::BOLD),
             );
             frame.buffer_mut().set_string(
@@ -9779,7 +9825,7 @@ impl App {
                 header_y,
                 format!("IN THIS RELEASE (v{})", env!("CARGO_PKG_VERSION")),
                 Style::default()
-                    .fg(Color::White)
+                    .fg(self.theme.ui(Color::White))
                     .add_modifier(Modifier::BOLD),
             );
 
@@ -9978,7 +10024,7 @@ impl App {
         let testing_hovered = hov == Some(ActivityIcon::Testing);
         let settings_hovered = hov == Some(ActivityIcon::Settings);
 
-        let active_color = Color::White;
+        let active_color = self.theme.ui(Color::White);
         let inactive_color = self.theme.ui(Color::Rgb(0x6c, 0x7d, 0x9c));
         let glyph_x = activity_icon_glyph_x(area);
         let render_glyph = |frame: &mut ratatui::Frame,
@@ -10727,7 +10773,7 @@ impl App {
             let shown: String = label.chars().take(room).collect();
             let fg = if active {
                 Style::default()
-                    .fg(Color::White)
+                    .fg(self.theme.ui(Color::White))
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
@@ -11256,7 +11302,7 @@ impl App {
         let active_fg = if brand {
             crate::gradient::rgb_color(crate::gradient::PANEL_TITLE_FG)
         } else {
-            Color::White
+            self.theme.ui(Color::White)
         };
         let inactive_fg = self.theme.ui(Color::Rgb(0x80, 0x88, 0x98));
         let right = strip.x + strip.width;
@@ -12443,7 +12489,7 @@ impl App {
         // through scm_worker() would pin all of &self for the whole render.
         let scm_status = self.scm_worker().status().clone();
         let mut spans: Vec<Span> = Vec::with_capacity(20);
-        spans.extend(brand_spans());
+        spans.extend(brand_spans(self.theme));
         if let Some(span) = self.perf.status_span() {
             spans.push(span);
         }
@@ -12966,7 +13012,7 @@ impl App {
             let row_style = if is_sel {
                 Style::default().fg(sel_fg).bg(sel_bg)
             } else {
-                Style::default().fg(Color::White)
+                Style::default().fg(self.theme.ui(Color::White))
             };
             let (label, right_hint) = match entry {
                 MenuEntry::Item { label, action } => {
@@ -13039,7 +13085,7 @@ impl App {
             height: items.len() as u16,
         };
         let bg = self.theme.ui(Color::Rgb(0x25, 0x2b, 0x37));
-        let fg = Color::White;
+        let fg = self.theme.ui(Color::White);
         let style = Style::default().fg(fg).bg(bg);
         frame.render_widget(ratatui::widgets::Clear, menu_rect);
         self.source_control.commit_menu_item_areas.clear();
@@ -13149,7 +13195,7 @@ impl App {
         let body = ratatui::text::Text::from(vec![
             ratatui::text::Line::from(ratatui::text::Span::styled(
                 warn_text,
-                Style::default().fg(Color::White),
+                Style::default().fg(self.theme.ui(Color::White)),
             )),
             ratatui::text::Line::from(""),
             ratatui::text::Line::from(ratatui::text::Span::styled(
@@ -13215,7 +13261,7 @@ impl App {
         let body = ratatui::text::Text::from(vec![
             ratatui::text::Line::from(ratatui::text::Span::styled(
                 "This will undo the change hunk under the cursor on disk.",
-                Style::default().fg(Color::White),
+                Style::default().fg(self.theme.ui(Color::White)),
             )),
             ratatui::text::Line::from(""),
             ratatui::text::Line::from(ratatui::text::Span::styled(
@@ -13340,7 +13386,7 @@ impl App {
         let body = ratatui::text::Text::from(vec![
             ratatui::text::Line::from(ratatui::text::Span::styled(
                 "This reverts every tracked file to HEAD. Untracked files are kept.",
-                Style::default().fg(Color::White),
+                Style::default().fg(self.theme.ui(Color::White)),
             )),
             ratatui::text::Line::from(""),
             ratatui::text::Line::from(vec![
@@ -13408,7 +13454,7 @@ impl App {
                 format!(
                     "Every keystroke and paste will go to {receiving} terminal panes at once (red \u{21f6} pills mark them). Cmd+K I stops it; Cmd+K Shift+I excludes a pane."
                 ),
-                Style::default().fg(Color::White),
+                Style::default().fg(self.theme.ui(Color::White)),
             )),
             ratatui::text::Line::from(""),
             ratatui::text::Line::from(vec![
@@ -13479,15 +13525,15 @@ impl App {
         let body = ratatui::text::Text::from(vec![
             Line::from(Span::styled(
                 "Croft draws its icons and images with inline-image protocols",
-                Style::default().fg(Color::White),
+                Style::default().fg(self.theme.ui(Color::White)),
             )),
             Line::from(Span::styled(
                 format!("that {current} does not support, so the activity bar and"),
-                Style::default().fg(Color::White),
+                Style::default().fg(self.theme.ui(Color::White)),
             )),
             Line::from(Span::styled(
                 "file icons stay blank. Croft still runs; for the full UI use:",
-                Style::default().fg(Color::White),
+                Style::default().fg(self.theme.ui(Color::White)),
             )),
             Line::from(""),
             Line::from(vec![
@@ -13567,7 +13613,7 @@ impl App {
         let body = ratatui::text::Text::from(vec![
             ratatui::text::Line::from(ratatui::text::Span::styled(
                 "This URL will open in YOUR LOCAL MAC's browser via the croft relay.",
-                Style::default().fg(Color::White),
+                Style::default().fg(self.theme.ui(Color::White)),
             )),
             ratatui::text::Line::from(""),
             ratatui::text::Line::from(ratatui::text::Span::styled(
@@ -13735,7 +13781,7 @@ impl App {
         let title = ratatui::text::Span::styled(
             format!(" {} ", p.label),
             Style::default()
-                .fg(Color::White)
+                .fg(self.theme.ui(Color::White))
                 .bg(title_bg)
                 .add_modifier(Modifier::BOLD),
         );
@@ -13766,7 +13812,7 @@ impl App {
                     ratatui::text::Span::raw("> "),
                     ratatui::text::Span::styled(
                         p.buffer.as_str(),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(self.theme.ui(Color::White)),
                     ),
                     ratatui::text::Span::styled("█", Style::default().fg(cursor_fg)),
                 ]),
@@ -13777,7 +13823,7 @@ impl App {
                     ratatui::text::Span::raw("> "),
                     ratatui::text::Span::styled(
                         p.buffer.as_str(),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(self.theme.ui(Color::White)),
                     ),
                     ratatui::text::Span::styled("█", Style::default().fg(cursor_fg)),
                 ]),
@@ -13788,7 +13834,7 @@ impl App {
                     ratatui::text::Span::raw("> "),
                     ratatui::text::Span::styled(
                         p.buffer.as_str(),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(self.theme.ui(Color::White)),
                     ),
                     ratatui::text::Span::styled("█", Style::default().fg(cursor_fg)),
                 ]),
@@ -13799,7 +13845,7 @@ impl App {
                     ratatui::text::Span::raw("> "),
                     ratatui::text::Span::styled(
                         p.buffer.as_str(),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(self.theme.ui(Color::White)),
                     ),
                     ratatui::text::Span::styled("█", Style::default().fg(cursor_fg)),
                 ]),
@@ -13810,7 +13856,7 @@ impl App {
                     ratatui::text::Span::raw("> "),
                     ratatui::text::Span::styled(
                         p.buffer.as_str(),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(self.theme.ui(Color::White)),
                     ),
                     ratatui::text::Span::styled("█", Style::default().fg(cursor_fg)),
                 ]),
@@ -13825,7 +13871,7 @@ impl App {
                     ratatui::text::Span::raw("> "),
                     ratatui::text::Span::styled(
                         p.buffer.as_str(),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(self.theme.ui(Color::White)),
                     ),
                     ratatui::text::Span::styled("█", Style::default().fg(cursor_fg)),
                 ]),
@@ -13836,7 +13882,7 @@ impl App {
                     ratatui::text::Span::raw("> "),
                     ratatui::text::Span::styled(
                         p.buffer.as_str(),
-                        Style::default().fg(Color::White),
+                        Style::default().fg(self.theme.ui(Color::White)),
                     ),
                     ratatui::text::Span::styled("█", Style::default().fg(cursor_fg)),
                 ]),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6689,7 +6689,7 @@ fn welcome_image_bake_produces_osc1337_carrying_logo_pixels() {
 
 #[test]
 fn brand_spans_render_the_cr_ft_wordmark_with_orange_brackets() {
-    let spans = brand_spans();
+    let spans = brand_spans(crate::theme::Theme::default());
     let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
     assert_eq!(text, " cr<>ft ");
     // The "<>" (the stylised "o") carries the logo orange; letters stay white.
@@ -11497,6 +11497,56 @@ fn quick_open_popup_follows_the_light_theme() {
                 luma < 128.0,
                 "light finder text must be dark on the white popup, got {:?}",
                 cell.fg
+            );
+        }
+    }
+}
+
+/// Issue #217: the Explorer's file names were white-on-white under Croft
+/// Light (a bare `Color::White` that bypassed the theme adapter). Render
+/// the tree under the light theme and inspect the actual name cell: the
+/// text must be dark, and under a dark theme it must stay white.
+#[test]
+fn explorer_names_are_legible_on_the_light_theme() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("alpha.rs"), "").unwrap();
+    for (theme, want_dark) in [
+        (crate::theme::Theme::DARK_BLUE, false),
+        (crate::theme::Theme::from_id("light"), true),
+    ] {
+        let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+        app.apply_theme(theme);
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut term = ratatui::Terminal::new(backend).unwrap();
+        term.draw(|frame| app.render(frame)).unwrap();
+        // Find the cell where "alpha.rs" is painted in the tree column.
+        let buf = term.backend().buffer();
+        let mut found = None;
+        'rows: for y in 0..40u16 {
+            for x in 0..40u16 {
+                if buf[(x, y)].symbol() == "a"
+                    && buf[(x + 1, y)].symbol() == "l"
+                    && buf[(x + 2, y)].symbol() == "p"
+                    && buf[(x + 3, y)].symbol() == "h"
+                {
+                    found = Some((x, y));
+                    break 'rows;
+                }
+            }
+        }
+        let (x, y) = found.expect("alpha.rs must be visible in the Explorer");
+        let fg = buf[(x, y)].fg;
+        if want_dark {
+            let ratatui::style::Color::Rgb(r, g, b) = fg else {
+                panic!("light tree names must resolve to Rgb, got {fg:?}")
+            };
+            let luma = 0.299 * f32::from(r) + 0.587 * f32::from(g) + 0.114 * f32::from(b);
+            assert!(luma < 128.0, "tree name must be dark on white, got {fg:?}");
+        } else {
+            assert_eq!(
+                fg,
+                ratatui::style::Color::White,
+                "dark themes keep the historical white tree names"
             );
         }
     }

--- a/src/iterm2_inline.rs
+++ b/src/iterm2_inline.rs
@@ -577,6 +577,38 @@ pub fn fit_image(
     fit_image_auto(src_png, canvas_w_px, canvas_h_px, bg)
 }
 
+/// [`fit_image`] with an optional ink recolor for light themes: pixels that
+/// are near-white (every channel above ~200) take `ink`'s hue while keeping
+/// their alpha, so a brand asset drawn with white glyphs (the welcome
+/// wordmark's "cr" / "ft" letters) stays legible on a white canvas. Colored
+/// strokes (the logo's orange and teal) pass through untouched. `None`
+/// bakes exactly like [`fit_image`].
+pub fn fit_image_with_ink(
+    src_png: &[u8],
+    canvas_w_px: u32,
+    canvas_h_px: u32,
+    bg: Rgba<u8>,
+    ink: Option<(u8, u8, u8)>,
+) -> Result<Vec<u8>, image::ImageError> {
+    let Some((ir, ig, ib)) = ink else {
+        return fit_image_auto(src_png, canvas_w_px, canvas_h_px, bg);
+    };
+    let mut img = image::load_from_memory(src_png)?.to_rgba8();
+    for px in img.pixels_mut() {
+        let [r, g, b, a] = px.0;
+        if a > 0 && r > 200 && g > 200 && b > 200 {
+            // Keep the pixel's alpha so antialiased glyph edges stay soft.
+            px.0 = [ir, ig, ib, a];
+        }
+    }
+    let mut recolored = Vec::with_capacity(src_png.len());
+    image::DynamicImage::ImageRgba8(img).write_to(
+        &mut std::io::Cursor::new(&mut recolored),
+        image::ImageFormat::Png,
+    )?;
+    fit_image_auto(&recolored, canvas_w_px, canvas_h_px, bg)
+}
+
 // Test-only counter of full `fit_image_auto` bakes, so tests can pin that
 // a pure anchor move does not re-decode a photo per scrolled row.
 // Thread-local: the bake runs on the asserting test's own thread, and a
@@ -1003,6 +1035,40 @@ mod tests {
     #[test]
     fn iterm_app_is_iterm2() {
         assert!(is_iterm2_term_program(Some("iTerm.app")));
+    }
+
+    /// Issue #217: the welcome wordmark's white letters vanished on the
+    /// light theme. The ink recolor must turn near-white pixels dark while
+    /// leaving colored strokes (the logo's orange) untouched, and `None`
+    /// must bake byte-identically to the plain path.
+    #[test]
+    fn fit_image_with_ink_darkens_only_the_white_glyphs() {
+        // 2x1 source: one white pixel, one orange pixel.
+        let mut src = RgbaImage::new(2, 1);
+        src.put_pixel(0, 0, Rgba([0xff, 0xff, 0xff, 0xff]));
+        src.put_pixel(1, 0, Rgba([0xe9, 0x7c, 0x41, 0xff]));
+        let mut png = Vec::new();
+        image::DynamicImage::ImageRgba8(src)
+            .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+            .unwrap();
+        let bg = Rgba([0xff, 0xff, 0xff, 0xff]);
+        let baked = fit_image_with_ink(&png, 2, 1, bg, Some((0x3b, 0x3b, 0x3b))).unwrap();
+        let out = image::load_from_memory(&baked).unwrap().to_rgba8();
+        let white_side = out.get_pixel(0, 0);
+        let orange_side = out.get_pixel(1, 0);
+        assert!(
+            white_side.0[0] < 0x80 && white_side.0[1] < 0x80,
+            "the white glyph pixel must take the dark ink, got {white_side:?}"
+        );
+        assert!(
+            orange_side.0[0] > 0xc0 && orange_side.0[2] < 0x80,
+            "the orange stroke must pass through untouched, got {orange_side:?}"
+        );
+        // No ink: identical to the plain bake.
+        assert_eq!(
+            fit_image_with_ink(&png, 2, 1, bg, None).unwrap(),
+            fit_image(&png, 2, 1, bg).unwrap()
+        );
     }
 
     /// Every fixed Kitty image id owns exactly one placement: two overlays

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Feature,
-    summary: "Reopen Closed Editor: Cmd+K Shift+W (or the Command Palette) brings back the most recently closed editor tab with its pin state, cursor, and scroll, walking back through the last 20 closes.",
+    kind: NoteKind::Fix,
+    summary: "The light theme is now legible everywhere: Explorer file names, panel headers, dialog text, menus, the status-bar and welcome wordmarks, the version badge, and the release card all render dark-on-light instead of keeping their dark-theme whites and pale accents.",
 }];

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -336,6 +336,7 @@ impl Theme {
                 Color::Yellow | Color::LightYellow => Color::Rgb(0xbf, 0x88, 0x03),
                 Color::Green | Color::LightGreen => Color::Rgb(0x10, 0x7c, 0x10),
                 Color::Cyan | Color::LightCyan => Color::Rgb(0x05, 0x98, 0xbc),
+                Color::Gray => Color::Rgb(0x61, 0x61, 0x61),
                 other => other,
             };
         };

--- a/src/widgets/captures.rs
+++ b/src/widgets/captures.rs
@@ -138,7 +138,7 @@ impl Widget for &mut CapturesPanel {
         let accent = if self.focus_gradient {
             crate::gradient::rgb_color(crate::gradient::PANEL_TITLE_FG)
         } else {
-            Color::White
+            self.theme.ui(Color::White)
         };
         buf.set_style(area, Style::default().bg(self.theme.editor_bg()));
 

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -304,7 +304,7 @@ fn render_hex(
             } else if byte_dim {
                 dim
             } else {
-                Style::default().fg(Color::Gray).bg(bg)
+                Style::default().fg(theme.ui(Color::Gray)).bg(bg)
             };
             let (hex_style, ascii_style) = if is_cursor {
                 if view.ascii_focus {
@@ -326,7 +326,7 @@ fn render_hex(
         &status,
         inner.width as usize,
         Style::default()
-            .fg(Color::Gray)
+            .fg(theme.ui(Color::Gray))
             .bg(theme.ui(Color::Rgb(0x07, 0x33, 0x55))),
     );
 }
@@ -404,7 +404,7 @@ fn render_archive(
         } else if entry.dir {
             Style::default().fg(Color::DarkGray).bg(bg)
         } else {
-            Style::default().fg(Color::Gray).bg(bg)
+            Style::default().fg(theme.ui(Color::Gray)).bg(bg)
         };
         let name_w = (inner.width as usize).saturating_sub(size.len() + 3);
         let line = format!(" {marker}{:<name_w$}{size}", entry.path, name_w = name_w);
@@ -417,7 +417,7 @@ fn render_archive(
         hint,
         inner.width as usize,
         Style::default()
-            .fg(Color::Gray)
+            .fg(theme.ui(Color::Gray))
             .bg(theme.ui(Color::Rgb(0x07, 0x33, 0x55))),
     );
 }
@@ -625,7 +625,7 @@ fn render_sheet(
         status_y,
         &status,
         Style::default()
-            .fg(Color::Gray)
+            .fg(theme.ui(Color::Gray))
             .bg(theme.ui(Color::Rgb(0x14, 0x18, 0x22))),
     );
 }
@@ -1000,7 +1000,7 @@ fn render_diff(
         status_y,
         &status,
         Style::default()
-            .fg(Color::Gray)
+            .fg(theme.ui(Color::Gray))
             .bg(theme.ui(Color::Rgb(0x14, 0x18, 0x22))),
     );
     (prev_arrow, next_arrow)
@@ -1298,7 +1298,7 @@ fn render_unified_deletion(
         status_y,
         &status,
         Style::default()
-            .fg(Color::Gray)
+            .fg(theme.ui(Color::Gray))
             .bg(theme.ui(Color::Rgb(0x14, 0x18, 0x22))),
     );
     (prev_arrow, next_arrow)
@@ -9276,7 +9276,7 @@ impl Widget for &mut Editor {
             if (!wrap || row_start == 0) && self.is_foldable(line_idx) {
                 let collapsed = self.folded.contains(&line_idx);
                 let (glyph, color) = if collapsed {
-                    ("▸", Color::Gray)
+                    ("▸", self.theme.ui(Color::Gray))
                 } else {
                     ("▾", Color::DarkGray)
                 };
@@ -11672,7 +11672,7 @@ impl Widget for &mut EditorTabs {
                 // Symbol crumbs (clickable) read brighter than the informational
                 // path crumbs, mirroring VS Code's active/inactive breadcrumbs.
                 let fg = if crumb.target.is_some() {
-                    Color::Gray
+                    self.theme.ui(Color::Gray)
                 } else {
                     Color::DarkGray
                 };

--- a/src/widgets/file_tree.rs
+++ b/src/widgets/file_tree.rs
@@ -1337,7 +1337,7 @@ impl Widget for &mut FileTree {
             Span::styled(
                 " EXPLORER ",
                 Style::default()
-                    .fg(Color::White)
+                    .fg(self.theme.ui(Color::White))
                     .bg(self.theme.ui(Color::Rgb(0x1e, 0x3a, 0x6e)))
                     .add_modifier(Modifier::BOLD),
             )
@@ -1455,7 +1455,7 @@ impl Widget for &mut FileTree {
             let name_fg = if self.is_ignored(&node.path) {
                 self.theme.ignored_fg()
             } else {
-                Color::White
+                self.theme.ui(Color::White)
             };
 
             if node.is_dir {
@@ -1471,11 +1471,11 @@ impl Widget for &mut FileTree {
                 };
                 spans.push(Span::styled(
                     format!("{chev} "),
-                    Style::default().fg(Color::Gray),
+                    Style::default().fg(self.theme.ui(Color::Gray)),
                 ));
                 spans.push(Span::styled(
                     format!("{} ", icon.glyph),
-                    Style::default().fg(icon.color),
+                    Style::default().fg(self.theme.ui(icon.color)),
                 ));
                 let base = Style::default().fg(name_fg).add_modifier(Modifier::BOLD);
                 push_name_spans(&mut spans, &name, &query, base, self.theme);
@@ -1489,7 +1489,7 @@ impl Widget for &mut FileTree {
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled(
                     format!("{} ", icon.glyph),
-                    Style::default().fg(icon.color),
+                    Style::default().fg(self.theme.ui(icon.color)),
                 ));
                 push_name_spans(
                     &mut spans,
@@ -1622,17 +1622,19 @@ impl Widget for &mut FileTree {
                 let name_fg = if self.is_ignored(&node.path) {
                     self.theme.ignored_fg()
                 } else {
-                    Color::White
+                    self.theme.ui(Color::White)
                 };
                 let spans = vec![
                     Span::raw("  ".repeat(node.depth)),
                     Span::styled(
                         format!("{} ", icons::CHEVRON_OPEN),
-                        Style::default().fg(Color::Gray).bg(bg),
+                        Style::default().fg(self.theme.ui(Color::Gray)).bg(bg),
                     ),
                     Span::styled(
                         format!("{} ", icons::FOLDER_OPEN.glyph),
-                        Style::default().fg(icons::FOLDER_OPEN.color).bg(bg),
+                        Style::default()
+                            .fg(self.theme.ui(icons::FOLDER_OPEN.color))
+                            .bg(bg),
                     ),
                     Span::styled(
                         name,

--- a/src/widgets/open_editors.rs
+++ b/src/widgets/open_editors.rs
@@ -302,7 +302,7 @@ impl Widget for &mut OpenEditorsPanel {
             };
             let name_style = if item.active {
                 Style::default()
-                    .fg(Color::White)
+                    .fg(self.theme.ui(Color::White))
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(self.theme.ui(COLOR_NAME))

--- a/src/widgets/outline.rs
+++ b/src/widgets/outline.rs
@@ -437,7 +437,7 @@ impl Widget for &mut OutlinePanel {
             spans.push(Span::raw("  ".repeat(depth)));
             spans.push(Span::styled(
                 format!("{} ", icon.glyph),
-                Style::default().fg(icon.color),
+                Style::default().fg(self.theme.ui(icon.color)),
             ));
             spans.push(Span::styled(
                 sym.name.clone(),

--- a/src/widgets/output.rs
+++ b/src/widgets/output.rs
@@ -330,7 +330,7 @@ impl Widget for &mut OutputPanel {
         let accent = if self.focus_gradient {
             crate::gradient::rgb_color(crate::gradient::PANEL_TITLE_FG)
         } else {
-            Color::White
+            self.theme.ui(Color::White)
         };
         buf.set_style(area, Style::default().bg(self.theme.editor_bg()));
 

--- a/src/widgets/ports.rs
+++ b/src/widgets/ports.rs
@@ -320,7 +320,7 @@ impl Widget for &mut PortsPanel {
         let accent = if self.focus_gradient {
             crate::gradient::rgb_color(crate::gradient::PANEL_TITLE_FG)
         } else {
-            Color::White
+            self.theme.ui(Color::White)
         };
         let orange = crate::gradient::rgb_color(crate::gradient::GRAD_TR);
         buf.set_style(area, Style::default().bg(self.theme.editor_bg()));

--- a/src/widgets/problems.rs
+++ b/src/widgets/problems.rs
@@ -566,7 +566,10 @@ impl ProblemsPanel {
                 format!("{chevron} "),
                 Style::default().fg(self.theme.ui(COLOR_DIM)),
             ),
-            Span::styled(format!("{} ", icon.glyph), Style::default().fg(icon.color)),
+            Span::styled(
+                format!("{} ", icon.glyph),
+                Style::default().fg(self.theme.ui(icon.color)),
+            ),
             Span::styled(
                 group.name.clone(),
                 Style::default()

--- a/src/widgets/remote.rs
+++ b/src/widgets/remote.rs
@@ -273,7 +273,10 @@ fn render_section_header(panel: &mut RemotePanel, buf: &mut Buffer, inner: Rect)
         inner.x,
         inner.y,
         &Line::from(vec![
-            Span::styled(format!("{chevron} "), Style::default().fg(Color::Gray)),
+            Span::styled(
+                format!("{chevron} "),
+                Style::default().fg(panel.theme.ui(Color::Gray)),
+            ),
             Span::styled("SSH", header_style),
         ]),
         inner.width,
@@ -336,7 +339,7 @@ fn render_filter_row(buf: &mut Buffer, area: Rect, filter: &str, theme: crate::t
         .fg(theme.ui(Color::Rgb(0x9d, 0xa5, 0xb4)))
         .add_modifier(Modifier::ITALIC);
     let val_style = Style::default()
-        .fg(Color::White)
+        .fg(theme.ui(Color::White))
         .add_modifier(Modifier::BOLD);
     let prefix = "filter: ";
     buf.set_string(area.x, area.y, prefix, label_style);
@@ -409,7 +412,7 @@ fn render_empty_state(panel: &mut RemotePanel, buf: &mut Buffer, area: Rect) {
             y,
             title,
             Style::default()
-                .fg(Color::White)
+                .fg(panel.theme.ui(Color::White))
                 .add_modifier(Modifier::BOLD),
         );
         y += 2;
@@ -764,7 +767,7 @@ impl Widget for &mut RemotePanel {
                 Span::styled(
                     target.alias.as_str(),
                     Style::default()
-                        .fg(Color::White)
+                        .fg(self.theme.ui(Color::White))
                         .add_modifier(Modifier::BOLD),
                 ),
             ];

--- a/src/widgets/search.rs
+++ b/src/widgets/search.rs
@@ -1592,9 +1592,9 @@ fn render_field(
                 .add_modifier(Modifier::ITALIC),
         ));
     } else {
-        let plain = Style::default().fg(Color::White).bg(fill);
+        let plain = Style::default().fg(theme.ui(Color::White)).bg(fill);
         let selected = Style::default()
-            .fg(Color::White)
+            .fg(theme.ui(Color::White))
             .bg(theme.ui(Color::Rgb(0x26, 0x4f, 0x78)));
         match args.selection {
             Some((a, b)) if a < b => {
@@ -2111,7 +2111,7 @@ impl Widget for &mut SearchPanel {
                         .add_modifier(Modifier::BOLD)
                 }
             } else {
-                Style::default().fg(Color::White)
+                Style::default().fg(self.theme.ui(Color::White))
             };
             let needle = self.query.trim();
             // High-contrast yellow background like ripgrep / VS Code's
@@ -2122,7 +2122,7 @@ impl Widget for &mut SearchPanel {
                 .fg(Color::Black)
                 .bg(self.theme.ui(Color::Rgb(0xff, 0xd7, 0x4a)))
                 .add_modifier(Modifier::BOLD);
-            let plain_style = Style::default().fg(Color::Gray);
+            let plain_style = Style::default().fg(self.theme.ui(Color::Gray));
             let mut spans: Vec<Span> = vec![
                 Span::styled(format!(" {path_display}"), header_style),
                 Span::styled(

--- a/src/widgets/source_control.rs
+++ b/src/widgets/source_control.rs
@@ -587,11 +587,11 @@ impl SourceControlPanel {
             let hover_bg =
                 crate::widgets::hover::row_hover_bg(rect, self.hover_pointer, self.theme);
             let (bg, fg) = if row.active {
-                (self.theme.selection(), Color::White)
+                (self.theme.selection(), self.theme.ui(Color::White))
             } else if let Some(h) = hover_bg {
-                (h, Color::Gray)
+                (h, self.theme.ui(Color::Gray))
             } else {
-                (Color::Reset, Color::Gray)
+                (Color::Reset, self.theme.ui(Color::Gray))
             };
             for x in rect.x..rect.x + rect.width {
                 buf[(x, y)].set_bg(bg);
@@ -1146,7 +1146,7 @@ impl Widget for &mut SourceControlPanel {
         spans.push(Span::styled(
             label,
             Style::default()
-                .fg(Color::White)
+                .fg(self.theme.ui(Color::White))
                 .add_modifier(Modifier::BOLD),
         ));
         if self.status.ahead > 0 {
@@ -1236,7 +1236,7 @@ impl Widget for &mut SourceControlPanel {
                     content_y,
                     &visible,
                     text_max,
-                    Style::default().fg(Color::White),
+                    Style::default().fg(self.theme.ui(Color::White)),
                 );
             }
         }
@@ -1394,7 +1394,7 @@ impl Widget for &mut SourceControlPanel {
                         Span::styled(
                             format!(" {count} "),
                             Style::default()
-                                .fg(Color::White)
+                                .fg(self.theme.ui(Color::White))
                                 .bg(self.theme.ui(Color::Rgb(0x2a, 0x33, 0x42)))
                                 .add_modifier(Modifier::BOLD),
                         ),
@@ -1492,8 +1492,8 @@ impl Widget for &mut SourceControlPanel {
                     let mut badge_style = Style::default()
                         .fg(badge_color(entry.kind, self.theme))
                         .add_modifier(Modifier::BOLD);
-                    let mut icon_style = Style::default().fg(icon.color);
-                    let mut path_style = Style::default().fg(Color::White);
+                    let mut icon_style = Style::default().fg(self.theme.ui(icon.color));
+                    let mut path_style = Style::default().fg(self.theme.ui(Color::White));
                     if let Some(bg) = row_bg {
                         badge_style = badge_style.bg(bg);
                         icon_style = icon_style.bg(bg);

--- a/src/widgets/symbol_picker.rs
+++ b/src/widgets/symbol_picker.rs
@@ -370,9 +370,9 @@ pub fn render_symbol_picker(
         };
         let icon = for_outline_kind(sym.kind);
         let icon_style = if is_selected {
-            Style::default().bg(sel_bg).fg(icon.color)
+            Style::default().bg(sel_bg).fg(theme.ui(icon.color))
         } else {
-            Style::default().fg(icon.color)
+            Style::default().fg(theme.ui(icon.color))
         };
         // Indent nested symbols by depth (capped), like the outline tree.
         let indent = "  ".repeat((sym.depth as usize).min(6));

--- a/src/widgets/workspace_symbols.rs
+++ b/src/widgets/workspace_symbols.rs
@@ -321,9 +321,9 @@ pub fn render_workspace_symbols(
         };
         let icon = for_outline_kind(item.kind);
         let icon_style = if is_selected {
-            Style::default().bg(sel_bg).fg(icon.color)
+            Style::default().bg(sel_bg).fg(theme.ui(icon.color))
         } else {
-            Style::default().fg(icon.color)
+            Style::default().fg(theme.ui(icon.color))
         };
         let prefix = if is_selected { "> " } else { "  " };
         // Right-align the workspace-relative path + line, like the in-file


### PR DESCRIPTION
Closes #217.

## What was broken

The screenshot in #217 shows the first light-theme cut with white backgrounds but dark-theme foregrounds surviving on several surfaces: Explorer file names and grey file icons near-invisible, the welcome "cr<>ft" wordmark ghost-white, the version badge and release-card border in washed-out brand teal.

## Root cause

The light adaptation routes colors through `Theme::ui`, but a whole class of paint sites bypasses it:

- bare `Color::White` bound to variables (tree names, panel headers like " EXPLORER ", dialog body text, menu rows, prompt buffers, the status-bar wordmark, the version badge, active tab labels) rather than the `fg(Color::White)` literal shape the original sweep matched,
- `Color::Gray` chevrons and dividers (now mapped in the adapter's named-color arm),
- file-type icon colors from `icons.rs` consumed raw at every icon site (tree, Source Control rows, outline, Problems groups, both symbol pickers) — the `.txt`/license grey `#cccccc` was the worst,
- the welcome screen's unconditional brand-gradient accents (header chevron, badge border, and the release card's gradient border, whose teal leg washes out on white),
- the welcome wordmark PNG itself, whose "cr"/"ft" letters are white pixels in the asset.

## Fix

- Wrapped every escaped foreground through `Theme::ui` (identity on all dark themes, pinned by the existing adapter tests, so dark renderings are byte-for-byte unchanged).
- `Color::Gray` maps to the light muted grey in the named-color arm.
- The release card paints a plain light widget border on light themes and keeps the brand gradient on dark ones.
- New `fit_image_with_ink`: at bake time on light themes, near-white glyph pixels in the wordmark PNG take dark ink while colored strokes (orange, teal) pass through, preserving antialiased edges via alpha.
- The Source Control no-repo hero asset carries an opaque dark backdrop that cannot be re-inked; light themes keep the panel's text-only empty state instead of a dark slab.

## Verification

- New regression tests: the Explorer name cell must be dark under Croft Light and stay `Color::White` under dark themes (real buffer inspection); `fit_image_with_ink` darkens white glyph pixels, leaves orange untouched, and `None` bakes byte-identically to the plain path.
- Full suite green (3289 lib + 6 CLI), clippy zero.
- Live drive of the built binary in tmux under Croft Light: tree names render `#1f1f1f`, folder icons tan, chevrons dark grey, tagline and header accents in the mapped blues; zero cells remain with the previously-leaking pale greys (`#cccccc`, `#eceff4`) anywhere on the welcome, explorer, or editor screens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved readability across light themes by applying theme-aware colors throughout the editor, file explorer, search, source control, dialogs, panels, and status areas.
  - Corrected light-theme rendering for welcome artwork, release cards, icons, file names, and other UI elements.
  - Updated light-theme gray colors for better contrast.

- **Release Notes**
  - Added a note describing the light-theme legibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->