### PR TITLE
feat(session-host): surface a host left running a replaced binary (#238)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2913,6 +2913,9 @@ pub struct App {
     pub session_channel: Option<crate::session_host::InnerChannel>,
     /// Roster last read from the session host's presence sidecar.
     pub session_participants: Vec<crate::session_host::Participant>,
+    /// Whether the host's stale-image marker (#238) has already been
+    /// announced, so the status hint fires once per session, not per poll.
+    session_host_stale_seen: bool,
     /// Multiplayer: the participant whose keystrokes are currently flowing
     /// into this croft (from the host's typing attribution frames).
     session_typist: Option<u64>,
@@ -3962,6 +3965,7 @@ impl App {
             list_picker: None,
             session_channel: crate::session_host::InnerChannel::from_env(),
             session_participants: Vec::new(),
+            session_host_stale_seen: false,
             session_typist: None,
             session_carets: std::collections::HashMap::new(),
             session_presence_mtime: None,
@@ -17945,6 +17949,19 @@ impl App {
             return false;
         }
         self.last_session_presence_poll = std::time::Instant::now();
+        // #238: the serve wrapper cannot re-exec the way this inner croft
+        // does, so after a binary update it keeps running the old image —
+        // session-host fixes included. The host writes the marker when it
+        // notices; the one recovery is a fresh host, which a detach +
+        // reattach of the last participant produces. Checked before the
+        // presence-mtime early-return: a roster that never changes must not
+        // hide the hint.
+        if !self.session_host_stale_seen && channel.stale_marker.exists() {
+            self.session_host_stale_seen = true;
+            self.status = String::from(
+                "Session host runs a pre-update binary; detach and reattach (all participants) to pick up the update",
+            );
+        }
         let path = channel.presence.clone();
         let mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
         if mtime == self.session_presence_mtime {

--- a/src/session.rs
+++ b/src/session.rs
@@ -355,8 +355,8 @@ pub fn attach(path: Option<PathBuf>, solo: bool) -> Result<()> {
 
 /// The live persistent sessions under `dir`, pruning any dead session
 /// sockets. One row per session: (id, workspace, uptime).
-fn session_rows(dir: &Path) -> Vec<(String, String, String)> {
-    let mut rows: Vec<(String, String, String)> = Vec::new();
+fn session_rows(dir: &Path) -> Vec<(String, String, String, bool)> {
+    let mut rows: Vec<(String, String, String, bool)> = Vec::new();
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
             let socket = entry.path();
@@ -396,7 +396,10 @@ fn session_rows(dir: &Path) -> Vec<(String, String, String)> {
                 .as_ref()
                 .map(|m| humanize_age(now_unix().saturating_sub(m.created_unix)))
                 .unwrap_or_else(|| String::from("?"));
-            rows.push((id, workspace, uptime));
+            // #238: the host wrote its stale-image marker — it survived a
+            // binary update and keeps running the old code until restarted.
+            let stale = crate::session_host::stale_marker_path(&socket).exists();
+            rows.push((id, workspace, uptime, stale));
         }
     }
     rows
@@ -410,8 +413,13 @@ pub fn list() -> Result<()> {
         return Ok(());
     }
     println!("{:<10}  {:<44}  UPTIME", "SESSION", "WORKSPACE");
-    for (id, ws, up) in rows {
-        println!("{id:<10}  {ws:<44}  {up}");
+    for (id, ws, up, stale) in rows {
+        let hint = if stale {
+            "  (host pre-dates a binary update; reattach to refresh)"
+        } else {
+            ""
+        };
+        println!("{id:<10}  {ws:<44}  {up}{hint}");
     }
     Ok(())
 }

--- a/src/session_host.rs
+++ b/src/session_host.rs
@@ -212,6 +212,56 @@ pub fn presence_path(socket: &Path) -> PathBuf {
     socket.with_file_name(name)
 }
 
+/// Sidecar the host writes when it notices its own binary was replaced on
+/// disk (#238): the serve wrapper outlives every attach by design and cannot
+/// re-exec the way the inner croft does, so after an update it keeps running
+/// the old image — including any session-host fixes the update carried. The
+/// marker lets the inner croft's status bar and `croft ls` say so instead of
+/// leaving the stale host undetectable (2026-08-22: a freshly shipped fix
+/// was resident nowhere until the host was killed by hand).
+pub fn stale_marker_path(socket: &Path) -> PathBuf {
+    let mut name = socket.file_name().unwrap_or_default().to_os_string();
+    name.push(".host-stale");
+    socket.with_file_name(name)
+}
+
+/// The (device, inode) pair that identifies the file currently at `path`.
+/// An updated install replaces the binary (rsync/cargo write a new file and
+/// rename it in), so the inode moving is the update signal — mtime alone
+/// would also fire on a plain `touch`.
+fn image_identity(path: &Path) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::metadata(path).ok()?;
+    Some((meta.dev(), meta.ino()))
+}
+
+/// Watch this process's own binary path for replacement; write the stale
+/// marker once when it happens, then stop. Resolved at spawn time — on
+/// Linux `current_exe` reads /proc/self/exe, which is still the real path
+/// here because the watcher starts before any update could land.
+fn spawn_stale_image_watcher(socket: PathBuf) {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let Some(start) = image_identity(&exe) else {
+        return;
+    };
+    std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(Duration::from_secs(30));
+            // A missing file (mid-replace) reads as "not yet": the next
+            // tick sees the settled state.
+            let Some(now) = image_identity(&exe) else {
+                continue;
+            };
+            if now != start {
+                let _ = std::fs::write(stale_marker_path(&socket), b"");
+                return;
+            }
+        }
+    });
+}
+
 /// How many bytes of undelivered output one client may accumulate before it
 /// is declared too slow to keep up. The PTY pump must never wait on a
 /// socket (#228), so a peer that stops draining cannot be allowed to apply
@@ -461,6 +511,10 @@ pub(crate) fn serve_with_token(
     if let Some(ws) = workspace {
         crate::session::write_meta_preserving_created(socket, ws)?;
     }
+    // A fresh host runs the binary currently on disk; any stale marker left
+    // by a predecessor is obsolete.
+    let _ = std::fs::remove_file(stale_marker_path(socket));
+    spawn_stale_image_watcher(socket.to_path_buf());
 
     let pair = native_pty_system()
         .openpty(PtySize {
@@ -544,6 +598,7 @@ pub(crate) fn serve_with_token(
     broadcast(&host, &encode_control_frame(&Control::Exit { code }));
     let _ = std::fs::remove_file(socket);
     let _ = std::fs::remove_file(presence_path(socket));
+    let _ = std::fs::remove_file(stale_marker_path(socket));
     // Drop the meta sidecar too, or a later server for this workspace inherits
     // the dead session's created time and `croft ls` reports an inflated uptime.
     crate::session::remove_meta(socket);
@@ -1029,6 +1084,7 @@ fn kill_stale_server(socket: &Path) {
     if !crate::session::is_alive(socket) {
         let _ = std::fs::remove_file(socket);
         let _ = std::fs::remove_file(presence_path(socket));
+        let _ = std::fs::remove_file(stale_marker_path(socket));
         crate::session::remove_meta(socket);
     }
 }
@@ -1351,6 +1407,9 @@ pub struct InnerChannel {
     reader: FrameReader,
     /// The presence sidecar this session's host maintains.
     pub presence: PathBuf,
+    /// The host's stale-image marker (#238): present once the host noticed
+    /// its binary was replaced on disk while it kept running the old image.
+    pub stale_marker: PathBuf,
 }
 
 impl InnerChannel {
@@ -1387,6 +1446,7 @@ impl InnerChannel {
             stream,
             reader: FrameReader::new(),
             presence: presence_path(socket),
+            stale_marker: stale_marker_path(socket),
         })
     }
 
@@ -2936,5 +2996,55 @@ mod tests {
         assert!(!sole_participant_lacks_control(&[p(false), p(false)]));
         assert!(!sole_participant_lacks_control(&[p(false), p(true)]));
         assert!(!sole_participant_lacks_control(&[]));
+    }
+
+    // #238: the marker sits next to the socket like the presence sidecar,
+    // and the update signal is the binary's inode moving — a plain touch of
+    // the same file must not read as an update.
+    #[test]
+    fn stale_marker_sits_next_to_socket_and_replacement_moves_the_identity() {
+        let p = stale_marker_path(Path::new("/x/sessions/ab.mux.sock"));
+        assert_eq!(p, Path::new("/x/sessions/ab.mux.sock.host-stale"));
+
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("croft");
+        std::fs::write(&bin, b"v1").unwrap();
+        let start = image_identity(&bin).unwrap();
+        // touch-equivalent: rewriting in place keeps the inode
+        std::fs::write(&bin, b"v1-touched").unwrap();
+        assert_eq!(
+            image_identity(&bin).unwrap(),
+            start,
+            "an in-place rewrite is not a replacement"
+        );
+        // an install replaces: new file renamed over the old path
+        let staged = dir.path().join("croft.new");
+        std::fs::write(&staged, b"v2").unwrap();
+        std::fs::rename(&staged, &bin).unwrap();
+        assert_ne!(
+            image_identity(&bin).unwrap(),
+            start,
+            "a rename-over is a replacement and must change the identity"
+        );
+    }
+
+    // A fresh host must clear a predecessor's stale marker: the new host IS
+    // the update the marker pointed at.
+    #[test]
+    fn a_fresh_host_clears_a_predecessors_stale_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("s.mux.sock");
+        std::fs::write(stale_marker_path(&socket), b"").unwrap();
+        let server = spawn_test_server(socket.clone());
+        wait_alive(&socket);
+        assert!(
+            !stale_marker_path(&socket).exists(),
+            "the marker must not outlive the host it described"
+        );
+        let mut a = TestClient::connect(&socket, "owner", 80, 24);
+        a.read_until(|f| matches!(f, Frame::Control(Control::Presence { .. })));
+        a.send(&encode_bytes_frame(&[0x04]));
+        a.read_until(|f| matches!(f, Frame::Control(Control::Exit { .. })));
+        let _ = server.join();
     }
 }


### PR DESCRIPTION
First step of #238 (leaves it open for the full re-exec).

Observed 2026-08-22 after shipping a fix to a box with a live session:

```
2798117: /root/.cargo/bin/croft (deleted)   <- session-host --serve
2798118: /root/.cargo/bin/croft             <- inner croft (re-exec'd, new)
2801479: /root/.cargo/bin/croft (deleted)   <- attach client
```

The inner croft re-exec'd into the update; the host it runs under kept the old image — and the host is exactly where the session-host fixes live. Nothing surfaced it: the update was "deployed" yet resident nowhere until the host was killed by hand.

## Mechanism

- At startup the host records its binary's **(device, inode)** and polls the path every 30s. Installs rename a new file over the old path, so the inode moving is the update signal — an in-place rewrite (`touch`) does not trip it. On detection it writes a `<socket>.host-stale` sidecar once and stops.
- A fresh host clears any predecessor's marker (the new host *is* the update the marker pointed at); both host exit paths remove it with the other sidecars.

## Surfacing

- **Inner croft status bar** (once per session, via the existing 500ms presence poll, checked before the presence-mtime early-return so an unchanging roster can't hide it): `Session host runs a pre-update binary; detach and reattach (all participants) to pick up the update`
- **`croft ls`**: appends `(host pre-dates a binary update; reattach to refresh)` to the session row.

## Tests

- `stale_marker_sits_next_to_socket_and_replacement_moves_the_identity` — the path helper, plus the identity signal both ways (in-place rewrite ≠ replacement, rename-over = replacement)
- `a_fresh_host_clears_a_predecessors_stale_marker` — end-to-end against a live test server

Full suite: 3342 passed; the 4 failures are the known load-sensitive flakes, identical on clean main. fmt + clippy `-D warnings` clean.