### PR TITLE
feat(editor): detect indentation from file content on open (v0.1.753)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.752"
+version = "0.1.753"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.752"
+version = "0.1.753"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -206,7 +206,7 @@ All three live under `~/.config/croft/` (XDG-resolved, so the same paths on macO
 | Two-finger horizontal swipe, or drag the bar | Pan long lines in code files; the cursor pans the view when it passes either edge |
 | Markdown soft-wrap | Markdown files wrap long lines onto the next visual row (no horizontal scrollbar); `↑`/`↓` move by visual row |
 | Printable char, Enter, Backspace, Delete | Edit (typing or deleting with a selection replaces it) |
-| `Tab` | Indent: a multi-line selection indents every touched line one level; otherwise inserts to the next tab stop (4, or 2 in YAML) |
+| `Tab` | Indent: a multi-line selection indents every touched line one level; otherwise inserts to the next tab stop. The stop width and tabs-vs-spaces are detected from the file's own content on open (VS Code's `editor.detectIndentation`), falling back to the language default (4, or 2 in YAML); the status bar's indent pill shows the result and clicking it overrides both |
 | `Shift`+`Tab` | Outdent one level, tab-stop aligned, for the current line or every line a selection touches |
 | `Alt`+`↑` / `Alt`+`↓` | Move the current line (or selected block) up / down, carrying the cursor and selection |
 | `Shift`+`Alt`+`↑` / `↓` | Copy the current line (or selected block) up / down |

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -17325,13 +17325,20 @@ fn clicking_an_outline_row_jumps_the_editor_to_that_symbol() {
 #[test]
 fn shift_tab_in_editor_dedents_the_current_python_line() {
     let tmp = tempfile::tempdir().unwrap();
-    let mut app = app_with_open_file(tmp.path(), "snippet.py", "def f():\n        pass\n");
-    app.editor.cursor_row = 1;
+    // Two 4-space levels so indent detection (#211) reads the file's step
+    // as 4; the old single 8-space jump now detects (correctly) as one
+    // 8-wide level.
+    let mut app = app_with_open_file(
+        tmp.path(),
+        "snippet.py",
+        "def f():\n    if x:\n        pass\n",
+    );
+    app.editor.cursor_row = 2;
     app.editor.cursor_col = 8;
     // Shift+Tab reaches the editor as BackTab.
     app.handle_editor_key(key(KeyCode::BackTab, KeyModifiers::SHIFT));
     assert_eq!(
-        app.editor.lines[1], "    pass",
+        app.editor.lines[2], "    pass",
         "Shift+Tab must outdent the line one level"
     );
     assert_eq!(app.editor.cursor_col, 4);

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Feature,
-    summary: "Navigation history is now two-way: Ctrl+Shift+- goes forward along the trail Go Back walked, and Cmd+K Cmd+Q jumps to the last edit location, both also in the Command Palette and the editor context menu.",
+    summary: "Indentation is now detected from each file's own content on open (tabs vs spaces and the step width), so Tab matches the file's existing style instead of the language default; the status bar's indent pill reflects it and a manual override still wins.",
 }];

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -1650,6 +1650,66 @@ pub struct IndentStyle {
     pub use_spaces: bool,
 }
 
