### PR TITLE
fix(build): never let an ancestor repo supply provenance

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,11 @@
 // only, not forge-derived content. A tree without git (registry or git
 // snapshots, tarballs) builds as `unknown`, which is itself a signal: such
 // a build can never ship local changes (see `source_snapshot_warning` in
-// `src/remote.rs`).
+// `src/remote.rs`). A checkout tracked only as a subdirectory of a larger
+// repo also bakes `unknown` — telling that layout apart from a snapshot
+// unpacked inside an unrelated repo isn't worth the risk of baking an
+// ancestor's commit, so it deliberately trades provenance away (no warning
+// covers it; the snapshot warning is path-based and won't fire).
 //
 // Watching: cargo's default (rerun on any package-file change) misses moves
 // of HEAD with no source edit — commit, branch switch, stage — which left
@@ -33,6 +37,12 @@ fn main() {
         println!("cargo:rustc-env=CROFT_GIT_HASH=unknown");
         println!("cargo:rustc-env=CROFT_GIT_HASH_FULL=unknown");
         emit_build_time();
+        // In this branch `.git` is absent (a dir with its own `.git` is its
+        // own toplevel), so declaring it forces a rerun every build: pure git
+        // operations touch no package file, and a later `git init`/adoption
+        // of the tree would otherwise leave `unknown` baked until an actual
+        // source edit.
+        println!("cargo:rerun-if-changed={root}/.git");
         return;
     }
     let suffix = if git_output(&root, &["status", "--porcelain"]).is_some_and(|s| !s.is_empty()) {
@@ -121,9 +131,18 @@ fn watch_provenance_inputs(root: &str) {
 }
 
 fn git_output(root: &str, args: &[&str]) -> Option<String> {
+    // An inherited `GIT_DIR` (bare-dotfiles shells: `export GIT_DIR=~/.dotfiles`)
+    // makes git skip discovery and treat `-C`'s dir as the worktree toplevel:
+    // `--show-toplevel` then echoes the question back — satisfying the guard by
+    // construction — while HEAD answers from the foreign repo. Only filesystem
+    // discovery may speak for this source, so git's env overrides are dropped.
     let out = std::process::Command::new("git")
         .arg("-C")
         .arg(root)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
         .args(args)
         .output()
         .ok()?;

--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,17 @@
 // default behavior stands.
 fn main() {
     let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    // git discovery walks UP from `-C`, so a crate unpacked inside some
+    // unrelated repo (`cargo publish --dry-run` verifying under
+    // `target/package/`, a registry snapshot under a $HOME that is itself a
+    // git repo) would happily bake that ANCESTOR's commit as provenance.
+    // Only a directory that is its own repo toplevel speaks for the source.
+    if !dir_is_repo_toplevel(&root) {
+        println!("cargo:rustc-env=CROFT_GIT_HASH=unknown");
+        println!("cargo:rustc-env=CROFT_GIT_HASH_FULL=unknown");
+        emit_build_time();
+        return;
+    }
     let suffix = if git_output(&root, &["status", "--porcelain"]).is_some_and(|s| !s.is_empty()) {
         "-dirty"
     } else {
@@ -42,6 +53,22 @@ fn main() {
         .map(|h| format!("{h}{suffix}"))
         .unwrap_or_else(|| String::from("unknown"));
     println!("cargo:rustc-env=CROFT_GIT_HASH_FULL={full}");
+    emit_build_time();
+    watch_provenance_inputs(&root);
+}
+
+/// True only when `dir` is the working-tree root of its own repository —
+/// the one case where git's answers describe THIS source rather than some
+/// repository that merely contains the directory.
+fn dir_is_repo_toplevel(dir: &str) -> bool {
+    let Some(toplevel) = git_output(dir, &["rev-parse", "--show-toplevel"]) else {
+        return false;
+    };
+    let canon = |p: &str| std::fs::canonicalize(p).ok();
+    canon(dir).is_some() && canon(dir) == canon(&toplevel)
+}
+
+fn emit_build_time() {
     let time = std::process::Command::new("date")
         .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
         .output()
@@ -51,7 +78,6 @@ fn main() {
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| String::from("unknown"));
     println!("cargo:rustc-env=CROFT_BUILD_TIME={time}");
-    watch_provenance_inputs(&root);
 }
 
 /// Declares every input that can move `CROFT_GIT_HASH`: the git metadata the

--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -87,6 +87,16 @@ fn probe_drift(manifest_dir: &str, baked_full: &str) -> Option<String> {
     if baked_full == "unknown" {
         return None;
     }
+    // git discovery walks up from `-C`, so a manifest dir that merely sits
+    // INSIDE some repo (a snapshot unpacked under a $HOME that is itself a
+    // git repo) would be answered for by that ancestor — and the hint would
+    // then offer to `cargo install` an immutable snapshot over itself. Only
+    // a dir that is its own repo toplevel speaks for this source (mirrors
+    // the same guard in `build.rs`).
+    let toplevel = git_in(manifest_dir, &["rev-parse", "--show-toplevel"])?;
+    if std::fs::canonicalize(manifest_dir).ok() != std::fs::canonicalize(&toplevel).ok() {
+        return None;
+    }
     let head = git_in(manifest_dir, &["rev-parse", "HEAD"])?;
     let dirty = !git_in(manifest_dir, &["status", "--porcelain"])?.is_empty();
     drift_label(baked_full, &head, dirty)?;
@@ -324,6 +334,18 @@ mod tests {
         // A directory git can't answer for (deleted repo, moved tree) is
         // silence, never a false alarm.
         assert_eq!(probe_drift("/nonexistent-croft-drift-probe", "abc"), None);
+        // A directory merely INSIDE a repo is answered for by its ancestor
+        // (`cargo publish` verify under target/package/, a snapshot under a
+        // $HOME that is a git repo): that ancestor's commits say nothing
+        // about this source, so the probe must stay silent rather than
+        // offer to reinstall an immutable snapshot over itself.
+        let nested = dir.join("vendored").join("croft-software-0.1.758");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(
+            probe_drift(nested.to_str().unwrap(), &"0".repeat(40)),
+            None,
+            "an ancestor repo must never supply drift provenance"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -82,8 +82,9 @@ impl DriftProbe {
 }
 
 fn probe_drift(manifest_dir: &str, baked_full: &str) -> Option<String> {
-    // `unknown` = built outside git (registry/git snapshot, tarball): the
-    // source can never move, and the snapshot warning already covers it.
+    // `unknown` = built without its own repo (registry/git snapshot,
+    // tarball, or a checkout tracked only as a subdirectory of a larger
+    // repo): drift can't be judged, so the probe stays silent.
     if baked_full == "unknown" {
         return None;
     }
@@ -94,7 +95,8 @@ fn probe_drift(manifest_dir: &str, baked_full: &str) -> Option<String> {
     // a dir that is its own repo toplevel speaks for this source (mirrors
     // the same guard in `build.rs`).
     let toplevel = git_in(manifest_dir, &["rev-parse", "--show-toplevel"])?;
-    if std::fs::canonicalize(manifest_dir).ok() != std::fs::canonicalize(&toplevel).ok() {
+    let dir = std::fs::canonicalize(manifest_dir).ok()?;
+    if Some(dir) != std::fs::canonicalize(&toplevel).ok() {
         return None;
     }
     let head = git_in(manifest_dir, &["rev-parse", "HEAD"])?;
@@ -126,9 +128,17 @@ fn drift_label(baked_hash: &str, head: &str, dirty: bool) -> Option<String> {
 }
 
 fn git_in(dir: &str, args: &[&str]) -> Option<String> {
+    // Same env scrub as `git_output` in `build.rs`: an inherited `GIT_DIR`
+    // (without a worktree) makes git treat `-C`'s dir as the toplevel, which
+    // would satisfy the guard in `probe_drift` by construction while HEAD
+    // answers from the foreign repo — guaranteed false drift.
     let out = std::process::Command::new("git")
         .arg("-C")
         .arg(dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
         .args(args)
         .output()
         .ok()?;


### PR DESCRIPTION
Found while pre-flighting `cargo publish` for 0.1.758.

## The hole

git discovery walks **up** from `-C`, so a crate unpacked inside some unrelated repository is answered for by that ancestor:

- `cargo publish`'s verify build under `target/package/…` baked the outer repo's commit as the tarball's provenance (observed in this repo's dry run).
- Worse: a registry snapshot unpacked under a `$HOME` that is itself a git repo would bake that repo's commit — bogus provenance instead of the honest `unknown` — and the #243 drift probe, comparing against the same ancestor, could then arm the F9 hint and offer to `cargo install --path` an **immutable snapshot over itself**.

## The fix

Both `build.rs` and `probe_drift` now require the manifest dir to be its **own repo toplevel** (`git rev-parse --show-toplevel`, canonicalized) before trusting git's answers. Anything else builds as `unknown` — the honest label for a tree git cannot speak for. Worktrees still resolve correctly (a worktree root is its own toplevel).

## Verified

- Repo build bakes real provenance (`b3c6a42-dirty` observed post-change).
- `cargo publish --dry-run` verify build now bakes `unknown` (was: the outer repo's hash).
- New regression test: a nested dir inside a repo yields probe silence, never drift.