### PR TITLE
feat(remote): loud no-op installs + build provenance (#236, #237)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,5 +2,51 @@
 // and the repository remote (`CROFT_REPOSITORY_REMOTE`) into the binary at
 // build time. Both are gone: the panel now renders hand-curated release
 // highlights from `src/release_notes.rs` (compiled-in data, zero network,
-// never derived from a forge), so there is nothing to do at build time.
-fn main() {}
+// never derived from a forge).
+//
+// What IS baked now is build provenance — the short git hash (`-dirty` when
+// the tree has uncommitted changes) and the UTC build time — for `--version`
+// and the splash badge. Two builds can share a crate version (0.1.758 was
+// both the broken and the fixed binary in the 2026-08-22 session-host
+// incident); provenance is what tells them apart. This is identification
+// only, not forge-derived content. A tree without git (registry or git
+// snapshots, tarballs) builds as `unknown`, which is itself a signal: such
+// a build can never ship local changes (see `source_snapshot_warning` in
+// `src/remote.rs`).
+//
+// No `cargo:rerun-if-changed` on purpose: cargo's default then reruns this
+// script whenever any package file changes, which keeps the `-dirty` flag
+// honest. The two git invocations cost milliseconds.
+fn main() {
+    let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let hash = git_output(&root, &["rev-parse", "--short", "HEAD"])
+        .map(|h| {
+            let dirty =
+                git_output(&root, &["status", "--porcelain"]).is_some_and(|s| !s.is_empty());
+            if dirty { format!("{h}-dirty") } else { h }
+        })
+        .unwrap_or_else(|| String::from("unknown"));
+    println!("cargo:rustc-env=CROFT_GIT_HASH={hash}");
+    let time = std::process::Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| String::from("unknown"));
+    println!("cargo:rustc-env=CROFT_BUILD_TIME={time}");
+}
+
+fn git_output(root: &str, args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(out.stdout).ok()?.trim().to_string())
+}

--- a/build.rs
+++ b/build.rs
@@ -14,9 +14,14 @@
 // a build can never ship local changes (see `source_snapshot_warning` in
 // `src/remote.rs`).
 //