+/// Detect the dominant indentation of a buffer's lines (VS Code's
+/// `editor.detectIndentation`). Tabs vs spaces is a straight majority of
+/// indented lines; the space width is the most common positive step
+/// between consecutive indentation depths (2..=8), falling back to the
+/// smallest leading run when the file never nests. `None` when nothing is
+/// indented, so the caller keeps the language default. Scans at most the
+/// first 10k lines: enough signal for any real file, bounded for huge ones.
+pub fn detect_indentation(lines: &[String]) -> Option<IndentStyle> {
+    let mut tab_lines = 0usize;
+    let mut space_lines = 0usize;
+    let mut steps: [usize; 9] = [0; 9];
+    let mut prev_depth = 0usize;
+    let mut min_run = usize::MAX;
+    for line in lines.iter().take(10_000) {
+        if line.starts_with('\t') {
+            tab_lines += 1;
+            continue;
+        }
+        let depth = line.chars().take_while(|&c| c == ' ').count();
+        if depth == 0 {
+            if !line.is_empty() {
+                prev_depth = 0;
+            }
+            continue;
+        }
+        if line.chars().nth(depth).is_none() {
+            // Whitespace-only lines carry no intent.
+            continue;
+        }
+        space_lines += 1;
+        min_run = min_run.min(depth);
+        let step = depth.abs_diff(prev_depth);
+        if (2..=8).contains(&step) {
+            steps[step] += 1;
+        }
+        prev_depth = depth;
+    }
+    if tab_lines == 0 && space_lines == 0 {
+        return None;
+    }
+    if tab_lines >= space_lines {
+        return Some(IndentStyle {
+            width: 4,
+            use_spaces: false,
+        });
+    }
+    let width = steps
+        .iter()
+        .enumerate()
+        .skip(2)
+        .max_by(|a, b| a.1.cmp(b.1).then(b.0.cmp(&a.0)))
+        .filter(|&(_, &n)| n > 0)
+        .map(|(w, _)| w)
+        .or(((2..=8).contains(&min_run)).then_some(min_run))?;
+    Some(IndentStyle {
+        width: width as u32,
+        use_spaces: true,
+    })
+}
+
 impl IndentStyle {
     /// The indentation unit as text: `width` spaces, or a single tab.
     pub fn unit(self) -> String {
@@ -1947,6 +2007,11 @@ pub struct Editor {
     /// falls back to the language default (2 spaces for YAML, 4 otherwise);
     /// `Some` pins spaces-vs-tabs and width for newly typed indentation.
     indent_override: Option<IndentStyle>,
+    /// Indentation detected from the buffer's own content on open (VS
+    /// Code's `editor.detectIndentation`): `Some` when the file showed a
+    /// clear preference, `None` when it gave no signal. The manual
+    /// status-bar override always wins over this.
+    detected_indent: Option<IndentStyle>,
     /// Line-ending style, detected on open and applied on save. Surfaced in the
     /// status bar; the user can switch it there.
     pub eol: LineEnding,
@@ -2191,6 +2256,7 @@ impl Editor {
             last_edit_kind: None,
             lang: None,
             indent_override: None,
+            detected_indent: None,
             eol: LineEnding::Lf,
             encoding: encoding_rs::UTF_8,
             bom: false,
@@ -3272,6 +3338,9 @@ impl Editor {
         if self.lines.is_empty() {
             self.lines.push(String::new());
         }
+        // VS Code's editor.detectIndentation: the freshly loaded content
+        // decides the buffer's indent style unless the user overrides it.
+        self.detected_indent = detect_indentation(&self.lines);
         self.hscroll_content_cols = None;
         self.wrap_total_cache.clear();
         self.scroll_sub = 0;
@@ -4655,13 +4724,16 @@ impl Editor {
         n
     }
 
-    /// The buffer's active indentation style: the status-bar override if set,
-    /// else the language default (2 spaces for YAML, 4 spaces otherwise).
+    /// The buffer's active indentation style: the status-bar override if
+    /// set, else the style detected from the file's content on open, else
+    /// the language default (2 spaces for YAML, 4 spaces otherwise).
     pub fn indent_style(&self) -> IndentStyle {
-        self.indent_override.unwrap_or(IndentStyle {
-            width: indent_unit_for(self.lang).chars().count() as u32,
-            use_spaces: true,
-        })
+        self.indent_override
+            .or(self.detected_indent)
+            .unwrap_or(IndentStyle {
+                width: indent_unit_for(self.lang).chars().count() as u32,
+                use_spaces: true,
+            })
     }
 
     /// Pin the buffer's indentation style (status-bar "Indent Using …" /
@@ -20847,6 +20919,98 @@ mod tests {
         e.indentation_to_tabs();
         // 4 spaces -> 1 tab; 6 spaces -> 1 tab + 2 leftover; interior spaces stay.
         assert_eq!(e.lines, vec!["\tfoo", "\t  bar", "b  c"]);
+    }
+
+    /// Issue #211: VS Code's editor.detectIndentation. Opening a file
+    /// whose content indents with 2 spaces must set the buffer's indent
+    /// style to 2 spaces even though the language default is 4; tabs win
+    /// when the content uses tabs; a flat file keeps the language default;
+    /// the manual status-bar override still beats detection.
+    #[test]
+    fn open_detects_indentation_from_file_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let two = tmp.path().join("two.rs");
+        std::fs::write(
+            &two,
+            "fn main() {\n  let a = 1;\n  if a > 0 {\n    println!();\n  }\n}\n",
+        )
+        .unwrap();
+        let mut e = Editor::new();
+        e.open(&two).unwrap();
+        assert_eq!(
+            e.indent_style(),
+            IndentStyle {
+                width: 2,
+                use_spaces: true
+            },
+            "2-space content must be detected over the 4-space rust default"
+        );
+
+        let tabs = tmp.path().join("tabs.rs");
+        std::fs::write(
+            &tabs,
+            "fn main() {\n\tlet a = 1;\n\tif a > 0 {\n\t\tprintln!();\n\t}\n}\n",
+        )
+        .unwrap();
+        let mut t = Editor::new();
+        t.open(&tabs).unwrap();
+        assert!(
+            !t.indent_style().use_spaces,
+            "tab-indented content must detect tabs"
+        );
+
+        let flat = tmp.path().join("flat.rs");
+        std::fs::write(&flat, "fn main() {}\nfn other() {}\n").unwrap();
+        let mut f = Editor::new();
+        f.open(&flat).unwrap();
+        assert_eq!(
+            f.indent_style(),
+            IndentStyle {
+                width: 4,
+                use_spaces: true
+            },
+            "a file with no indented lines keeps the language default"
+        );
+
+        // The manual override still wins over detection.
+        let mut o = Editor::new();
+        o.open(&two).unwrap();
+        o.set_indent_style(IndentStyle {
+            width: 8,
+            use_spaces: true,
+        });
+        assert_eq!(o.indent_style().width, 8, "override beats detection");
+    }
+
+    /// The pure detector: majority rules between tabs and spaces, and the
+    /// space width comes from the most common indentation step.
+    #[test]
+    fn detect_indentation_picks_majority_and_step() {
+        let lines = |v: &[&str]| v.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert_eq!(
+            detect_indentation(&lines(&["a {", "    b;", "        c;", "    d;", "}"])),
+            Some(IndentStyle {
+                width: 4,
+                use_spaces: true
+            })
+        );
+        assert_eq!(
+            detect_indentation(&lines(&["a {", "\tb;", "\t\tc;", "}"])),
+            Some(IndentStyle {
+                width: 4,
+                use_spaces: false
+            })
+        );
+        assert_eq!(detect_indentation(&lines(&["a", "b", "c"])), None);
+        // Mixed content: the majority style wins (three tab lines, one
+        // spaced line).
+        assert_eq!(
+            detect_indentation(&lines(&["a {", "\tb;", "\tc;", "\td;", "  e;", "}"])),
+            Some(IndentStyle {
+                width: 4,
+                use_spaces: false
+            })
+        );
     }
 
     #[test]

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -1665,7 +1665,12 @@ pub fn detect_indentation(lines: &[String]) -> Option<IndentStyle> {
     let mut min_run = usize::MAX;
     for line in lines.iter().take(10_000) {
         if line.starts_with('\t') {
-            tab_lines += 1;
+            // Whitespace-only lines carry no intent, same as the space
+            // branch below: a blank line with leftover tab indentation
+            // must not vote.
+            if line.chars().any(|c| !c.is_whitespace()) {
+                tab_lines += 1;
+            }
             continue;
         }
         let depth = line.chars().take_while(|&c| c == ' ').count();
@@ -21009,6 +21014,16 @@ mod tests {
             Some(IndentStyle {
                 width: 4,
                 use_spaces: false
+            })
+        );
+        // Whitespace-only lines carry no intent on EITHER side: tab-only
+        // blank lines must not outvote real space indentation (review
+        // round 1).
+        assert_eq!(
+            detect_indentation(&lines(&["a {", "  b;", "  c;", "\t", "\t\t", "\t \t", "}"])),
+            Some(IndentStyle {
+                width: 2,
+                use_spaces: true
             })
         );
     }


### PR DESCRIPTION
Closes #211.

## What

VS Code's `editor.detectIndentation` for croft: opening a text file now detects its indentation from the content itself.

- Tabs vs spaces is a straight majority of indented lines (scanning at most the first 10k lines).
- The space width is the most common positive step between consecutive indentation depths (2..=8), falling back to the smallest leading run for files that indent but never nest.
- Precedence: the manual status-bar override still wins over detection, and the language default (4, or 2 for YAML) remains the fallback when the file shows no signal.
- Everything downstream follows automatically: the Tab key's insert unit, Shift+Tab dedent width, LSP formatting preferences, and the status bar's "Spaces: N" pill.

## Tests

- Pure detector: 4-space nesting, tab files, flat files (None), and mixed content where the majority wins.
- Editor-level: opening a 2-space Rust file yields width 2 over the 4-space default; tab content detects tabs; flat files keep the default; a manual override beats detection.
- The Shift+Tab dedent fixture gains a second indent level: its old content's only signal was a single 8-space jump, which now detects (correctly, as VS Code would) as one 8-wide level.
- Full suite green (3291 lib + 6 CLI), clippy zero.
- Live drive: opening a 2-space Python file in the built binary shows "Spaces: 2" in the status pill where the language default is 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects whether files use tabs or spaces and identifies the indentation width.
  * Applies detected indentation settings when opening files, while preserving language defaults when detection is inconclusive.
  * Manual indentation settings from the status bar take precedence over detected values.
* **Documentation**
  * Updated editor shortcut documentation to describe automatic indentation detection and manual overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->