### PR TITLE
feat(remote): confirm before compiling croft on the remote box

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20072,6 +20072,16 @@ impl App {
                     }
                 }
                 crate::install_session::InstallEvent::CanLaunch => can_launch = true,
+                crate::install_session::InstallEvent::FallbackPrompt { reason } => {
+                    if let Some(dialog) = self.connect_dialog.as_mut() {
+                        dialog.set_fallback_prompt(&reason);
+                    } else if let Some(session) = self.install_session.as_ref() {
+                        // No dialog to ask through: decline so the installer
+                        // errors out with the `croft setup-cross` guidance
+                        // instead of blocking forever on an answer.
+                        session.respond_fallback(false);
+                    }
+                }
                 crate::install_session::InstallEvent::Done(Ok(())) => done = true,
                 crate::install_session::InstallEvent::Done(Err(detail)) => {
                     failure = Some(detail);
@@ -20341,6 +20351,14 @@ impl App {
                 if !dialog.phase.awaits_input() {
                     return;
                 }
+                if matches!(
+                    dialog.phase,
+                    crate::widgets::connect_dialog::DialogPhase::AwaitingFallbackConfirmation
+                ) {
+                    let payload = dialog.input_for_submit();
+                    self.answer_install_fallback(&payload);
+                    return;
+                }
                 let payload = dialog.input_for_submit();
                 dialog.submitted = true;
                 dialog.status_line = format!("Verifying credentials with {}", dialog.host);
@@ -20373,6 +20391,14 @@ impl App {
             return true;
         }
         if rect_contains(dialog.submit_btn, col, row) && dialog.phase.awaits_input() {
+            if matches!(
+                dialog.phase,
+                crate::widgets::connect_dialog::DialogPhase::AwaitingFallbackConfirmation
+            ) {
+                let payload = dialog.input_for_submit();
+                self.answer_install_fallback(&payload);
+                return true;
+            }
             let payload = dialog.input_for_submit();
             dialog.submitted = true;
             dialog.status_line = format!(
@@ -20387,6 +20413,31 @@ impl App {
             return true;
         }
         rect_contains(dialog.last_area, col, row)
+    }
+
+    /// Resolve the connect dialog's slow-fallback question. "y"/"yes"
+    /// continues with the compile-on-remote install; anything else aborts
+    /// the connect so the user can run `croft setup-cross` and reconnect
+    /// for the seconds-fast prebuilt-binary path.
+    fn answer_install_fallback(&mut self, payload: &str) {
+        let proceed = matches!(payload.trim().to_ascii_lowercase().as_str(), "y" | "yes");
+        if proceed {
+            if let Some(dialog) = self.connect_dialog.as_mut() {
+                dialog.set_installing();
+            }
+            if let Some(session) = self.install_session.as_ref() {
+                session.respond_fallback(true);
+            }
+            return;
+        }
+        if let Some(session) = self.install_session.as_ref() {
+            session.respond_fallback(false);
+        }
+        self.connect_dialog = None;
+        self.tear_down_connect_auth();
+        self.status = String::from(
+            "Connect cancelled — run `croft setup-cross`, then reconnect for a fast install",
+        );
     }
 
     fn open_ssh_config_in_editor(&mut self) {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -28556,3 +28556,68 @@ fn drag_target_over_the_sticky_band_is_the_pinned_directory() {
     );
     let _ = MouseEventKind::Down(MouseButton::Left); // silence unused import paths on some cfgs
 }
+
+// The 2026-08-09 gitcgr report: the installer slid into the slow
+// compile-on-remote fallback without asking. `answer_install_fallback` is the
+// decision point behind both the Enter and the click handler, so the y/yes
+// parsing and the decline teardown are pinned here rather than at each caller.
+#[test]
+fn install_fallback_proceeds_only_on_an_explicit_yes() {
+    let tmp = tempfile::tempdir().unwrap();
+    for reply in ["y", "Y", "yes", "YES", "  yes  "] {
+        let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+        app.connect_dialog = Some(crate::widgets::connect_dialog::ConnectDialog::new(
+            "gitcgr".to_string(),
+        ));
+        app.answer_install_fallback(reply);
+        let dialog = app.connect_dialog.as_ref().unwrap_or_else(|| {
+            panic!("{reply:?} accepts the slow compile, so the dialog stays up")
+        });
+        assert_eq!(
+            dialog.phase,
+            crate::widgets::connect_dialog::DialogPhase::Installing,
+            "{reply:?} should hand over to the installing phase"
+        );
+    }
+}
+
+#[test]
+fn install_fallback_declines_and_tears_down_on_anything_else() {
+    let tmp = tempfile::tempdir().unwrap();
+    // An empty submit (bare Enter) is the important one: the footer offers it
+    // as Cancel, so it must never read as consent.
+    for reply in ["", "   ", "n", "no", "yep", "later"] {
+        let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+        app.connect_dialog = Some(crate::widgets::connect_dialog::ConnectDialog::new(
+            "gitcgr".to_string(),
+        ));
+        app.pending_remote_launch_host = Some("gitcgr".to_string());
+        app.answer_install_fallback(reply);
+        assert!(
+            app.connect_dialog.is_none(),
+            "{reply:?} declines, which closes the dialog"
+        );
+        assert!(
+            app.pending_remote_launch_host.is_none(),
+            "{reply:?} declines, so the pending launch is torn down too"
+        );
+        assert!(
+            app.status.contains("setup-cross"),
+            "the decline must point at the fast-path fix, got {:?}",
+            app.status
+        );
+    }
+}
+
+#[test]
+fn install_fallback_without_a_dialog_does_not_panic() {
+    // The install thread can answer after the dialog is gone (user hit Esc
+    // while the prompt was in flight); both arms must tolerate the absence.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.answer_install_fallback("y");
+    assert!(app.connect_dialog.is_none());
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.answer_install_fallback("");
+    assert!(app.connect_dialog.is_none());
+}

--- a/src/install_session.rs
+++ b/src/install_session.rs
@@ -10,6 +10,15 @@ pub enum InstallEvent {
     /// dropped into it now while the (re)install continues in the
     /// background. Fired at most once, before `Done`.
     CanLaunch,
+    /// The fast cross-build path is unavailable and the installer wants to
+    /// compile on the remote box instead (slow). The UI must answer via
+    /// `respond_fallback`: `true` runs the remote compile, `false` aborts
+    /// the install so the user can run `croft setup-cross` and reconnect
+    /// for the fast path. Fired only while the install still blocks the
+    /// connect (never after `CanLaunch`).
+    FallbackPrompt {
+        reason: String,
+    },
     Done(Result<(), String>),
 }
 
@@ -18,6 +27,7 @@ pub struct InstallSession {
     pub path: Option<String>,
     pub adopted: Option<AdoptedMaster>,
     events_rx: Receiver<InstallEvent>,
+    fallback_answer_tx: Sender<bool>,
     _handle: Option<JoinHandle<()>>,
 }
 
@@ -47,12 +57,28 @@ impl InstallSession {
             });
             s
         };
+        let (fallback_answer_tx, fallback_answer_rx) = channel::<bool>();
+        let prompt_tx = tx.clone();
         let done_tx = tx.clone();
         let handle = std::thread::spawn(move || {
+            let mut confirm_fallback = move |reason: &str| {
+                if prompt_tx
+                    .send(InstallEvent::FallbackPrompt {
+                        reason: reason.to_string(),
+                    })
+                    .is_err()
+                {
+                    return false;
+                }
+                // Blocks until the dialog answers. A torn-down dialog drops
+                // the answer sender, which reads as a decline.
+                fallback_answer_rx.recv().unwrap_or(false)
+            };
             let result = crate::remote::install_only_streaming(
                 adopted_for_thread,
                 log_tx_for_install,
                 can_launch_tx,
+                &mut confirm_fallback,
             );
             let payload = match result {
                 Ok(_) => Ok(()),
@@ -65,6 +91,7 @@ impl InstallSession {
             path,
             adopted: Some(adopted),
             events_rx: rx,
+            fallback_answer_tx,
             _handle: Some(handle),
         }
     }
@@ -79,6 +106,12 @@ impl InstallSession {
             }
         }
         out
+    }
+
+    /// Answer a pending `FallbackPrompt`: `true` proceeds with the slow
+    /// remote compile, `false` aborts the install.
+    pub fn respond_fallback(&self, proceed: bool) {
+        let _ = self.fallback_answer_tx.send(proceed);
     }
 
     pub fn take_adopted(&mut self) -> Option<AdoptedMaster> {

--- a/src/install_session.rs
+++ b/src/install_session.rs
@@ -114,6 +114,9 @@ impl InstallSession {
         let _ = self.fallback_answer_tx.send(proceed);
     }
 
+    /// Hand the adopted control master to the caller, leaving `None`
+    /// behind. Taken once the TUI has surrendered the alt-screen and is
+    /// ready to launch through the existing connection.
     pub fn take_adopted(&mut self) -> Option<AdoptedMaster> {
         self.adopted.take()
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -159,6 +159,7 @@ pub fn install_only_streaming(
     adopted: AdoptedMaster,
     log_tx: std::sync::mpsc::Sender<String>,
     can_launch_tx: std::sync::mpsc::Sender<()>,
+    confirm_fallback: &mut dyn FnMut(&str) -> bool,
 ) -> Result<AdoptedMaster> {
     let host_label = adopted.host.clone();
     // Mirror every line into ~/.cache/croft/install.log so the install
@@ -170,7 +171,8 @@ pub fn install_only_streaming(
     ));
     let _ = log_tx.send(format!("Adopting control socket for {host_label}"));
     let ssh = SshControl::adopt(adopted.clone());
-    let result = install_only_streaming_over(&ssh, &host_label, &log_tx, &can_launch_tx);
+    let result =
+        install_only_streaming_over(&ssh, &host_label, &log_tx, &can_launch_tx, confirm_fallback);
     // Never drop `ssh`: its Drop kills the shared control master, and by now
     // the user may already be attached through it (the launch signal fires
     // before any fallible work).
@@ -183,6 +185,7 @@ fn install_only_streaming_over(
     host_label: &str,
     log_tx: &std::sync::mpsc::Sender<String>,
     can_launch_tx: &std::sync::mpsc::Sender<()>,
+    confirm_fallback: &mut dyn FnMut(&str) -> bool,
 ) -> Result<()> {
     // If a croft is already on the remote, the user gets dropped into it
     // immediately and the (re)install proceeds in the background. The
@@ -216,7 +219,23 @@ fn install_only_streaming_over(
         let _ = log_tx.send(msg);
     });
     let _ = log_tx.send(format!("Installing/updating Croft on {host_label}"));
-    if let Err(e) = install_remote_croft_streaming(ssh, &bulk.lane, &local_stamp, log_tx) {
+    // `present` means the user was already dropped into the running remote
+    // croft: there is nobody left to ask, and an unasked-for compile on the
+    // box would load their live session. Decline the slow path outright and
+    // log how to get the update fast; a fresh install (dialog still up)
+    // forwards the question to the caller's prompt.
+    let mut gate = |reason: &str| {
+        if present {
+            let _ = log_tx.send(format!(
+                "Update NOT installed: cross-build unavailable ({reason}). Run `croft setup-cross` on this machine, then reconnect — updates then ship a prebuilt binary in seconds."
+            ));
+            false
+        } else {
+            confirm_fallback(reason)
+        }
+    };
+    if let Err(e) = install_remote_croft_streaming(ssh, &bulk.lane, &local_stamp, log_tx, &mut gate)
+    {
         clear_remote_updating(ssh);
         return Err(e);
     }
@@ -439,16 +458,23 @@ fn install_remote_croft_streaming(
     lane: &crate::remote_bulk::BulkLane,
     source_stamp: &str,
     log_tx: &std::sync::mpsc::Sender<String>,
+    confirm_fallback: &mut dyn FnMut(&str) -> bool,
 ) -> Result<()> {
-    match try_local_cross_install_streaming(ssh, lane, source_stamp, log_tx) {
-        Ok(true) => return Ok(()),
-        Ok(false) => {}
-        Err(e) => {
-            let _ = log_tx.send(format!(
-                "Local cross-build skipped ({e}); falling back to remote cargo install"
-            ));
-        }
+    let reason = match try_local_cross_install_streaming(ssh, lane, source_stamp, log_tx) {
+        Ok(None) => return Ok(()),
+        Ok(Some(reason)) => reason,
+        Err(e) => format!("local cross-build failed: {e:#}"),
+    };
+    // Never slide into the slow on-box compile silently: the caller decides
+    // (dialog prompt, tty prompt, or an automatic decline for background
+    // updates). The fix — `croft setup-cross` — is one command away and
+    // turns every future install into a seconds-long prebuilt-binary ship.
+    if !confirm_fallback(&reason) {
+        anyhow::bail!(
+            "cross-build unavailable ({reason}); remote compile declined — run `croft setup-cross`, then reconnect for the fast install"
+        );
     }
+    let _ = log_tx.send(format!("Falling back to remote cargo install ({reason})"));
     let _ = log_tx.send("Syncing source tree to remote".to_string());
     sync_local_source_to_remote_streaming(ssh, lane, log_tx)?;
     let _ = log_tx
@@ -464,24 +490,30 @@ fn install_remote_croft_streaming(
     Ok(())
 }
 
+/// `Ok(None)` = binary shipped via the fast path; `Ok(Some(reason))` = the
+/// fast path is unavailable (the reason feeds the fallback confirmation);
+/// `Err` = the fast path was attempted and broke.
 fn try_local_cross_install_streaming(
     ssh: &SshControl,
     lane: &crate::remote_bulk::BulkLane,
     source_stamp: &str,
     log_tx: &std::sync::mpsc::Sender<String>,
-) -> Result<bool> {
+) -> Result<Option<String>> {
     if let Some(reason) = cross_compile_unavailable_reason() {
         let _ = log_tx.send(format!("Local cross-build skipped: {reason}"));
-        return Ok(false);
+        return Ok(Some(reason));
     }
     let Some(triple) = remote_target_triple(ssh)? else {
-        return Ok(false);
+        let reason = String::from("could not detect the remote architecture");
+        let _ = log_tx.send(format!("Local cross-build skipped: {reason}"));
+        return Ok(Some(reason));
     };
     if !rust_target_installed(triple) {
-        let _ = log_tx.send(format!(
-            "Local cross-build skipped: rustup target `{triple}` missing (run `rustup target add {triple}` once to enable the fast path)"
-        ));
-        return Ok(false);
+        let reason = format!(
+            "rustup target `{triple}` missing (run `rustup target add {triple}` once to enable the fast path)"
+        );
+        let _ = log_tx.send(format!("Local cross-build skipped: {reason}"));
+        return Ok(Some(reason));
     }
 
     let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -554,7 +586,7 @@ fn try_local_cross_install_streaming(
         anyhow::bail!("remote activation exited with {act_status}");
     }
     let _ = log_tx.send("Installed croft on remote via local cross-build.".to_string());
-    Ok(true)
+    Ok(None)
 }
 
 fn sync_local_source_to_remote_streaming(
@@ -629,7 +661,10 @@ fn spawn_background_install(ssh: &SshControl) {
         // even with a disconnected downstream.
         let (log_tx, _) = std::sync::mpsc::channel();
         let (can_launch_tx, _) = std::sync::mpsc::channel();
-        let _ = install_only_streaming(adopted, log_tx, can_launch_tx);
+        // Unreachable: this thread only runs when a croft is already on the
+        // remote, and the installer auto-declines the slow fallback in that
+        // case (see the `present` gate in `install_only_streaming_over`).
+        let _ = install_only_streaming(adopted, log_tx, can_launch_tx, &mut |_| false);
     });
 }
 
@@ -1474,18 +1509,26 @@ fn install_remote_croft(ssh: &SshControl, source_stamp: &str) -> Result<()> {
     // Fast path: cross-compile a static musl binary on the local Mac and
     // rsync it directly into the remote's ~/.cargo/bin. Skips the
     // crates.io index update, the dependency walk, and the release-mode
-    // codegen+link of the croft crate on the remote. Falls back to the
-    // legacy source-rsync + `cargo install` path when the tooling isn't
-    // present (zig + cargo-zigbuild + the matching rust target), when
-    // we can't detect the remote arch, or when the build fails for any
-    // reason — the user sees a one-line note and the slower install
-    // continues so the connect succeeds.
-    match try_local_cross_install(ssh, source_stamp) {
-        Ok(true) => return Ok(()),
-        Ok(false) => {}
+    // codegen+link of the croft crate on the remote. The legacy
+    // source-rsync + `cargo install` fallback still exists for when the
+    // tooling isn't present (zig + cargo-zigbuild + the matching rust
+    // target), the remote arch can't be detected, or the build fails —
+    // but it never engages silently: the user confirms it on the tty
+    // first, because quitting to run `croft setup-cross` once is almost
+    // always the better deal.
+    let reason = match try_local_cross_install(ssh, source_stamp) {
+        Ok(None) => return Ok(()),
+        Ok(Some(reason)) => reason,
         Err(e) => {
-            eprintln!("Local cross-build failed ({e}); falling back to remote `cargo install`");
+            eprintln!("Local cross-build failed ({e:#})");
+            format!("local cross-build failed: {e:#}")
         }
+    };
+    if !confirm_remote_compile_on_tty(&ssh.host, &reason) {
+        anyhow::bail!(
+            "cross-build unavailable ({reason}); remote compile declined — run `croft setup-cross`, then `croft remote {}` again for the fast install",
+            ssh.host
+        );
     }
     sync_local_source_to_remote(ssh)?;
     let status = ssh
@@ -1896,19 +1939,25 @@ fn rust_target_installed(triple: &str) -> bool {
         .any(|line| line.trim() == triple)
 }
 
-fn try_local_cross_install(ssh: &SshControl, source_stamp: &str) -> Result<bool> {
+/// `Ok(None)` = binary shipped via the fast path; `Ok(Some(reason))` = the
+/// fast path is unavailable (the reason feeds the fallback confirmation);
+/// `Err` = the fast path was attempted and broke.
+fn try_local_cross_install(ssh: &SshControl, source_stamp: &str) -> Result<Option<String>> {
     if let Some(reason) = cross_compile_unavailable_reason() {
         eprintln!("Local cross-build skipped: {reason}");
-        return Ok(false);
+        return Ok(Some(reason));
     }
     let Some(triple) = remote_target_triple(ssh)? else {
-        return Ok(false);
+        let reason = String::from("could not detect the remote architecture");
+        eprintln!("Local cross-build skipped: {reason}");
+        return Ok(Some(reason));
     };
     if !rust_target_installed(triple) {
-        eprintln!(
-            "Local cross-build skipped: rustup target `{triple}` not installed (run `rustup target add {triple}` once to enable the fast path)"
+        let reason = format!(
+            "rustup target `{triple}` not installed (run `rustup target add {triple}` once to enable the fast path)"
         );
-        return Ok(false);
+        eprintln!("Local cross-build skipped: {reason}");
+        return Ok(Some(reason));
     }
 
     let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -1977,7 +2026,35 @@ fn try_local_cross_install(ssh: &SshControl, source_stamp: &str) -> Result<bool>
         anyhow::bail!("remote activation exited with {activate_status}");
     }
     println!("Installed croft on remote via local cross-build.");
-    Ok(true)
+    Ok(None)
+}
+
+/// Ask on the controlling terminal before the slow on-box compile. The
+/// answer defaults to "no": quitting to run `croft setup-cross` once turns
+/// every future install into a seconds-long prebuilt-binary ship, so the
+/// slow path must be an explicit choice, never a silent fallback.
+/// Non-interactive stdin (scripts, CI) declines for the same reason.
+fn confirm_remote_compile_on_tty(host: &str, reason: &str) -> bool {
+    use std::io::{IsTerminal as _, Write as _};
+    eprintln!("Fast install unavailable: {reason}");
+    eprintln!(
+        "Croft can compile itself on {host} instead; the first build can take several minutes and loads the box."
+    );
+    if !std::io::stdin().is_terminal() {
+        eprintln!(
+            "stdin is not a terminal; declining the remote compile. Run `croft setup-cross`, then retry."
+        );
+        return false;
+    }
+    eprint!(
+        "Compile on {host} anyway? [y/N] (N quits; run `croft setup-cross` once and reconnect — much faster) "
+    );
+    let _ = std::io::stderr().flush();
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_err() {
+        return false;
+    }
+    matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 pub fn remote_croft_command(path: Option<&str>, env: &[(String, String)], solo: bool) -> String {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -180,6 +180,15 @@ pub fn install_only_streaming(
     result.map(|_| adopted)
 }
 
+/// The body of `install_only_streaming`, split out so the SSH control
+/// master can be leaked on every exit path rather than dropped (its `Drop`
+/// kills the shared master the user may already be attached through).
+///
+/// Probes the remote first: an already-installed croft releases
+/// `can_launch_tx` within one SSH roundtrip and the (re)install continues
+/// behind the user's session, so `confirm_fallback` is bypassed in favour
+/// of an automatic decline — there is nobody left to ask, and an
+/// unrequested on-box compile would load a live session.
 fn install_only_streaming_over(
     ssh: &SshControl,
     host_label: &str,
@@ -453,6 +462,13 @@ fn run_command_streaming(
     Ok(status)
 }
 
+/// Ship croft to the remote, preferring the fast path: cross-build a
+/// static binary locally and rsync it over.
+///
+/// When that path is unavailable, `confirm_fallback` is asked — with the
+/// reason — whether to compile on the remote box instead. Declining is an
+/// error, not a silent skip, so the caller can point the user at
+/// `croft setup-cross`. The slow path never engages on its own.
 fn install_remote_croft_streaming(
     ssh: &SshControl,
     lane: &crate::remote_bulk::BulkLane,
@@ -589,6 +605,11 @@ fn try_local_cross_install_streaming(
     Ok(None)
 }
 
+/// Rsync the local source tree into `~/.cache/croft/source` on the remote,
+/// streaming rsync's progress through `log_tx`. Only needed for the slow
+/// compile-on-remote fallback; the fast path ships a built binary instead.
+/// Runs over `lane` so the bulk transfer never queues ahead of the user's
+/// keystrokes on the shared interactive master.
 fn sync_local_source_to_remote_streaming(
     ssh: &SshControl,
     lane: &crate::remote_bulk::BulkLane,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -2378,7 +2378,11 @@ CROFT_NICE=""
 if command -v nice >/dev/null 2>&1; then CROFT_NICE="nice -n 19"; fi
 CROFT_IONICE=""
 if command -v ionice >/dev/null 2>&1; then CROFT_IONICE="ionice -c3"; fi
-$CROFT_NICE $CROFT_IONICE cargo install --path "$HOME/.cache/croft/source" --jobs "$CROFT_JOBS" --force --locked
+# eval, because this script runs under the remote user's login shell and
+# zsh does not word-split unquoted parameters: bare `$CROFT_NICE ...` would
+# try to run a command literally named "nice -n 19". eval re-parses the
+# assembled line, which splits correctly under both sh/bash and zsh.
+eval "$CROFT_NICE $CROFT_IONICE"' cargo install --path "$HOME/.cache/croft/source" --jobs "$CROFT_JOBS" --force --locked'
 mkdir -p "$HOME/.cache/croft"
 printf %s {stamp} > "$HOME/.cache/croft/install-stamp"
 rm -f "$HOME/.cache/croft/updating"

--- a/src/widgets/connect_dialog.rs
+++ b/src/widgets/connect_dialog.rs
@@ -18,6 +18,10 @@ pub enum DialogPhase {
     AwaitingVerificationCode,
     AwaitingHostKeyConfirmation,
     AwaitingGeneric,
+    /// The fast cross-build path is unavailable; the user chooses between
+    /// the slow compile-on-remote fallback and aborting to run
+    /// `croft setup-cross` locally first.
+    AwaitingFallbackConfirmation,
     Installing,
     Authenticated,
     Failed,
@@ -32,6 +36,7 @@ impl DialogPhase {
                 | DialogPhase::AwaitingVerificationCode
                 | DialogPhase::AwaitingHostKeyConfirmation
                 | DialogPhase::AwaitingGeneric
+                | DialogPhase::AwaitingFallbackConfirmation
         )
     }
 
@@ -159,6 +164,18 @@ impl ConnectDialog {
         self.input.clear();
     }
 
+    /// The installer cannot use the fast cross-build path and asks whether
+    /// to compile on the remote box instead (slow) or abort so the user can
+    /// run `croft setup-cross` and reconnect for the fast install.
+    pub fn set_fallback_prompt(&mut self, reason: &str) {
+        self.phase = DialogPhase::AwaitingFallbackConfirmation;
+        self.prompt_text = format!("Fast install unavailable: {reason}");
+        self.status_line = default_status_for(&self.phase, &self.host);
+        self.input.clear();
+        self.submitted = false;
+        self.show_logs = true;
+    }
+
     pub fn set_installing(&mut self) {
         self.phase = DialogPhase::Installing;
         self.status_line = format!("Preparing remote croft on {}", self.host);
@@ -258,6 +275,10 @@ fn default_status_for(phase: &DialogPhase, host: &str) -> String {
             String::from("First-time host key, type yes to continue")
         }
         DialogPhase::AwaitingGeneric => String::from("Server prompt"),
+        DialogPhase::AwaitingFallbackConfirmation => format!(
+            "Compile on {} instead? Slow — quitting to run `croft setup-cross` once is much faster",
+            host
+        ),
         _ => String::new(),
     }
 }
@@ -330,6 +351,7 @@ impl Widget for &mut ConnectDialog {
             DialogPhase::AwaitingVerificationCode => "2FA",
             DialogPhase::AwaitingHostKeyConfirmation => "Host key",
             DialogPhase::AwaitingGeneric => "Prompt",
+            DialogPhase::AwaitingFallbackConfirmation => "Slow install?",
             DialogPhase::Installing => "Installing",
             DialogPhase::Authenticated => "Done",
             DialogPhase::Failed => "Failed",
@@ -433,6 +455,9 @@ impl Widget for &mut ConnectDialog {
                         "  type yes and press Enter to trust this host"
                     }
                     DialogPhase::AwaitingGeneric => "  type a response and press Enter",
+                    DialogPhase::AwaitingFallbackConfirmation => {
+                        "  y + Enter compiles on the remote; Enter alone cancels"
+                    }
                     _ => "",
                 };
                 if !placeholder.is_empty() {
@@ -494,6 +519,8 @@ impl Widget for &mut ConnectDialog {
             ""
         } else if matches!(self.phase, DialogPhase::AwaitingHostKeyConfirmation) {
             "[Enter] Continue"
+        } else if matches!(self.phase, DialogPhase::AwaitingFallbackConfirmation) {
+            "[y+Enter] Slow compile   [Enter] Cancel"
         } else {
             "[Enter] Submit"
         };
@@ -641,6 +668,25 @@ mod tests {
             "Are you sure you want to continue connecting (yes/no/[fingerprint])? ".into(),
         );
         assert_eq!(d.phase, DialogPhase::AwaitingHostKeyConfirmation);
+    }
+
+    // The 2026-08-09 gitcgr report: the installer slid into the slow
+    // compile-on-remote fallback without asking, so a missing
+    // `croft setup-cross` surfaced only as a stale remote version. The
+    // fallback now needs an explicit yes; an empty submit must decline.
+    #[test]
+    fn set_fallback_prompt_awaits_an_explicit_yes() {
+        let mut d = ConnectDialog::new("gitcgr".to_string());
+        d.set_fallback_prompt("`cargo-zigbuild` not found");
+        assert_eq!(d.phase, DialogPhase::AwaitingFallbackConfirmation);
+        assert!(d.phase.awaits_input());
+        assert!(d.prompt_text.contains("cargo-zigbuild"));
+        assert!(
+            d.input_for_submit().is_empty(),
+            "no auto-yes: an empty submit reads as a decline"
+        );
+        assert!(!d.input_is_secret());
+        assert!(d.show_logs, "the skip reason lives in the log panel");
     }
 
     #[test]

--- a/src/widgets/connect_dialog.rs
+++ b/src/widgets/connect_dialog.rs
@@ -176,6 +176,9 @@ impl ConnectDialog {
         self.show_logs = true;
     }
 
+    /// Switch to the installing phase: reveal the log panel and start the
+    /// elapsed-time clock. Entered once credentials are accepted, or when
+    /// the user consents to the slow compile-on-remote fallback.
     pub fn set_installing(&mut self) {
         self.phase = DialogPhase::Installing;
         self.status_line = format!("Preparing remote croft on {}", self.host);


### PR DESCRIPTION
When the fast install path is unavailable, the installer silently fell back to rsyncing the source and running `cargo install` **on the remote box**. That build takes minutes and loads the machine — and because it was silent, a missing `croft setup-cross` never announced itself. It surfaced only indirectly, as a remote that stayed mysteriously out of date.

The fallback now requires an explicit yes, and the reason the fast path was unavailable travels with the question.

## The signature change

`try_local_cross_install` and `try_local_cross_install_streaming` returned `bool`, which could say *whether* the fast path ran but not *why* it didn't. They now return `Option<String>`:

- `None` — the prebuilt binary shipped, nothing to ask
- `Some(reason)` — the fast path is unavailable, and `reason` is what the user gets shown (`cargo-zigbuild not found`, `rustup target aarch64-unknown-linux-musl missing`, a build failure…)

`install_remote_croft_streaming` takes a `confirm_fallback: &mut dyn FnMut(&str) -> bool` gate, so each entry point supplies its own way of asking.

## Three ways of asking, one default

| Context | Behavior |
|---|---|
| TUI connect | `InstallEvent::FallbackPrompt` → the connect dialog's new `AwaitingFallbackConfirmation` phase → `respond_fallback` |
| CLI connect | `confirm_remote_compile_on_tty`; non-interactive stdin declines |
| Background update (already attached) | Declines automatically, logs the `setup-cross` hint |
| Dialog torn down mid-prompt | `respond_fallback(false)` — no deadlock |
| Answer channel dropped | `recv().unwrap_or(false)` — reads as a decline |

Every path defaults to **no**. The slow compile is always a choice, never a slide.

The background-update case is deliberate rather than incidental: when a croft is already running on the remote the user is attached to it, so there is nobody to ask and an unrequested compile would load the box under a live session. It declines and logs how to get the fast path instead.

## Tests

Three cases pin `answer_install_fallback`, the decision point behind both the Enter and the click handler:

- `install_fallback_proceeds_only_on_an_explicit_yes` — `y`/`Y`/`yes`/`YES`/`  yes  ` reach `DialogPhase::Installing`
- `install_fallback_declines_and_tears_down_on_anything_else` — `""`, `"   "`, `n`, `no`, `yep`, `later` close the dialog, clear the pending launch, and set a status naming `setup-cross`
- `install_fallback_without_a_dialog_does_not_panic` — both arms tolerate a torn-down dialog

The empty-string case is the one that matters: the footer offers bare Enter as Cancel, so it must never read as consent. Verified by mutation — forcing `let proceed = true` fails that test specifically.

Also `set_fallback_prompt_awaits_an_explicit_yes` on the dialog side.

## Also here

One drive-by fix, kept as its own commit: the remote install script's `$CROFT_NICE $CROFT_IONICE cargo install ...` line. zsh does not word-split unquoted parameters, so under a zsh login shell that tried to run a command literally named `nice -n 19`. Now `eval`-ed, which splits correctly under sh, bash and zsh alike.

## Test suite

3334 passed. Four failures (`accept_all_incoming_then_complete_merge_stages_the_resolved_file`, `repositories_overview_lists_every_folder_and_a_pin_overrides_the_follow`, `gui_path::probing_a_real_shell_returns_a_usable_path`, `workspace_file_round_trips_with_relative_paths_and_tolerates_comments`) reproduce identically on clean `origin/main` — shell-spawning and load-sensitive, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive confirmation prompt when remote installation must fall back to slower compilation.
  * Displays the reason for the fallback and provides clear guidance for proceeding or canceling.
  * Accepts only “y” or “yes” to continue; other responses cancel the connection safely.
  * Supports confirmation through both keyboard and mouse submission.

* **Bug Fixes**
  * Prevents unattended or background sessions from waiting indefinitely for fallback confirmation.
  * Ensures canceled connections clean up authentication and update status guidance appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->