### PR TITLE
feat(app): local drift hint + one-key background reinstall

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,14 +24,24 @@
 // default behavior stands.
 fn main() {
     let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let suffix = if git_output(&root, &["status", "--porcelain"]).is_some_and(|s| !s.is_empty()) {
+        "-dirty"
+    } else {
+        ""
+    };
+    // Two spellings of the same provenance: the short label for display
+    // (`--version`, splash badge) and the full commit ID for comparison —
+    // abbreviation length follows `core.abbrev`/repo size, so short labels
+    // for one commit can differ between builds and would read as false
+    // drift (see `probe_drift` in `src/update_watch.rs`).
     let hash = git_output(&root, &["rev-parse", "--short", "HEAD"])
-        .map(|h| {
-            let dirty =
-                git_output(&root, &["status", "--porcelain"]).is_some_and(|s| !s.is_empty());
-            if dirty { format!("{h}-dirty") } else { h }
-        })
+        .map(|h| format!("{h}{suffix}"))
         .unwrap_or_else(|| String::from("unknown"));
     println!("cargo:rustc-env=CROFT_GIT_HASH={hash}");
+    let full = git_output(&root, &["rev-parse", "HEAD"])
+        .map(|h| format!("{h}{suffix}"))
+        .unwrap_or_else(|| String::from("unknown"));
+    println!("cargo:rustc-env=CROFT_GIT_HASH_FULL={full}");
     let time = std::process::Command::new("date")
         .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
         .output()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2746,8 +2746,10 @@ pub struct App {
     /// launcher instead. Dropped once its verdict is drained.
     drift_probe: Option<crate::update_watch::DriftProbe>,
     /// The repo's current hash label when the probe found drift ("def456",
-    /// "def456-dirty"). Arms the "F9 to rebuild" status-bar hint; cleared
-    /// when the rebuild starts.
+    /// "def456-dirty"). Arms the "F9 to rebuild" status-bar hint. Kept
+    /// through a running rebuild — the Idle guards hide the hint while it
+    /// runs, and a failure then re-arms F9 for a retry instead of
+    /// silently reverting the key to its breakpoint meaning.
     local_drift: Option<String>,
     /// Background `cargo install --path <repo>` reinstalling the local
     /// croft after the user pressed F9 on a drift hint. Reported through
@@ -20228,7 +20230,7 @@ impl App {
         }
         self.drift_probe = Some(crate::update_watch::DriftProbe::start(
             String::from(env!("CARGO_MANIFEST_DIR")),
-            String::from(env!("CROFT_GIT_HASH")),
+            String::from(env!("CROFT_GIT_HASH_FULL")),
         ));
     }
 
@@ -20258,7 +20260,6 @@ impl App {
     /// `cargo install` runs, then the same "F9 to relaunch" flow a remote
     /// background update uses.
     fn start_local_reinstall(&mut self) {
-        self.local_drift = None;
         self.self_install = Some(crate::update_watch::SelfInstall::start(
             String::from(env!("CARGO_MANIFEST_DIR")),
             croft_cache_dir().join("self-install.log"),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2740,6 +2740,19 @@ pub struct App {
     /// the local cross-build writes when it finishes shipping a newer
     /// binary, so the running croft can re-exec into it in place.
     update_watch: Option<crate::update_watch::UpdateWatch>,
+    /// One-shot startup probe (#242): does the repo this binary was built
+    /// from now sit at a different commit/dirty state than the binary has
+    /// baked in? Local-only — a remote-launched croft is re-stamped by its
+    /// launcher instead. Dropped once its verdict is drained.
+    drift_probe: Option<crate::update_watch::DriftProbe>,
+    /// The repo's current hash label when the probe found drift ("def456",
+    /// "def456-dirty"). Arms the "F9 to rebuild" status-bar hint; cleared
+    /// when the rebuild starts.
+    local_drift: Option<String>,
+    /// Background `cargo install --path <repo>` reinstalling the local
+    /// croft after the user pressed F9 on a drift hint. Reported through
+    /// the same UpdateEvent lifecycle as the remote watcher.
+    self_install: Option<crate::update_watch::SelfInstall>,
     update_status: UpdateStatus,
     /// When a background self-update is in progress, the instant it started.
     /// Drives the spinning update glyph in the status bar (and the redraw
@@ -3881,6 +3894,9 @@ impl App {
             connect_auth: None,
             install_session: None,
             update_watch: None,
+            drift_probe: None,
+            local_drift: None,
+            self_install: None,
             update_status: UpdateStatus::Idle,
             update_spinner_start: None,
             pending_reexec: false,
@@ -12616,6 +12632,22 @@ impl App {
                     .add_modifier(Modifier::BOLD),
             ));
         }
+        if let Some(current) = self.local_drift.as_ref()
+            && self.update_status == UpdateStatus::Idle
+        {
+            // Amber, persistent: the binary predates its own source tree
+            // (#242). One keypress rebuilds it in the background.
+            spans.push(Span::styled(
+                format!(
+                    " ⟳ croft {} < repo {current} - F9 to rebuild ",
+                    env!("CROFT_GIT_HASH")
+                ),
+                Style::default()
+                    .bg(self.theme.ui(Color::Rgb(0x8a, 0x60, 0x00)))
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
         if self.update_status == UpdateStatus::InProgress {
             // Red + a spinning circular-arrow glyph to draw the eye to the
             // in-progress background update.
@@ -14606,9 +14638,7 @@ impl App {
             self.debug_pause();
             return Ok(());
         }
-        if matches!(key.code, KeyCode::F(9))
-            && !(terminal_owns_fkeys && self.update_status != UpdateStatus::Ready)
-        {
+        if matches!(key.code, KeyCode::F(9)) && !(terminal_owns_fkeys && !self.f9_update_armed()) {
             if key.modifiers.contains(KeyModifiers::SHIFT)
                 && key.modifiers.contains(KeyModifiers::ALT)
             {
@@ -14625,6 +14655,10 @@ impl App {
                 // A background update has landed: bare F9 re-execs into it.
                 self.pending_reexec = true;
                 self.quit = true;
+            } else if self.local_drift.is_some() && self.update_status == UpdateStatus::Idle {
+                // The drift hint is armed (#242): bare F9 rebuilds and
+                // reinstalls the local croft in the background.
+                self.start_local_reinstall();
             } else {
                 self.debug_toggle_breakpoint();
             }
@@ -20184,12 +20218,70 @@ impl App {
         ));
     }
 
-    pub fn poll_update_watch(&mut self) -> bool {
-        let Some(watch) = self.update_watch.as_ref() else {
+    /// Start the one-shot local drift probe (#242) on a locally-launched
+    /// croft. A remote-launched croft skips it: its binary is re-stamped by
+    /// the launching machine on every connect, and its baked manifest dir
+    /// points at a tree on another box anyway.
+    fn start_drift_probe_if_local(&mut self) {
+        if std::env::var_os("CROFT_REMOTE_AUTOUPDATE").is_some() {
+            return;
+        }
+        self.drift_probe = Some(crate::update_watch::DriftProbe::start(
+            String::from(env!("CARGO_MANIFEST_DIR")),
+            String::from(env!("CROFT_GIT_HASH")),
+        ));
+    }
+
+    /// Arm the rebuild hint when the drift probe's verdict lands. The probe
+    /// is dropped either way — it only ever answers once.
+    fn poll_drift_probe(&mut self) -> bool {
+        let Some(probe) = self.drift_probe.as_ref() else {
             return false;
         };
-        let mut changed = false;
-        for ev in watch.drain() {
+        let Some(verdict) = probe.take() else {
+            return false;
+        };
+        self.drift_probe = None;
+        let Some(current) = verdict else {
+            return false;
+        };
+        self.status = format!(
+            "This croft was built at {}, but its repo is now at {current} - press F9 to rebuild & reinstall in the background",
+            env!("CROFT_GIT_HASH"),
+        );
+        self.local_drift = Some(current);
+        true
+    }
+
+    /// Kick off the background reinstall the drift hint offered. The
+    /// existing update state machine takes it from here: spinner while
+    /// `cargo install` runs, then the same "F9 to relaunch" flow a remote
+    /// background update uses.
+    fn start_local_reinstall(&mut self) {
+        self.local_drift = None;
+        self.self_install = Some(crate::update_watch::SelfInstall::start(
+            String::from(env!("CARGO_MANIFEST_DIR")),
+            croft_cache_dir().join("self-install.log"),
+        ));
+    }
+
+    /// True when bare F9 is claimed by the update flow: either a landed
+    /// update waiting to re-exec, or an armed drift hint waiting to rebuild.
+    fn f9_update_armed(&self) -> bool {
+        self.update_status == UpdateStatus::Ready
+            || (self.local_drift.is_some() && self.update_status == UpdateStatus::Idle)
+    }
+
+    pub fn poll_update_watch(&mut self) -> bool {
+        let mut changed = self.poll_drift_probe();
+        let mut events: Vec<crate::update_watch::UpdateEvent> = Vec::new();
+        if let Some(watch) = self.update_watch.as_ref() {
+            events.extend(watch.drain());
+        }
+        if let Some(install) = self.self_install.as_ref() {
+            events.extend(install.drain());
+        }
+        for ev in events {
             changed = true;
             match ev {
                 crate::update_watch::UpdateEvent::InProgress => {
@@ -20202,8 +20294,13 @@ impl App {
                 crate::update_watch::UpdateEvent::Failed => {
                     self.update_status = UpdateStatus::Idle;
                     self.update_spinner_start = None;
-                    self.status =
-                        String::from("Background croft update failed; staying on current version");
+                    self.status = if self.self_install.take().is_some() {
+                        String::from(
+                            "croft rebuild failed - see ~/.cache/croft/self-install.log (still on the old binary)",
+                        )
+                    } else {
+                        String::from("Background croft update failed; staying on current version")
+                    };
                 }
                 crate::update_watch::UpdateEvent::Ready => {
                     self.update_spinner_start = None;
@@ -37108,6 +37205,7 @@ pub fn run(
         app.open_file_at_launch(file);
     }
     app.start_update_watch_if_remote();
+    app.start_drift_probe_if_local();
 
     enable_raw_mode().context("enable raw mode")?;
     // Sixel has no env var, so when neither iTerm2 nor Kitty was detected from

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -28702,3 +28702,29 @@ fn drift_probe_verdict_arms_the_rebuild_hint() {
         app.status
     );
 }
+
+// CodeRabbit on #243: a failed rebuild used to strand the user — the drift
+// marker was cleared when the install started and nothing restored it, so
+// after a failure F9 silently reverted to its breakpoint meaning and only a
+// full relaunch re-probed. A failure must leave the hint armed for a retry.
+#[test]
+fn a_failed_reinstall_rearms_the_drift_hint_for_retry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.local_drift = Some(String::from("def456"));
+    app.self_install = Some(crate::update_watch::SelfInstall::preloaded(&[
+        crate::update_watch::UpdateEvent::InProgress,
+        crate::update_watch::UpdateEvent::Failed,
+    ]));
+    assert!(app.poll_update_watch());
+    assert_eq!(app.update_status, UpdateStatus::Idle);
+    assert!(
+        app.status.contains("self-install.log"),
+        "a failure must say where the build log is: {:?}",
+        app.status
+    );
+    assert!(
+        app.f9_update_armed(),
+        "the drift hint must survive a failed rebuild so F9 retries"
+    );
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -28621,3 +28621,84 @@ fn install_fallback_without_a_dialog_does_not_panic() {
     app.answer_install_fallback("");
     assert!(app.connect_dialog.is_none());
 }
+
+// 2026-08-22 (#242): a Mac croft shipped a remote main @ 84a31a0 while itself
+// running an hour-old binary — locally, nothing ever compares the installed
+// croft against the repo it came from. The drift hint claims bare F9 only
+// while it is armed and no update is otherwise in flight, so the key keeps
+// its debugger meaning everywhere else.
+#[test]
+fn drift_hint_arms_f9_only_while_idle() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    assert!(
+        !app.f9_update_armed(),
+        "no drift, no landed update: F9 stays a breakpoint key"
+    );
+    app.local_drift = Some(String::from("def456"));
+    assert!(app.f9_update_armed(), "an armed drift hint claims F9");
+    app.update_status = UpdateStatus::InProgress;
+    assert!(
+        !app.f9_update_armed(),
+        "a running rebuild must not re-trigger on F9"
+    );
+    app.local_drift = None;
+    app.update_status = UpdateStatus::Ready;
+    assert!(
+        app.f9_update_armed(),
+        "a landed update claims F9 for the re-exec"
+    );
+}
+
+// The probe end-to-end against a real repo: a baked hash that differs from
+// the repo's HEAD must arm the hint and say how to act on it.
+#[test]
+fn drift_probe_verdict_arms_the_rebuild_hint() {
+    let repo = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo.path())
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "git {args:?} failed");
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    };
+    git(&["init", "-q"]);
+    git(&[
+        "-c",
+        "user.email=t@t",
+        "-c",
+        "user.name=t",
+        "commit",
+        "-q",
+        "--allow-empty",
+        "-m",
+        "one",
+    ]);
+    let head = git(&["rev-parse", "--short", "HEAD"]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.drift_probe = Some(crate::update_watch::DriftProbe::start(
+        repo.path().to_string_lossy().into_owned(),
+        String::from("0000000"),
+    ));
+    let mut armed = false;
+    for _ in 0..50 {
+        if app.poll_drift_probe() {
+            armed = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    assert!(armed, "the probe's verdict must arrive and report drift");
+    assert!(app.drift_probe.is_none(), "the probe answers exactly once");
+    assert_eq!(app.local_drift.as_deref(), Some(head.as_str()));
+    assert!(
+        app.status.contains("F9"),
+        "the status must say how to act on the drift: {:?}",
+        app.status
+    );
+}

--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -59,40 +59,52 @@ pub struct DriftProbe {
 }
 
 impl DriftProbe {
-    /// `manifest_dir` is the baked `CARGO_MANIFEST_DIR`, `baked_hash` the
-    /// baked `CROFT_GIT_HASH`. The git calls run off-thread so a slow or
-    /// unreachable directory can never stall startup.
-    pub fn start(manifest_dir: String, baked_hash: String) -> Self {
+    /// `manifest_dir` is the baked `CARGO_MANIFEST_DIR`, `baked_full` the
+    /// baked `CROFT_GIT_HASH_FULL` — the full commit ID, because
+    /// abbreviation length follows `core.abbrev`/repo size and can differ
+    /// between build time and probe time for the same commit. The git
+    /// calls run off-thread so a slow or unreachable directory can never
+    /// stall startup.
+    pub fn start(manifest_dir: String, baked_full: String) -> Self {
         let (tx, rx) = channel();
         std::thread::spawn(move || {
-            let _ = tx.send(probe_drift(&manifest_dir, &baked_hash));
+            let _ = tx.send(probe_drift(&manifest_dir, &baked_full));
         });
         Self { rx }
     }
 
     /// The probe's verdict once it lands: `Some(Some(hash))` = the repo has
-    /// moved to `hash`, `Some(None)` = no drift (or no way to tell),
-    /// `None` = still probing.
+    /// moved to `hash` (a short display label), `Some(None)` = no drift (or
+    /// no way to tell), `None` = still probing.
     pub fn take(&self) -> Option<Option<String>> {
         self.rx.try_recv().ok()
     }
 }
 
-fn probe_drift(manifest_dir: &str, baked_hash: &str) -> Option<String> {
+fn probe_drift(manifest_dir: &str, baked_full: &str) -> Option<String> {
     // `unknown` = built outside git (registry/git snapshot, tarball): the
     // source can never move, and the snapshot warning already covers it.
-    if baked_hash == "unknown" {
+    if baked_full == "unknown" {
         return None;
     }
-    let head = git_in(manifest_dir, &["rev-parse", "--short", "HEAD"])?;
+    let head = git_in(manifest_dir, &["rev-parse", "HEAD"])?;
     let dirty = !git_in(manifest_dir, &["status", "--porcelain"])?.is_empty();
-    drift_label(baked_hash, &head, dirty)
+    drift_label(baked_full, &head, dirty)?;
+    // Drift confirmed on full IDs; what surfaces in the status bar is the
+    // short label, matching how the baked hash is displayed.
+    let short = git_in(manifest_dir, &["rev-parse", "--short", "HEAD"])
+        .unwrap_or_else(|| head.chars().take(7).collect());
+    Some(if dirty {
+        format!("{short}-dirty")
+    } else {
+        short
+    })
 }
 
-/// Pure comparison mirroring how `build.rs` composes `CROFT_GIT_HASH`: the
-/// repo's current label is `<head>` or `<head>-dirty`, and any difference
-/// from the baked value means the binary predates its own source tree.
-/// (Same-hash-still-dirty edits are invisible here — content-precise
+/// Pure comparison mirroring how `build.rs` composes `CROFT_GIT_HASH_FULL`:
+/// the repo's current label is `<head>` or `<head>-dirty`, and any
+/// difference from the baked value means the binary predates its own source
+/// tree. (Same-hash-still-dirty edits are invisible here — content-precise
 /// comparison is the remote stamp's job; this is a hint, not a proof.)
 fn drift_label(baked_hash: &str, head: &str, dirty: bool) -> Option<String> {
     let current = if dirty {
@@ -162,6 +174,17 @@ impl SelfInstall {
             out.push(ev);
         }
         out
+    }
+
+    /// A finished install with a scripted outcome, for exercising the app's
+    /// event handling without running a real `cargo install`.
+    #[cfg(test)]
+    pub fn preloaded(events: &[UpdateEvent]) -> Self {
+        let (tx, rx) = channel();
+        for ev in events {
+            let _ = tx.send(*ev);
+        }
+        Self { rx }
     }
 }
 
@@ -275,18 +298,28 @@ mod tests {
             "-m",
             "one",
         ]);
-        let head = git(&["rev-parse", "--short", "HEAD"]);
+        let full = git(&["rev-parse", "HEAD"]);
+        let short = git(&["rev-parse", "--short", "HEAD"]);
 
-        assert_eq!(probe_drift(dir.to_str().unwrap(), &head), None);
+        assert_eq!(probe_drift(dir.to_str().unwrap(), &full), None);
         assert_eq!(probe_drift(dir.to_str().unwrap(), "unknown"), None);
+        // The comparison runs on full commit IDs, so an abbreviation-length
+        // change between build and probe (`core.abbrev` is auto-scaled by
+        // repo size) can never read as drift...
+        git(&["config", "core.abbrev", "12"]);
+        assert_eq!(probe_drift(dir.to_str().unwrap(), &full), None);
+        git(&["config", "--unset", "core.abbrev"]);
+        // ...and a baked short label must never be passed for comparison.
+        assert_ne!(probe_drift(dir.to_str().unwrap(), &short), None);
+        // Real drift surfaces the short display label, not the full ID.
         assert_eq!(
-            probe_drift(dir.to_str().unwrap(), "0000000"),
-            Some(head.clone())
+            probe_drift(dir.to_str().unwrap(), &"0".repeat(40)),
+            Some(short.clone())
         );
         std::fs::write(dir.join("scratch.txt"), "edit").unwrap();
         assert_eq!(
-            probe_drift(dir.to_str().unwrap(), &head),
-            Some(format!("{head}-dirty"))
+            probe_drift(dir.to_str().unwrap(), &full),
+            Some(format!("{short}-dirty"))
         );
         // A directory git can't answer for (deleted repo, moved tree) is
         // silence, never a false alarm.

--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -48,6 +48,123 @@ impl UpdateWatch {
     }
 }
 
+/// One-shot background probe answering: does the repo this binary was
+/// installed from now sit at a different commit/dirty state than the binary
+/// has baked in? The local half of the deploy-verification story (#242) —
+/// remotes are re-stamped on every connect, but `~/.cargo/bin/croft` only
+/// changes when someone reinstalls, so it can silently fall behind the tree
+/// it came from.
+pub struct DriftProbe {
+    rx: Receiver<Option<String>>,
+}
+
+impl DriftProbe {
+    /// `manifest_dir` is the baked `CARGO_MANIFEST_DIR`, `baked_hash` the
+    /// baked `CROFT_GIT_HASH`. The git calls run off-thread so a slow or
+    /// unreachable directory can never stall startup.
+    pub fn start(manifest_dir: String, baked_hash: String) -> Self {
+        let (tx, rx) = channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(probe_drift(&manifest_dir, &baked_hash));
+        });
+        Self { rx }
+    }
+
+    /// The probe's verdict once it lands: `Some(Some(hash))` = the repo has
+    /// moved to `hash`, `Some(None)` = no drift (or no way to tell),
+    /// `None` = still probing.
+    pub fn take(&self) -> Option<Option<String>> {
+        self.rx.try_recv().ok()
+    }
+}
+
+fn probe_drift(manifest_dir: &str, baked_hash: &str) -> Option<String> {
+    // `unknown` = built outside git (registry/git snapshot, tarball): the
+    // source can never move, and the snapshot warning already covers it.
+    if baked_hash == "unknown" {
+        return None;
+    }
+    let head = git_in(manifest_dir, &["rev-parse", "--short", "HEAD"])?;
+    let dirty = !git_in(manifest_dir, &["status", "--porcelain"])?.is_empty();
+    drift_label(baked_hash, &head, dirty)
+}
+
+/// Pure comparison mirroring how `build.rs` composes `CROFT_GIT_HASH`: the
+/// repo's current label is `<head>` or `<head>-dirty`, and any difference
+/// from the baked value means the binary predates its own source tree.
+/// (Same-hash-still-dirty edits are invisible here — content-precise
+/// comparison is the remote stamp's job; this is a hint, not a proof.)
+fn drift_label(baked_hash: &str, head: &str, dirty: bool) -> Option<String> {
+    let current = if dirty {
+        format!("{head}-dirty")
+    } else {
+        head.to_string()
+    };
+    (current != baked_hash).then_some(current)
+}
+
+fn git_in(dir: &str, args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(out.stdout).ok()?.trim().to_string())
+}
+
+/// A background `cargo install --path <repo> --locked` reinstalling the
+/// local croft, reported through the same [`UpdateEvent`] lifecycle the
+/// remote watcher uses so the app consumes both with one state machine:
+/// `InProgress` immediately, then `Ready` (new binary at the install path,
+/// F9 re-execs into it) or `Failed` (old binary keeps running).
+pub struct SelfInstall {
+    rx: Receiver<UpdateEvent>,
+}
+
+impl SelfInstall {
+    /// Full build output lands in `log_path` so a failure is diagnosable
+    /// without scrollback.
+    pub fn start(manifest_dir: String, log_path: PathBuf) -> Self {
+        let (tx, rx) = channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(UpdateEvent::InProgress);
+            let result = std::process::Command::new("cargo")
+                .args(["install", "--path", &manifest_dir, "--locked"])
+                .output();
+            let event = match result {
+                Ok(out) => {
+                    let mut log = out.stdout;
+                    log.extend_from_slice(&out.stderr);
+                    let _ = std::fs::write(&log_path, &log);
+                    if out.status.success() {
+                        UpdateEvent::Ready
+                    } else {
+                        UpdateEvent::Failed
+                    }
+                }
+                Err(err) => {
+                    let _ = std::fs::write(&log_path, format!("failed to run cargo: {err}"));
+                    UpdateEvent::Failed
+                }
+            };
+            let _ = tx.send(event);
+        });
+        Self { rx }
+    }
+
+    pub fn drain(&self) -> Vec<UpdateEvent> {
+        let mut out = Vec::new();
+        while let Ok(ev) = self.rx.try_recv() {
+            out.push(ev);
+        }
+        out
+    }
+}
+
 fn poll_loop(cache_dir: &std::path::Path, launch_stamp: &str, tx: &Sender<UpdateEvent>) {
     let stamp_path = cache_dir.join(STAMP_FILE);
     let marker_path = cache_dir.join(MARKER_FILE);
@@ -105,6 +222,75 @@ mod tests {
         let watch = UpdateWatch::start(dir.clone(), String::from("old"));
         std::fs::write(dir.join(STAMP_FILE), "new").unwrap();
         assert!(wait_for(&watch, UpdateEvent::Ready));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn drift_label_matches_how_build_rs_composes_the_hash() {
+        assert_eq!(drift_label("abc123", "abc123", false), None);
+        assert_eq!(drift_label("abc123-dirty", "abc123", true), None);
+        assert_eq!(
+            drift_label("abc123", "def456", false),
+            Some(String::from("def456"))
+        );
+        // The same commit gaining uncommitted changes is drift: the binary
+        // no longer matches the tree.
+        assert_eq!(
+            drift_label("abc123", "abc123", true),
+            Some(String::from("abc123-dirty"))
+        );
+        // ...and so is the reverse (the dirty edits were committed away).
+        assert_eq!(
+            drift_label("abc123-dirty", "abc123", false),
+            Some(String::from("abc123"))
+        );
+    }
+
+    // 2026-08-22 (#242): a Mac croft shipped a remote main @ 84a31a0 while
+    // itself running a binary built an hour earlier — the machine deployed
+    // code newer than itself, invisibly. The probe exists so that state
+    // announces itself.
+    #[test]
+    fn probe_reports_drift_against_a_real_repo_and_silence_when_current() {
+        let dir = scratch_dir("drift");
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(out.status.success(), "git {args:?} failed");
+            String::from_utf8(out.stdout).unwrap().trim().to_string()
+        };
+        git(&["init", "-q"]);
+        git(&[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "one",
+        ]);
+        let head = git(&["rev-parse", "--short", "HEAD"]);
+
+        assert_eq!(probe_drift(dir.to_str().unwrap(), &head), None);
+        assert_eq!(probe_drift(dir.to_str().unwrap(), "unknown"), None);
+        assert_eq!(
+            probe_drift(dir.to_str().unwrap(), "0000000"),
+            Some(head.clone())
+        );
+        std::fs::write(dir.join("scratch.txt"), "edit").unwrap();
+        assert_eq!(
+            probe_drift(dir.to_str().unwrap(), &head),
+            Some(format!("{head}-dirty"))
+        );
+        // A directory git can't answer for (deleted repo, moved tree) is
+        // silence, never a false alarm.
+        assert_eq!(probe_drift("/nonexistent-croft-drift-probe", "abc"), None);
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Closes #242.

## What

The local half of the deploy-verification story: remotes get re-stamped on every connect, but `~/.cargo/bin/croft` only changes when someone remembers to run `cargo install`. Observed right after the #239–#241 merges: the Mac shipped gitcgr a fresh main @ 84a31a0 while itself running a binary built an hour earlier.

- **Detect** (`DriftProbe`, off-thread at startup, local launches only): compare baked `CROFT_GIT_HASH` (#239) against `git -C <baked CARGO_MANIFEST_DIR> rev-parse --short HEAD` + dirty state, composed exactly like `build.rs` composes the baked value. `unknown`/snapshot builds and unreachable dirs are silence, never a false alarm.
- **Hint**: amber status-bar span `⟳ croft <old> < repo <new> - F9 to rebuild` plus a status-line message. Bare F9 keeps its debugger meaning unless the hint (or a landed update) has armed it.
- **One-key rebuild** (`SelfInstall`): F9 runs `cargo install --path <repo> --locked` in the background, reported through the existing `UpdateEvent` lifecycle — spinner while building, then the same "Update ready - F9 to relaunch" re-exec flow the remote autoupdate uses (session state handed off, same tty). Failure points at `~/.cache/croft/self-install.log` and leaves the old binary running.

## Tests

- `drift_label_matches_how_build_rs_composes_the_hash` — pure comparator, incl. both dirty-transition directions.
- `probe_reports_drift_against_a_real_repo_and_silence_when_current` — real temp git repo; also pins `unknown` and unreachable-dir silence.
- `drift_hint_arms_f9_only_while_idle` — F9 claiming rules across update states.
- `drift_probe_verdict_arms_the_rebuild_hint` — probe → hint end-to-end through `poll_drift_probe`.

Local `cargo fmt --check`, `clippy --all-targets -D warnings` clean; suite shows only the four known environment flakes (identical on clean main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of local source changes when launching a Croft.
  * The status bar now shows the built-in and current repository revisions when changes are detected.
  * Press **F9** to rebuild and reinstall the Croft.
  * Reinstallation displays progress, relaunches the app when complete, and provides a dedicated failure message.
  * Remote launches are unaffected and skip local source checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->