### PR TITLE
test: harden the two load-sensitive test harnesses

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -22,6 +22,33 @@ fn probe_command(probe: &str) -> String {
     format!("printf '%s%s\\n' '{head}' '{tail}'\r")
 }
 
+/// How long the terminal end-to-end tests wait for their probe to come back
+/// through the PTY. Generous on purpose: a real shell has to start, run the
+/// command, and have the reader thread drain the bytes into the grid, and on
+/// a box running the whole suite in parallel that took longer than the three
+/// seconds this used to allow (issue #226).
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Run the probe command in the app's embedded terminal and wait until the
+/// probe is on screen. Panics with the actual screen contents if it never
+/// arrives, so a failure says what the terminal was showing instead of
+/// unwrapping `None` several lines later.
+fn await_terminal_probe(app: &mut App, probe: &str) {
+    app.terminal_mut()
+        .write_input(probe_command(probe).as_bytes());
+    let started = std::time::Instant::now();
+    while started.elapsed() < PROBE_TIMEOUT {
+        if app.terminal().visible_text().contains(probe) {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    panic!(
+        "the shell never printed the probe {probe:?} within {PROBE_TIMEOUT:?}; terminal showed:\n{}",
+        app.terminal().visible_text()
+    );
+}
+
 #[test]
 fn minimap_rgba_paints_chars_skips_whitespace() {
     let mut e = crate::widgets::editor::Editor::new();
@@ -4702,18 +4729,7 @@ fn cmd_c_on_terminal_selection_lands_text_on_macos_clipboard() {
     term.draw(|f| app.render(f)).unwrap();
 
     let probe = format!("croft-terminal-cmdc-{}", std::process::id());
-    app.terminal_mut()
-        .write_input(probe_command(&probe).as_bytes());
-
-    // Wait for the shell to push bytes through the PTY and the
-    // background reader thread to drain them into the grid.
-    let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(3000) {
-        if app.terminal().visible_text().contains(&probe) {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+    await_terminal_probe(&mut app, &probe);
     // Re-render to refresh `last_inner` after the grid has grown.
     term.draw(|f| app.render(f)).unwrap();
 
@@ -6122,15 +6138,7 @@ fn double_click_in_terminal_word_selects_in_split_and_maximised_layout() {
         }
         app.focus_pane(Pane::Terminal);
         let probe = format!("croft-dclick-{}", std::process::id());
-        app.terminal_mut()
-            .write_input(probe_command(&probe).as_bytes());
-        let started = std::time::Instant::now();
-        while started.elapsed() < std::time::Duration::from_millis(3000) {
-            if app.terminal().visible_text().contains(&probe) {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(20));
-        }
+        await_terminal_probe(&mut app, &probe);
         term.draw(|f| app.render(f)).unwrap();
         let snap = app.terminal().visible_text();
         let row_idx = snap
@@ -6180,15 +6188,7 @@ fn terminal_copy_paste_into_other_panes_works_in_split_and_maximised_layout() {
     // landed on the clipboard.
     fn copy_terminal_word(app: &mut App) -> String {
         let probe = format!("croft-e2e-{}", std::process::id());
-        app.terminal_mut()
-            .write_input(probe_command(&probe).as_bytes());
-        let started = std::time::Instant::now();
-        while started.elapsed() < std::time::Duration::from_millis(3000) {
-            if app.terminal().visible_text().contains(&probe) {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(20));
-        }
+        await_terminal_probe(app, &probe);
         let snap = app.terminal().visible_text();
         let row_idx = snap.lines().position(|l| l.contains(&probe)).unwrap();
         let line = snap.lines().nth(row_idx).unwrap();
@@ -6401,15 +6401,7 @@ fn terminal_cmd_c_copies_even_when_search_sidebar_is_open() {
     term.draw(|f| app.render(f)).unwrap();
 
     let probe = format!("croft-search-open-{}", std::process::id());
-    app.terminal_mut()
-        .write_input(probe_command(&probe).as_bytes());
-    let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(3000) {
-        if app.terminal().visible_text().contains(&probe) {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+    await_terminal_probe(&mut app, &probe);
     term.draw(|f| app.render(f)).unwrap();
     let snap = app.terminal().visible_text();
     let row_idx = snap.lines().position(|l| l.contains(&probe)).unwrap();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6,6 +6,22 @@ fn key(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
     KeyEvent::new(code, mods)
 }
 
+/// Shell command that prints `probe` on its own line WITHOUT the typed
+/// command line spelling the probe out.
+///
+/// The terminal end-to-end tests find their probe by searching the rendered
+/// grid for it, but the shell echoes what was typed, so a literal
+/// `printf '<probe>\n'` puts two matching rows on screen. Under load the echo
+/// arrives first, the wait loop is satisfied by it, and the row search lands
+/// on the echoed command: its quoting shifts the columns, and the selection
+/// comes back as `"oft-e2e-638881\\n"` instead of the probe (issue #226).
+/// Splitting the probe across two printf arguments leaves the echo carrying
+/// only the fragments, so nothing but the OUTPUT can ever match.
+fn probe_command(probe: &str) -> String {
+    let (head, tail) = probe.split_at(1);
+    format!("printf '%s%s\\n' '{head}' '{tail}'\r")
+}
+
 #[test]
 fn minimap_rgba_paints_chars_skips_whitespace() {
     let mut e = crate::widgets::editor::Editor::new();
@@ -4687,7 +4703,7 @@ fn cmd_c_on_terminal_selection_lands_text_on_macos_clipboard() {
 
     let probe = format!("croft-terminal-cmdc-{}", std::process::id());
     app.terminal_mut()
-        .write_input(format!("printf '{probe}\\n'\r").as_bytes());
+        .write_input(probe_command(&probe).as_bytes());
 
     // Wait for the shell to push bytes through the PTY and the
     // background reader thread to drain them into the grid.
@@ -6107,7 +6123,7 @@ fn double_click_in_terminal_word_selects_in_split_and_maximised_layout() {
         app.focus_pane(Pane::Terminal);
         let probe = format!("croft-dclick-{}", std::process::id());
         app.terminal_mut()
-            .write_input(format!("printf '{probe}\\n'\r").as_bytes());
+            .write_input(probe_command(&probe).as_bytes());
         let started = std::time::Instant::now();
         while started.elapsed() < std::time::Duration::from_millis(3000) {
             if app.terminal().visible_text().contains(&probe) {
@@ -6165,7 +6181,7 @@ fn terminal_copy_paste_into_other_panes_works_in_split_and_maximised_layout() {
     fn copy_terminal_word(app: &mut App) -> String {
         let probe = format!("croft-e2e-{}", std::process::id());
         app.terminal_mut()
-            .write_input(format!("printf '{probe}\\n'\r").as_bytes());
+            .write_input(probe_command(&probe).as_bytes());
         let started = std::time::Instant::now();
         while started.elapsed() < std::time::Duration::from_millis(3000) {
             if app.terminal().visible_text().contains(&probe) {
@@ -6325,6 +6341,47 @@ fn terminal_copy_paste_into_other_panes_works_in_split_and_maximised_layout() {
     }
 }
 
+/// Issue #226: the probe command must not spell the probe out, or the
+/// shell's echo of it becomes a second row that matches the grid search
+/// (and wins the race under load). Pins both halves of `probe_command`:
+/// the echoed text can't contain the probe, and running it still puts the
+/// probe on screen.
+#[test]
+fn the_terminal_probe_command_prints_the_probe_without_echoing_it() {
+    let probe = format!("croft-probe-echo-{}", std::process::id());
+    let cmd = probe_command(&probe);
+    assert!(
+        !cmd.contains(&probe),
+        "the typed command line must not contain the probe verbatim, or the shell echo matches the grid search alongside the output; got {cmd:?}"
+    );
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    let backend = ratatui::backend::TestBackend::new(120, 40);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    app.terminal_mut().focused = true;
+    term.draw(|f| app.render(f)).unwrap();
+    app.terminal_mut().write_input(cmd.as_bytes());
+    let started = std::time::Instant::now();
+    while started.elapsed() < std::time::Duration::from_millis(3000) {
+        if app.terminal().visible_text().contains(&probe) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    let snap = app.terminal().visible_text();
+    let rows: Vec<&str> = snap.lines().filter(|l| l.contains(&probe)).collect();
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly one row may carry the probe (the command's output); got {rows:?}"
+    );
+    assert_eq!(
+        rows[0].trim(),
+        probe,
+        "the matching row must be the printed probe alone, not a command line quoting it"
+    );
+}
+
 /// User-reported root cause: with the Search sidebar open, Cmd+C /
 /// Cmd+V in the terminal silently no-op because the search-editing
 /// shortcut guard fired on `focus != Editor`, swallowing the keys
@@ -6345,7 +6402,7 @@ fn terminal_cmd_c_copies_even_when_search_sidebar_is_open() {
 
     let probe = format!("croft-search-open-{}", std::process::id());
     app.terminal_mut()
-        .write_input(format!("printf '{probe}\\n'\r").as_bytes());
+        .write_input(probe_command(&probe).as_bytes());
     let started = std::time::Instant::now();
     while started.elapsed() < std::time::Duration::from_millis(3000) {
         if app.terminal().visible_text().contains(&probe) {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -6360,14 +6360,9 @@ fn the_terminal_probe_command_prints_the_probe_without_echoing_it() {
     let mut term = ratatui::Terminal::new(backend).unwrap();
     app.terminal_mut().focused = true;
     term.draw(|f| app.render(f)).unwrap();
-    app.terminal_mut().write_input(cmd.as_bytes());
-    let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(3000) {
-        if app.terminal().visible_text().contains(&probe) {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+    // Runs the very command asserted on above, on the same budget every other
+    // probe site uses.
+    await_terminal_probe(&mut app, &probe);
     let snap = app.terminal().visible_text();
     let rows: Vec<&str> = snap.lines().filter(|l| l.contains(&probe)).collect();
     assert_eq!(

--- a/src/session_host.rs
+++ b/src/session_host.rs
@@ -1474,12 +1474,43 @@ mod tests {
 
         /// Read frames until `pred` matches one, returning everything seen.
         fn read_until(&mut self, pred: impl Fn(&Frame) -> bool) -> Vec<Frame> {
+            self.read_until_within(READ_UNTIL_DEADLINE, pred)
+        }
+
+        /// [`Self::read_until`] with an explicit budget. The socket carries a
+        /// short read timeout and an expired read surfaces as `WouldBlock`
+        /// (`TimedOut` on some platforms), which is "nothing yet", not a
+        /// failure: unwrapping it turned a busy box into a panic reading
+        /// `read: Os { code: 11 }` with no clue what the client was waiting
+        /// for (issue #227). Only the budget below ends the wait, and it ends
+        /// it with the frames seen so far.
+        fn read_until_within(
+            &mut self,
+            budget: Duration,
+            pred: impl Fn(&Frame) -> bool,
+        ) -> Vec<Frame> {
             let mut seen = Vec::new();
             let mut buf = [0u8; 4096];
-            let deadline = Instant::now() + Duration::from_secs(10);
+            let deadline = Instant::now() + budget;
+            self.stream
+                .set_read_timeout(Some(READ_POLL_INTERVAL))
+                .unwrap();
             loop {
                 assert!(Instant::now() < deadline, "timed out; saw {seen:?}");
-                let n = self.stream.read(&mut buf).expect("read");
+                let n = match self.stream.read(&mut buf) {
+                    Ok(n) => n,
+                    Err(e)
+                        if matches!(
+                            e.kind(),
+                            std::io::ErrorKind::WouldBlock
+                                | std::io::ErrorKind::TimedOut
+                                | std::io::ErrorKind::Interrupted
+                        ) =>
+                    {
+                        continue;
+                    }
+                    Err(e) => panic!("read failed: {e}; saw {seen:?}"),
+                };
                 assert!(n > 0, "server closed early; saw {seen:?}");
                 let frames = self.reader.push(&buf[..n]);
                 let done = frames.iter().any(&pred);
@@ -1489,6 +1520,33 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// How long a `read_until` waits for the frame it wants. Generous: the
+    /// flood tests push megabytes through a real PTY, and a loaded box (the
+    /// whole suite running in parallel) is exactly when the old ten seconds
+    /// ran out.
+    const READ_UNTIL_DEADLINE: Duration = Duration::from_secs(30);
+    /// How long a single `read` blocks before the loop re-checks the deadline.
+    const READ_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+    /// Issue #227: a read that expires with nothing on the wire must keep
+    /// waiting until the budget runs out, and then report what the client was
+    /// waiting for. Waits for a frame the server never sends, on a budget far
+    /// shorter than one read timeout would have been, so the only way to reach
+    /// the timeout assert is by looping over `WouldBlock` instead of
+    /// unwrapping it.
+    #[test]
+    #[should_panic(expected = "timed out")]
+    fn read_until_waits_out_an_idle_socket_instead_of_unwrapping_would_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("s.mux.sock");
+        let _server = spawn_test_server(socket.clone());
+        wait_alive(&socket);
+        let mut c = TestClient::connect(&socket, "idle", 80, 24);
+        // `cat` echoes only what it is fed, and this client sends nothing, so
+        // no Bytes frame can ever arrive.
+        c.read_until_within(Duration::from_millis(300), |f| matches!(f, Frame::Bytes(_)));
     }
 
     fn output_text(frames: &[Frame]) -> String {

--- a/src/session_host.rs
+++ b/src/session_host.rs
@@ -1492,11 +1492,14 @@ mod tests {
             let mut seen = Vec::new();
             let mut buf = [0u8; 4096];
             let deadline = Instant::now() + budget;
-            self.stream
-                .set_read_timeout(Some(READ_POLL_INTERVAL))
-                .unwrap();
             loop {
-                assert!(Instant::now() < deadline, "timed out; saw {seen:?}");
+                // Never block past the budget: a read armed with the full poll
+                // interval a hair before the deadline would overshoot it.
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                assert!(!remaining.is_zero(), "timed out; saw {seen:?}");
+                self.stream
+                    .set_read_timeout(Some(remaining.min(READ_POLL_INTERVAL)))
+                    .unwrap();
                 let n = match self.stream.read(&mut buf) {
                     Ok(n) => n,
                     Err(e)


### PR DESCRIPTION
Two load-dependent test failures, both found while running the full suite with `RUST_TEST_THREADS=8` for an unrelated change. Each failed twice on a busy box and passed when run alone.

**#226, the terminal probe search matched the shell's echo.** Four terminal copy/selection tests seed the embedded shell with `printf '<probe>\n'` and then locate the probe by searching the rendered grid. The shell echoes the typed command, so the probe was on two rows; under load the echo arrived first, satisfied the wait loop, and the row search measured columns on a quoted command line:

```
assertion `left == right` failed: terminal selection_text must reproduce the probe before we copy
  left: "oft-e2e-638881\\n"
 right: "croft-e2e-638881"
```

All four sites go through `probe_command` now, which splits the probe across two `printf` arguments so the echo carries only fragments and nothing but the command's output can match. Same family, second failure mode: the wait allowed three seconds for a shell to start, run the command, and have the reader thread drain the grid, which also ran out under load and then unwrapped `None` further down. The sites share `await_terminal_probe`, with a 15s budget and a failure that prints what the terminal was showing.

**#227, the collab test client panicked on a timed-out read.** `TestClient::read_until` unwrapped a socket read, but the socket carries a read timeout and an expired read returns `WouldBlock`, which means "nothing yet":

```
panicked at src/session_host.rs:1482:52:
read: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
```

The read now loops over `WouldBlock`/`TimedOut`/`Interrupted` and only the overall budget ends the wait, reporting the frames seen. The budget moves to 30s (the flood tests push megabytes through a real PTY) with a 100ms poll interval, and `read_until_within` takes an explicit budget so the timeout path can be asserted in a fraction of a second.

Both fixes carry a test. `the_terminal_probe_command_prints_the_probe_without_echoing_it` pins that the typed line never contains the probe and that exactly one row matches after it runs; it fails against the old command form. `read_until_waits_out_an_idle_socket_instead_of_unwrapping_would_block` waits for a frame that never comes on a 300ms budget, which can only reach the timeout assert by looping over `WouldBlock`.

Test-only change, so no version bump: the shipped binary is byte-identical and there is nothing for the release notes to describe.

Gates: `cargo fmt`, `cargo clippy --bin croft --all-targets` at zero warnings, and the full suite green (3316 passed, 0 failed) with `RUST_TEST_THREADS=8`.

Closes #226
Closes #227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when waiting for terminal and session responses, including handling temporary read delays and idle connections.
  * Extended response wait periods to reduce premature failures during slower operations.
  * Enhanced timeout diagnostics by providing relevant terminal and session output.

* **Tests**
  * Added regression coverage for terminal probe output and delayed session responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->