### PR TITLE
fix(update): harden the F9 self-reinstall flow

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -14657,7 +14657,7 @@ impl App {
                 // A background update has landed: bare F9 re-execs into it.
                 self.pending_reexec = true;
                 self.quit = true;
-            } else if self.local_drift.is_some() && self.update_status == UpdateStatus::Idle {
+            } else if self.f9_update_armed() && self.update_status == UpdateStatus::Idle {
                 // The drift hint is armed (#242): bare F9 rebuilds and
                 // reinstalls the local croft in the background.
                 self.start_local_reinstall();
@@ -20262,7 +20262,7 @@ impl App {
     fn start_local_reinstall(&mut self) {
         self.self_install = Some(crate::update_watch::SelfInstall::start(
             String::from(env!("CARGO_MANIFEST_DIR")),
-            croft_cache_dir().join("self-install.log"),
+            self_install_log_path(),
         ));
     }
 
@@ -20270,7 +20270,14 @@ impl App {
     /// update waiting to re-exec, or an armed drift hint waiting to rebuild.
     fn f9_update_armed(&self) -> bool {
         self.update_status == UpdateStatus::Ready
-            || (self.local_drift.is_some() && self.update_status == UpdateStatus::Idle)
+            || (self.local_drift.is_some()
+                && self.update_status == UpdateStatus::Idle
+                // `update_status` only leaves Idle when the InProgress event
+                // is drained - once per outer loop, BEFORE the input drain -
+                // so without this latch two F9s in one crossterm batch spawn
+                // two concurrent `cargo install`s racing cargo's locks
+                // (#245).
+                && self.self_install.is_none())
     }
 
     pub fn poll_update_watch(&mut self) -> bool {
@@ -20296,8 +20303,9 @@ impl App {
                     self.update_status = UpdateStatus::Idle;
                     self.update_spinner_start = None;
                     self.status = if self.self_install.take().is_some() {
-                        String::from(
-                            "croft rebuild failed - see ~/.cache/croft/self-install.log (still on the old binary)",
+                        format!(
+                            "croft rebuild failed - see {} (still on the old binary)",
+                            self_install_log_path().display()
                         )
                     } else {
                         String::from("Background croft update failed; staying on current version")
@@ -36579,16 +36587,28 @@ fn croft_cache_dir() -> PathBuf {
     home.join(".cache").join("croft")
 }
 
-/// Resolve the binary to re-exec into after an update. The remote install
-/// always lands at `~/.cargo/bin/croft`; preferring that path (over
-/// `current_exe`, which may resolve to the now-replaced inode) guarantees
-/// the swap picks up the freshly-shipped file.
-fn reexec_binary_path() -> PathBuf {
-    if let Some(home) = std::env::var_os("HOME") {
-        let p = PathBuf::from(home).join(".cargo").join("bin").join("croft");
-        if p.exists() {
-            return p;
-        }
+/// The per-process self-install log: two drift-armed croft instances on one
+/// machine must not overwrite each other's build diagnostics (#245).
+fn self_install_log_path() -> PathBuf {
+    croft_cache_dir().join(format!("self-install-{}.log", std::process::id()))
+}
+
+/// Resolve the binary to re-exec into after an update. A local self-install
+/// lands wherever cargo's install root points (`CARGO_INSTALL_ROOT` /
+/// `CARGO_HOME` / `~/.cargo`); the remote installer always rsyncs to the
+/// literal `~/.cargo/bin/croft`. Either way the fresh file is preferred
+/// over `current_exe`, which may resolve to the now-replaced inode.
+fn reexec_binary_path(local_install: bool) -> PathBuf {
+    let installed = if local_install {
+        crate::update_watch::cargo_install_bin()
+    } else {
+        std::env::var_os("HOME")
+            .map(|home| PathBuf::from(home).join(".cargo").join("bin").join("croft"))
+    };
+    if let Some(p) = installed
+        && p.exists()
+    {
+        return p;
     }
     std::env::current_exe().unwrap_or_else(|_| PathBuf::from("croft"))
 }
@@ -37346,7 +37366,7 @@ pub fn run(
         let session_path = crate::session_state::handoff_path();
         let _ = state.save(&session_path);
         use std::os::unix::process::CommandExt;
-        let mut cmd = std::process::Command::new(reexec_binary_path());
+        let mut cmd = std::process::Command::new(reexec_binary_path(app.self_install.is_some()));
         cmd.arg(app.workspace_root())
             .arg("--restore-session")
             .arg(&session_path);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12636,6 +12636,7 @@ impl App {
         }
         if let Some(current) = self.local_drift.as_ref()
             && self.update_status == UpdateStatus::Idle
+            && self.self_install.is_none()
         {
             // Amber, persistent: the binary predates its own source tree
             // (#242). One keypress rebuilds it in the background.
@@ -14661,6 +14662,10 @@ impl App {
                 // The drift hint is armed (#242): bare F9 rebuilds and
                 // reinstalls the local croft in the background.
                 self.start_local_reinstall();
+            } else if self.self_install.is_some() {
+                // A rebuild is already in flight (second F9 of an input
+                // batch, or pressed again mid-install): swallow it -
+                // toggling a breakpoint here is never what was meant.
             } else {
                 self.debug_toggle_breakpoint();
             }
@@ -36594,13 +36599,17 @@ fn self_install_log_path() -> PathBuf {
 }
 
 /// Resolve the binary to re-exec into after an update. A local self-install
-/// lands wherever cargo's install root points (`CARGO_INSTALL_ROOT` /
-/// `CARGO_HOME` / `~/.cargo`); the remote installer always rsyncs to the
-/// literal `~/.cargo/bin/croft`. Either way the fresh file is preferred
-/// over `current_exe`, which may resolve to the now-replaced inode.
-fn reexec_binary_path(local_install: bool) -> PathBuf {
-    let installed = if local_install {
-        crate::update_watch::cargo_install_bin()
+/// re-execs the exact path cargo reported writing (which honors an
+/// `install.root` from cargo config that env resolution can't see), falling
+/// back to cargo's env-level root (`CARGO_INSTALL_ROOT` / `CARGO_HOME` /
+/// `~/.cargo`); the remote installer always rsyncs to the literal
+/// `~/.cargo/bin/croft`. Either way the fresh file is preferred over
+/// `current_exe`, which may resolve to the now-replaced inode.
+fn reexec_binary_path(local_install: Option<&crate::update_watch::SelfInstall>) -> PathBuf {
+    let installed = if let Some(install) = local_install {
+        install
+            .installed_path()
+            .or_else(crate::update_watch::cargo_install_bin)
     } else {
         std::env::var_os("HOME")
             .map(|home| PathBuf::from(home).join(".cargo").join("bin").join("croft"))
@@ -37366,7 +37375,7 @@ pub fn run(
         let session_path = crate::session_state::handoff_path();
         let _ = state.save(&session_path);
         use std::os::unix::process::CommandExt;
-        let mut cmd = std::process::Command::new(reexec_binary_path(app.self_install.is_some()));
+        let mut cmd = std::process::Command::new(reexec_binary_path(app.self_install.as_ref()));
         cmd.arg(app.workspace_root())
             .arg("--restore-session")
             .arg(&session_path);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -28637,6 +28637,13 @@ fn drift_hint_arms_f9_only_while_idle() {
     );
     app.local_drift = Some(String::from("def456"));
     assert!(app.f9_update_armed(), "an armed drift hint claims F9");
+    app.self_install = Some(crate::update_watch::SelfInstall::preloaded(&[]));
+    assert!(
+        !app.f9_update_armed(),
+        "a spawned install must latch F9 even before its InProgress event \
+         is drained - two F9s in one input batch must not double-spawn"
+    );
+    app.self_install = None;
     app.update_status = UpdateStatus::InProgress;
     assert!(
         !app.f9_update_armed(),
@@ -28719,8 +28726,9 @@ fn a_failed_reinstall_rearms_the_drift_hint_for_retry() {
     assert!(app.poll_update_watch());
     assert_eq!(app.update_status, UpdateStatus::Idle);
     assert!(
-        app.status.contains("self-install.log"),
-        "a failure must say where the build log is: {:?}",
+        app.status
+            .contains(&format!("self-install-{}.log", std::process::id())),
+        "a failure must say where THIS process's build log is: {:?}",
         app.status
     );
     assert!(

--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -198,34 +198,20 @@ fn parse_installed_binary(output: &str) -> Option<PathBuf> {
     })
 }
 
-/// True when `toml` declares `pkg` as its `[package]` name. Deliberately
-/// line-based (no toml dependency) but section-aware: a `name` under
-/// `[[bin]]` or a dependency table must not vouch for the package, and
-/// both TOML quote styles plus `name="x"` spacing are legal.
-fn manifest_declares_package(toml: &str, pkg: &str) -> bool {
-    let mut in_package = false;
-    for line in toml.lines() {
-        let line = line.trim();
-        if line.starts_with('[') {
-            in_package = line == "[package]";
-            continue;
-        }
-        if !in_package {
-            continue;
-        }
-        let Some(value) = line
-            .strip_prefix("name")
-            .map(str::trim_start)
-            .and_then(|rest| rest.strip_prefix('='))
-        else {
-            continue;
-        };
-        let value = value.split('#').next().unwrap_or("").trim();
-        if value == format!("\"{pkg}\"") || value == format!("'{pkg}'") {
-            return true;
-        }
-    }
-    false
+/// True when the manifest declares `pkg` as its `[package]` name. Parsed
+/// semantically - a line scanner is fooled by multiline strings (a
+/// `description = \"\"\"...\"\"\"` can contain `[package]`/`name` lines), and a
+/// `name` under `[[bin]]` or a dependency table must not vouch for the
+/// package.
+fn manifest_declares_package(manifest: &str, pkg: &str) -> bool {
+    manifest
+        .parse::<toml::Table>()
+        .ok()
+        .and_then(|table| {
+            let name = table.get("package")?.get("name")?.as_str()?;
+            Some(name == pkg)
+        })
+        .unwrap_or(false)
 }
 
 /// Best-effort cleanup of per-process install logs, which otherwise
@@ -426,6 +412,13 @@ mod tests {
             "a name in another table must not vouch for the package"
         );
         assert!(!manifest_declares_package("", "croft-software"));
+        let multiline_trap = "[package]\nname = \"foreign\"\nversion = \"0.1.0\"\n\
+                              description = \"\"\"\n[package]\nname = \"croft-software\"\n\"\"\"\n";
+        assert!(
+            !manifest_declares_package(multiline_trap, "croft-software"),
+            "package/name lines inside a multiline string must not vouch for the package"
+        );
+        assert!(manifest_declares_package(multiline_trap, "foreign"));
     }
 
     #[test]

--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -167,11 +167,93 @@ fn install_bin_from(
     cargo_home: Option<std::ffi::OsString>,
     home: Option<std::ffi::OsString>,
 ) -> Option<PathBuf> {
-    let root = install_root
-        .or(cargo_home)
+    // Cargo treats an empty env var as unset (home crate filters it);
+    // honoring one here would yield the RELATIVE path `bin/croft`, resolved
+    // against the workspace being edited - an arbitrary workspace file could
+    // then pass the exists() check and get exec'd as the "update".
+    let set = |v: Option<std::ffi::OsString>| v.filter(|v| !v.is_empty());
+    let root = set(install_root)
+        .or_else(|| set(cargo_home))
         .map(PathBuf::from)
-        .or_else(|| home.map(|h| PathBuf::from(h).join(".cargo")))?;
+        .or_else(|| set(home).map(|h| PathBuf::from(h).join(".cargo")))?;
     Some(root.join("bin").join("croft"))
+}
+
+/// The destination cargo itself reported (`Installing`/`Replacing <path>`
+/// in its output) - authoritative where env resolution is not: an
+/// `install.root` in cargo config is invisible to [`cargo_install_bin`],
+/// and re-execing the env-resolved guess would silently relaunch a stale
+/// `~/.cargo/bin/croft` forever. Package-progress lines ("Installing
+/// croft-software v…") are skipped by requiring an absolute path to the
+/// binary.
+fn parse_installed_binary(output: &str) -> Option<PathBuf> {
+    output.lines().rev().find_map(|line| {
+        let line = line.trim();
+        let rest = line
+            .strip_prefix("Installing ")
+            .or_else(|| line.strip_prefix("Replacing "))?;
+        let path = std::path::Path::new(rest.trim());
+        (path.is_absolute() && path.file_name() == Some(std::ffi::OsStr::new("croft")))
+            .then(|| path.to_path_buf())
+    })
+}
+
+/// True when `toml` declares `pkg` as its `[package]` name. Deliberately
+/// line-based (no toml dependency) but section-aware: a `name` under
+/// `[[bin]]` or a dependency table must not vouch for the package, and
+/// both TOML quote styles plus `name="x"` spacing are legal.
+fn manifest_declares_package(toml: &str, pkg: &str) -> bool {
+    let mut in_package = false;
+    for line in toml.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_package = line == "[package]";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        let Some(value) = line
+            .strip_prefix("name")
+            .map(str::trim_start)
+            .and_then(|rest| rest.strip_prefix('='))
+        else {
+            continue;
+        };
+        let value = value.split('#').next().unwrap_or("").trim();
+        if value == format!("\"{pkg}\"") || value == format!("'{pkg}'") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Best-effort cleanup of per-process install logs, which otherwise
+/// accumulate one file per croft run forever. A week keeps every recent
+/// diagnostic (including whatever a live sibling instance just wrote)
+/// while bounding the pile; the legacy shared `self-install.log` ages out
+/// under the same rule.
+fn prune_old_install_logs(dir: &std::path::Path, keep: &std::path::Path) {
+    const WEEK: std::time::Duration = std::time::Duration::from_secs(7 * 24 * 3600);
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !name.starts_with("self-install") || !name.ends_with(".log") || entry.path() == keep {
+            continue;
+        }
+        let expired = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .is_some_and(|age| age > WEEK);
+        if expired {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }
 
 /// A background `cargo install --path <repo> --locked` reinstalling the
@@ -181,6 +263,9 @@ fn install_bin_from(
 /// F9 re-execs into it) or `Failed` (old binary keeps running).
 pub struct SelfInstall {
     rx: Receiver<UpdateEvent>,
+    /// Where cargo said it wrote the binary, parsed from its output on
+    /// success; read by the F9 re-exec.
+    installed: std::sync::Arc<std::sync::Mutex<Option<PathBuf>>>,
 }
 
 impl SelfInstall {
@@ -188,18 +273,26 @@ impl SelfInstall {
     /// without scrollback.
     pub fn start(manifest_dir: String, log_path: PathBuf) -> Self {
         let (tx, rx) = channel();
+        let installed = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let installed_writer = std::sync::Arc::clone(&installed);
         std::thread::spawn(move || {
             let _ = tx.send(UpdateEvent::InProgress);
+            // The cache dir may not exist yet (nothing else in the local
+            // drift flow creates it), and for a refusal below the log is
+            // the only place the reason is recorded.
+            if let Some(dir) = log_path.parent() {
+                let _ = std::fs::create_dir_all(dir);
+                prune_old_install_logs(dir, &log_path);
+            }
             // The manifest dir is a path baked at build time; nothing stops
             // the filesystem from hosting a different crate there by now.
             // `cargo install` would happily build that foreign package, exit
             // 0, and the app would announce a croft update that never
             // happened - so refuse unless the manifest still declares THIS
             // package (#245).
-            let expected = concat!("name = \"", env!("CARGO_PKG_NAME"), "\"");
             let manifest_ok =
                 std::fs::read_to_string(std::path::Path::new(&manifest_dir).join("Cargo.toml"))
-                    .is_ok_and(|s| s.lines().any(|l| l.trim() == expected));
+                    .is_ok_and(|s| manifest_declares_package(&s, env!("CARGO_PKG_NAME")));
             if !manifest_ok {
                 let _ = std::fs::write(
                     &log_path,
@@ -222,6 +315,9 @@ impl SelfInstall {
                     log.extend_from_slice(&out.stderr);
                     let _ = std::fs::write(&log_path, &log);
                     if out.status.success() {
+                        if let Ok(mut slot) = installed_writer.lock() {
+                            *slot = parse_installed_binary(&String::from_utf8_lossy(&log));
+                        }
                         UpdateEvent::Ready
                     } else {
                         UpdateEvent::Failed
@@ -234,7 +330,13 @@ impl SelfInstall {
             };
             let _ = tx.send(event);
         });
-        Self { rx }
+        Self { rx, installed }
+    }
+
+    /// The path cargo reported installing to, once `Ready` has been sent.
+    /// `None` before that, or when the output had no binary line.
+    pub fn installed_path(&self) -> Option<PathBuf> {
+        self.installed.lock().ok()?.clone()
     }
 
     pub fn drain(&self) -> Vec<UpdateEvent> {
@@ -253,7 +355,10 @@ impl SelfInstall {
         for ev in events {
             let _ = tx.send(*ev);
         }
-        Self { rx }
+        Self {
+            rx,
+            installed: std::sync::Arc::new(std::sync::Mutex::new(None)),
+        }
     }
 }
 
@@ -298,6 +403,47 @@ mod tests {
     }
 
     #[test]
+    fn manifest_name_check_is_section_aware() {
+        let croft = "[package]\nname = \"croft-software\"\nversion = \"0.1.0\"\n\n[[bin]]\nname = \"croft\"\n";
+        assert!(manifest_declares_package(croft, "croft-software"));
+        assert!(
+            !manifest_declares_package(croft, "croft"),
+            "a [[bin]] name must not vouch for the package"
+        );
+        assert!(
+            manifest_declares_package("[package]\nname=\"croft-software\"\n", "croft-software"),
+            "TOML does not require spaces around ="
+        );
+        assert!(
+            manifest_declares_package("[package]\nname = 'croft-software'\n", "croft-software"),
+            "single quotes are legal TOML"
+        );
+        assert!(
+            !manifest_declares_package(
+                "[package]\nname = \"other\"\n\n[dependencies.x]\nname = \"croft-software\"\n",
+                "croft-software"
+            ),
+            "a name in another table must not vouch for the package"
+        );
+        assert!(!manifest_declares_package("", "croft-software"));
+    }
+
+    #[test]
+    fn installed_binary_is_parsed_from_cargo_output_not_progress_lines() {
+        let output = "  Installing croft-software v0.1.758 (/repo)\n\
+                         Compiling croft-software v0.1.758\n\
+                        Finished `release` profile [optimized] target(s) in 57s\n\
+                       Replacing /custom/root/bin/croft\n\
+                        Replaced package `croft-software v0.1.758` with `croft-software v0.1.758`\n";
+        assert_eq!(
+            parse_installed_binary(output),
+            Some(PathBuf::from("/custom/root/bin/croft")),
+            "the binary line, not the package-progress line, names the destination"
+        );
+        assert_eq!(parse_installed_binary("nothing relevant"), None);
+    }
+
+    #[test]
     fn install_bin_follows_cargo_root_resolution() {
         let bin = |p: Option<&str>| p.map(std::ffi::OsString::from);
         assert_eq!(
@@ -320,6 +466,12 @@ mod tests {
             "default is ~/.cargo/bin"
         );
         assert_eq!(install_bin_from(None, None, None), None);
+        assert_eq!(
+            install_bin_from(bin(Some("")), bin(Some("")), bin(Some("/home/u"))),
+            Some(PathBuf::from("/home/u/.cargo/bin/croft")),
+            "empty env vars are unset (cargo's rule) - honoring one would \
+             yield a relative path resolved against the edited workspace"
+        );
     }
 
     // The baked manifest path can outlive the tree it pointed at; if some

--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -148,6 +148,32 @@ fn git_in(dir: &str, args: &[&str]) -> Option<String> {
     Some(String::from_utf8(out.stdout).ok()?.trim().to_string())
 }
 
+/// The `bin/croft` a local `cargo install` will actually write, mirroring
+/// cargo's own root resolution: `CARGO_INSTALL_ROOT`, then `CARGO_HOME`,
+/// then `~/.cargo`. (An `install.root` from cargo config files is not read
+/// here - best effort; #245.) The re-exec after a self-install must follow
+/// the same resolution, or a custom root leaves it relaunching a stale
+/// `~/.cargo/bin/croft` forever.
+pub fn cargo_install_bin() -> Option<PathBuf> {
+    install_bin_from(
+        std::env::var_os("CARGO_INSTALL_ROOT"),
+        std::env::var_os("CARGO_HOME"),
+        std::env::var_os("HOME"),
+    )
+}
+
+fn install_bin_from(
+    install_root: Option<std::ffi::OsString>,
+    cargo_home: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+) -> Option<PathBuf> {
+    let root = install_root
+        .or(cargo_home)
+        .map(PathBuf::from)
+        .or_else(|| home.map(|h| PathBuf::from(h).join(".cargo")))?;
+    Some(root.join("bin").join("croft"))
+}
+
 /// A background `cargo install --path <repo> --locked` reinstalling the
 /// local croft, reported through the same [`UpdateEvent`] lifecycle the
 /// remote watcher uses so the app consumes both with one state machine:
@@ -164,6 +190,29 @@ impl SelfInstall {
         let (tx, rx) = channel();
         std::thread::spawn(move || {
             let _ = tx.send(UpdateEvent::InProgress);
+            // The manifest dir is a path baked at build time; nothing stops
+            // the filesystem from hosting a different crate there by now.
+            // `cargo install` would happily build that foreign package, exit
+            // 0, and the app would announce a croft update that never
+            // happened - so refuse unless the manifest still declares THIS
+            // package (#245).
+            let expected = concat!("name = \"", env!("CARGO_PKG_NAME"), "\"");
+            let manifest_ok =
+                std::fs::read_to_string(std::path::Path::new(&manifest_dir).join("Cargo.toml"))
+                    .is_ok_and(|s| s.lines().any(|l| l.trim() == expected));
+            if !manifest_ok {
+                let _ = std::fs::write(
+                    &log_path,
+                    format!(
+                        "refusing to install: {manifest_dir}/Cargo.toml no longer declares \
+                         package `{}` - the source tree this croft was built from has been \
+                         replaced",
+                        env!("CARGO_PKG_NAME")
+                    ),
+                );
+                let _ = tx.send(UpdateEvent::Failed);
+                return;
+            }
             let result = std::process::Command::new("cargo")
                 .args(["install", "--path", &manifest_dir, "--locked"])
                 .output();
@@ -246,6 +295,67 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn install_bin_follows_cargo_root_resolution() {
+        let bin = |p: Option<&str>| p.map(std::ffi::OsString::from);
+        assert_eq!(
+            install_bin_from(
+                bin(Some("/custom/root")),
+                bin(Some("/ch")),
+                bin(Some("/home/u"))
+            ),
+            Some(PathBuf::from("/custom/root/bin/croft")),
+            "CARGO_INSTALL_ROOT wins over everything"
+        );
+        assert_eq!(
+            install_bin_from(None, bin(Some("/ch")), bin(Some("/home/u"))),
+            Some(PathBuf::from("/ch/bin/croft")),
+            "CARGO_HOME beats the HOME default"
+        );
+        assert_eq!(
+            install_bin_from(None, None, bin(Some("/home/u"))),
+            Some(PathBuf::from("/home/u/.cargo/bin/croft")),
+            "default is ~/.cargo/bin"
+        );
+        assert_eq!(install_bin_from(None, None, None), None);
+    }
+
+    // The baked manifest path can outlive the tree it pointed at; if some
+    // OTHER crate lives there now, the install must refuse rather than
+    // build the foreign package and report a croft update that never
+    // happened.
+    #[test]
+    fn self_install_refuses_a_foreign_package_at_the_baked_path() {
+        let dir = scratch_dir("foreign-pkg");
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"definitely-not-croft\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let log = dir.join("install.log");
+        let install = SelfInstall::start(dir.to_string_lossy().into_owned(), log.clone());
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut events = Vec::new();
+        while std::time::Instant::now() < deadline {
+            events.extend(install.drain());
+            if events.contains(&UpdateEvent::Failed) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert_eq!(
+            events,
+            vec![UpdateEvent::InProgress, UpdateEvent::Failed],
+            "a foreign package must fail the install, not build it"
+        );
+        let log = std::fs::read_to_string(&log).unwrap();
+        assert!(
+            log.contains("refusing to install"),
+            "the log must say WHY nothing was built: {log:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn wait_for(watch: &UpdateWatch, want: UpdateEvent) -> bool {


### PR DESCRIPTION
Fixes the four confirmed findings from the adversarial review in #245 — all in the drift/reinstall flow shipped in #243/#244.

## Custom install roots no longer strand the re-exec
`SelfInstall` runs `cargo install` with inherited env, so `CARGO_INSTALL_ROOT`/`CARGO_HOME` send the fresh binary to a custom root — but the re-exec hard-preferred `~/.cargo/bin/croft` whenever it existed, relaunching a stale binary in a loop (or exec'ing a replaced inode and dying). `reexec_binary_path` now takes which flow produced the update: a local self-install follows cargo's root resolution (`CARGO_INSTALL_ROOT` → `CARGO_HOME` → `~/.cargo`, via the new `cargo_install_bin()`); the remote flow keeps the literal path its installer rsyncs to.

## F9 double-spawn latch
`update_status` only leaves `Idle` when the `InProgress` event is drained — once per outer loop, *before* the input drain — so two F9s in one crossterm batch both passed the arm and spawned two concurrent `cargo install`s racing cargo's locks. `f9_update_armed` now also requires `self_install.is_none()`, and the key handler routes through it.

## Foreign package at the baked path is refused
Nothing verified the tree at the baked `CARGO_MANIFEST_DIR` was still this crate: a different repo there would be built, exit 0, and be announced as "Update ready" while `croft` was never touched. `SelfInstall` now checks the manifest still declares this package before running cargo, failing with an explanatory log otherwise.

## Per-process install log
Two drift-armed instances wrote the same `self-install.log`, last-writer-wins, destroying the diagnostics the failure message points at. The log is now `self-install-<pid>.log` and the status message prints the actual path.

Tests: cargo-root resolution order (pure), foreign-package refusal (real `SelfInstall` against a scratch dir), the F9 latch, and the failure message's per-pid path.

Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate self-install attempts when an installation is already starting or in progress.
  * Repeated F9 presses during installation are now ignored instead of triggering unrelated actions.
  * Re-execution now prioritizes the exact newly installed application.
  * Install failures now show the correct, process-specific log location.
  * Self-install safely refuses to proceed if the bundled package is no longer valid.

* **Maintenance**
  * Old self-install logs are automatically cleaned up after one week.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->