-// No `cargo:rerun-if-changed` on purpose: cargo's default then reruns this
-// script whenever any package file changes, which keeps the `-dirty` flag
-// honest. The two git invocations cost milliseconds.
+// Watching: cargo's default (rerun on any package-file change) misses moves
+// of HEAD with no source edit — commit, branch switch, stage — which left
+// the baked hash stale. So the git metadata is watched explicitly (worktree
+// HEAD, index, refs, packed-refs via `--git-path`, which resolves worktree
+// layouts). Emitting any rerun-if-changed disables cargo's default watch,
+// so the package files that shape the binary (and flip `-dirty`) are
+// re-declared alongside. Outside a git tree nothing is emitted and cargo's
+// default behavior stands.
 fn main() {
     let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
     let hash = git_output(&root, &["rev-parse", "--short", "HEAD"])
@@ -36,6 +41,47 @@ fn main() {
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| String::from("unknown"));
     println!("cargo:rustc-env=CROFT_BUILD_TIME={time}");
+    watch_provenance_inputs(&root);
+}
+
+/// Declares every input that can move `CROFT_GIT_HASH`: the git metadata the
+/// hash reads, and the package files whose edits flip `-dirty`. A path is
+/// only declared when it exists — a declared-but-missing path makes cargo
+/// rerun on every build (`packed-refs` is the usual absentee); if it appears
+/// later, the operation that creates it also rewrites `refs`, which is
+/// watched.
+fn watch_provenance_inputs(root: &str) {
+    let Some(git_paths) = git_output(
+        root,
+        &[
+            "rev-parse",
+            "--git-path",
+            "HEAD",
+            "--git-path",
+            "index",
+            "--git-path",
+            "refs",
+            "--git-path",
+            "packed-refs",
+        ],
+    ) else {
+        return;
+    };
+    let package_files = [
+        "Cargo.toml",
+        "Cargo.lock",
+        "build.rs",
+        "rust-toolchain.toml",
+        "src",
+        "assets",
+        "tests",
+    ];
+    for path in git_paths.lines().chain(package_files) {
+        let path = std::path::Path::new(root).join(path);
+        if path.exists() {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
 }
 
 fn git_output(root: &str, args: &[&str]) -> Option<String> {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9780,7 +9780,16 @@ impl App {
 
         // Version badge to the right of the wordmark (the wordmark sits
         // in the lower portion of the logo PNG; the badge tracks that row).
-        let version_label = format!(" v{} ", env!("CARGO_PKG_VERSION"));
+        // The git hash makes two builds of the same crate version tell each
+        // other apart on sight (an updated remote shows a new hash even when
+        // the version number never moved). `unknown` = built outside git;
+        // showing it would only add noise to an unfixable state.
+        let git_hash = env!("CROFT_GIT_HASH");
+        let version_label = if git_hash == "unknown" {
+            format!(" v{} ", env!("CARGO_PKG_VERSION"))
+        } else {
+            format!(" v{}\u{00b7}{} ", env!("CARGO_PKG_VERSION"), git_hash)
+        };
         let version_w = version_label.chars().count() as u16;
         let badge_x = logo_x + logo_w_cells + 1;
         let badge_y = logo_y + (logo_h_cells * 5) / 6;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,8 +10,21 @@ const ITERM2_FONT_PS_NAME: &str = "MesloLGSNFM-Regular";
 const ITERM2_NONASCII_PS_NAME: &str = "SymbolsNFM";
 const ITERM2_FONT_SIZE: u32 = 13;
 
+/// Crate version plus build provenance (short git hash and UTC build time,
+/// from `build.rs`). Two builds can share a crate version — 0.1.758 was both
+/// the broken and the fixed binary in the 2026-08-22 session-host incident —
+/// and provenance is what lets `--version` tell them apart.
+const FULL_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (",
+    env!("CROFT_GIT_HASH"),
+    ", built ",
+    env!("CROFT_BUILD_TIME"),
+    ")"
+);
+
 #[derive(Parser, Debug)]
-#[command(name = "croft", version, about = "Terminal-based VS Code replica")]
+#[command(name = "croft", version = FULL_VERSION, about = "Terminal-based VS Code replica")]
 pub struct Cli {
     /// Workspace folder to open (defaults to current directory). A file works
     /// too: the workspace roots at its parent and the file opens in the editor.

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -2611,11 +2611,13 @@ fn source_snapshot_warning() -> Option<String> {
 }
 
 /// The two places `cargo install` unpacks immutable sources: registry
-/// tarballs and git checkouts. Both live under `$CARGO_HOME` (`~/.cargo` by
-/// default); a custom `CARGO_HOME` still uses these two subtrees, so the
-/// path fragments are matched without pinning the prefix.
+/// tarballs and git checkouts. Both are subtrees of `$CARGO_HOME`, and a
+/// custom `CARGO_HOME` need not contain `.cargo` anywhere in its path
+/// (`CARGO_HOME=/custom/cargo-home` unpacks to
+/// `/custom/cargo-home/registry/src/...`), so only the two layout-defining
+/// components are matched, with no assumption about the prefix.
 fn source_dir_is_snapshot(dir: &str) -> bool {
-    dir.contains(".cargo/registry/src/") || dir.contains(".cargo/git/checkouts/")
+    dir.contains("/registry/src/") || dir.contains("/git/checkouts/")
 }
 
 /// Names of the root entries that shape the shipped binary: the crate source,
@@ -3769,6 +3771,13 @@ Host !blocked *.internal
         ));
         assert!(source_dir_is_snapshot(
             "/custom/cargo-home/.cargo/git/checkouts/croft-9a1f/de1a7ab"
+        ));
+        // CARGO_HOME=/custom/cargo-home has no `.cargo` component at all
+        assert!(source_dir_is_snapshot(
+            "/custom/cargo-home/registry/src/index.crates.io-6f17d22bba15001f/croft-software-0.1.757"
+        ));
+        assert!(source_dir_is_snapshot(
+            "/custom/cargo-home/git/checkouts/croft-9a1f/de1a7ab"
         ));
         assert!(!source_dir_is_snapshot("/Users/u/Documents/croft"));
         assert!(!source_dir_is_snapshot("/home/u/work/croft"));

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -208,7 +208,13 @@ fn install_only_streaming_over(
     }
     let _ = log_tx.send("Hashing local source tree".to_string());
     let local_stamp = local_source_stamp()?;
-    let _ = log_tx.send(format!("Local source stamp: {local_stamp}"));
+    let _ = log_tx.send(format!(
+        "Local source stamp: {local_stamp} (source: {})",
+        env!("CARGO_MANIFEST_DIR")
+    ));
+    if let Some(warning) = source_snapshot_warning() {
+        let _ = log_tx.send(warning);
+    }
     if !remote_install_needed(ssh, &local_stamp)? {
         let _ = log_tx.send(format!("Croft on {host_label} is already up to date."));
         if !present {
@@ -418,6 +424,9 @@ fn run_croft_session(
             RemoteStatusClass::Exited => return Ok(RemoteOutcome::Exited),
             RemoteStatusClass::NotInstalled if !bootstrapped => {
                 println!("Croft is not installed on {host}; bootstrapping from local source");
+                if let Some(warning) = source_snapshot_warning() {
+                    eprintln!("{warning}");
+                }
                 install_remote_croft(&ssh, &local_source_stamp()?)?;
                 bootstrapped = true;
             }
@@ -676,6 +685,9 @@ pub fn launch_croft_with(
     } else {
         let local_stamp = local_source_stamp()?;
         println!("Installing Croft on {host}");
+        if let Some(warning) = source_snapshot_warning() {
+            eprintln!("{warning}");
+        }
         install_remote_croft(&ssh, &local_stamp)?;
     }
     let persistent = remote_has_session_supervisor(&ssh);
@@ -2582,6 +2594,30 @@ fn local_source_stamp() -> Result<String> {
     source_stamp_for(&PathBuf::from(env!("CARGO_MANIFEST_DIR")))
 }
 
+/// A croft installed with `cargo install` from a registry or git snapshot
+/// bakes that frozen checkout as its `CARGO_MANIFEST_DIR`, so the stamp it
+/// hashes can never change: "already up to date" then reports on a dead tree
+/// while the user's working repo drifts, and installs silently ship nothing.
+/// (2026-08-22: a session-host fix believed deployed was never shipped
+/// because of exactly this.) Every install path surfaces this warning so the
+/// no-op is loud instead of silent.
+fn source_snapshot_warning() -> Option<String> {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    source_dir_is_snapshot(dir).then(|| {
+        format!(
+            "WARNING: this croft was installed from an immutable snapshot ({dir}); remote installs can never ship local changes. Reinstall with `cargo install --path <your repo>` to make installs track your tree."
+        )
+    })
+}
+
+/// The two places `cargo install` unpacks immutable sources: registry
+/// tarballs and git checkouts. Both live under `$CARGO_HOME` (`~/.cargo` by
+/// default); a custom `CARGO_HOME` still uses these two subtrees, so the
+/// path fragments are matched without pinning the prefix.
+fn source_dir_is_snapshot(dir: &str) -> bool {
+    dir.contains(".cargo/registry/src/") || dir.contains(".cargo/git/checkouts/")
+}
+
 /// Names of the root entries that shape the shipped binary: the crate source,
 /// the embedded asset tree, and the build/toolchain pins. The stamp hashes
 /// exactly these, so build artifacts (`target`, `target.noindex`), `.git`,
@@ -3716,6 +3752,29 @@ Host !blocked *.internal
         assert_eq!(
             lock_version, toml_version,
             "Cargo.lock croft version {lock_version} drifted from Cargo.toml {toml_version}; run `cargo update -p croft-software`"
+        );
+    }
+
+    // 2026-08-22: a croft installed from `git#de1a7ab7` hashed its frozen
+    // ~/.cargo checkout, said "already up to date", and silently shipped
+    // nothing while the fix sat in the working repo. The snapshot warning
+    // exists so that no-op announces itself.
+    #[test]
+    fn snapshot_dirs_are_detected_and_real_repos_are_not() {
+        assert!(source_dir_is_snapshot(
+            "/Users/u/.cargo/registry/src/index.crates.io-6f17d22bba15001f/croft-software-0.1.757"
+        ));
+        assert!(source_dir_is_snapshot(
+            "/home/u/.cargo/git/checkouts/croft-9a1f/de1a7ab"
+        ));
+        assert!(source_dir_is_snapshot(
+            "/custom/cargo-home/.cargo/git/checkouts/croft-9a1f/de1a7ab"
+        ));
+        assert!(!source_dir_is_snapshot("/Users/u/Documents/croft"));
+        assert!(!source_dir_is_snapshot("/home/u/work/croft"));
+        assert!(
+            source_snapshot_warning().is_none(),
+            "the test build itself must come from a working tree, not a snapshot"
         );
     }
 }


### PR DESCRIPTION
Closes #236. Closes #237.

Both guards come from the 2026-08-22 incident: a croft installed with `cargo install` from a **git snapshot** hashed its frozen `~/.cargo` checkout, reported *"already up to date"*, and silently shipped nothing — while the #232 session-host fix sat undeployed and the production freeze recurred. Confirming the eventual real deploy then required comparing binary mtimes over SSH, because the broken and fixed builds both reported `v0.1.758`.

## Snapshot warning (#236)

`source_dir_is_snapshot` matches the two places `cargo install` unpacks immutable sources (`.cargo/registry/src/`, `.cargo/git/checkouts/`), prefix-free so custom `CARGO_HOME`s still match. All three install paths surface the warning (streaming log for the TUI, stderr for the CLI), and the streaming log now names the source tree next to the stamp:

```
Local source stamp: e6a68b0c1a93d9b7 (source: /Users/u/Documents/croft)
```

## Build provenance (#237)

`build.rs` bakes `CROFT_GIT_HASH` (short hash, `-dirty` when the tree has uncommitted changes) and `CROFT_BUILD_TIME` (UTC):

- `croft --version` → `croft 0.1.758 (4bac444-dirty, built 2026-08-22T00:11:44Z)`
- splash badge → `v0.1.758·4bac444`

Trees without git bake `unknown` — hidden on the badge, and itself the snapshot signal. No `rerun-if-changed` directives on purpose: cargo's default reruns the script when any package file changes, which keeps `-dirty` honest.

Deliberately *not* changed: the `CARGO_PKG_VERSION` fields in the session-host handshake — versions are compared there, and widening them is #238's territory.

## Tests

`snapshot_dirs_are_detected_and_real_repos_are_not` pins the predicate both ways plus the meta-assertion that the test build itself comes from a working tree. fmt, clippy `-D warnings`, and the suite pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version information now includes the short Git commit hash and UTC build timestamp when available.
  * The application version badge displays the Git commit hash alongside the package version.
  * Remote installation logs now show the local manifest directory and identify immutable source snapshots.

* **Bug Fixes**
  * Added clear warnings when installing from immutable registry or Git snapshot locations.
  * Version and build metadata gracefully fall back to `unknown` when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->