### PR TITLE
fix(self-install): resolve cargo by absolute path so GUI launches can rebuild

### DIFF
--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -247,7 +247,13 @@ fn prune_old_install_logs(dir: &std::path::Path, keep: &std::path::Path) {
 /// `PATH`, where spawning a bare `cargo` fails with "No such file or
 /// directory" even though a terminal launch finds it.
 fn self_install_command(manifest_dir: &str) -> std::process::Command {
-    let mut cmd = std::process::Command::new(crate::widgets::dependencies::cargo_binary());
+    self_install_command_with(crate::widgets::dependencies::cargo_binary(), manifest_dir)
+}
+
+/// Split from [`self_install_command`] so tests can inject a deterministic
+/// cargo path instead of comparing against the resolver's own answer.
+fn self_install_command_with(cargo: PathBuf, manifest_dir: &str) -> std::process::Command {
+    let mut cmd = std::process::Command::new(cargo);
     cmd.args(["install", "--path", manifest_dir, "--locked"]);
     cmd
 }
@@ -430,17 +436,29 @@ mod tests {
     }
 
     #[test]
-    fn self_install_resolves_cargo_by_absolute_path() {
+    fn self_install_spawns_the_injected_cargo_verbatim() {
+        let cmd = self_install_command_with(PathBuf::from("/fake/toolchain/cargo"), "/some/repo");
+        assert_eq!(
+            PathBuf::from(cmd.get_program()),
+            PathBuf::from("/fake/toolchain/cargo")
+        );
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_os_string()).collect();
+        assert_eq!(args, ["install", "--path", "/some/repo", "--locked"]);
+    }
+
+    #[test]
+    fn self_install_wires_in_the_resolved_cargo() {
+        // A GUI-launched croft inherits launchd's stripped PATH, so the
+        // self-install must go through the dependencies widget's resolver
+        // instead of spawning a bare `cargo`. The resolver itself may fall
+        // back to a bare `cargo` on a machine with no toolchain at all;
+        // this test proves the wiring, the one above proves the command
+        // uses whatever path it is given.
         let cmd = self_install_command("/some/repo");
         assert_eq!(
             PathBuf::from(cmd.get_program()),
             crate::widgets::dependencies::cargo_binary(),
-            "a GUI-launched croft inherits launchd's stripped PATH, so the \
-             self-install must resolve cargo the same way the dependencies \
-             widget does instead of spawning a bare `cargo`"
         );
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_os_string()).collect();
-        assert_eq!(args, ["install", "--path", "/some/repo", "--locked"]);
     }
 
     #[test]

--- a/src/update_watch.rs
+++ b/src/update_watch.rs
@@ -242,6 +242,16 @@ fn prune_old_install_logs(dir: &std::path::Path, keep: &std::path::Path) {
     }
 }
 
+/// The `cargo install` invocation for the self-install, with cargo resolved
+/// to an absolute path: a GUI-launched croft inherits launchd's stripped
+/// `PATH`, where spawning a bare `cargo` fails with "No such file or
+/// directory" even though a terminal launch finds it.
+fn self_install_command(manifest_dir: &str) -> std::process::Command {
+    let mut cmd = std::process::Command::new(crate::widgets::dependencies::cargo_binary());
+    cmd.args(["install", "--path", manifest_dir, "--locked"]);
+    cmd
+}
+
 /// A background `cargo install --path <repo> --locked` reinstalling the
 /// local croft, reported through the same [`UpdateEvent`] lifecycle the
 /// remote watcher uses so the app consumes both with one state machine:
@@ -292,9 +302,7 @@ impl SelfInstall {
                 let _ = tx.send(UpdateEvent::Failed);
                 return;
             }
-            let result = std::process::Command::new("cargo")
-                .args(["install", "--path", &manifest_dir, "--locked"])
-                .output();
+            let result = self_install_command(&manifest_dir).output();
             let event = match result {
                 Ok(out) => {
                     let mut log = out.stdout;
@@ -419,6 +427,20 @@ mod tests {
             "package/name lines inside a multiline string must not vouch for the package"
         );
         assert!(manifest_declares_package(multiline_trap, "foreign"));
+    }
+
+    #[test]
+    fn self_install_resolves_cargo_by_absolute_path() {
+        let cmd = self_install_command("/some/repo");
+        assert_eq!(
+            PathBuf::from(cmd.get_program()),
+            crate::widgets::dependencies::cargo_binary(),
+            "a GUI-launched croft inherits launchd's stripped PATH, so the \
+             self-install must resolve cargo the same way the dependencies \
+             widget does instead of spawning a bare `cargo`"
+        );
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_os_string()).collect();
+        assert_eq!(args, ["install", "--path", "/some/repo", "--locked"]);
     }
 
     #[test]


### PR DESCRIPTION
The self-install rebuild spawned a bare `cargo`, which fails with "failed to run cargo: No such file or directory" when croft was launched from a GUI context that inherits launchd's stripped PATH (no `~/.cargo/bin`). Resolve cargo through the existing `cargo_binary()` helper the dependencies widget already uses, via a new `self_install_command()` builder with a unit test asserting the resolved program and args.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-installation reliability by using the resolved Cargo executable directly.
  * Ensured self-installation consistently applies locked dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->