### PR TITLE
fix(editor): make Close All close every split group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.758"
+version = "0.1.759"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.758"
+version = "0.1.759"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15194,15 +15194,7 @@ impl App {
             }
             // Cmd+K W: close all editor tabs.
             KeyCode::Char(c) if plain && c.eq_ignore_ascii_case(&'w') => {
-                let removed = self.editor.close_all();
-                self.sync_open_file_poll_mtime();
-                self.status = if removed == 1 {
-                    String::from("Closed 1 tab")
-                } else {
-                    format!("Closed {removed} tabs")
-                };
-                self.poke_cursor();
-                self.collapse_split_if_empty();
+                self.close_all_tabs();
                 true
             }
             // Cmd+K U: close all saved (non-dirty) editor tabs.
@@ -33136,17 +33128,7 @@ impl App {
                     self.poke_cursor();
                 }
             }
-            MenuAction::CloseAllTabs => {
-                let removed = self.editor.close_all();
-                self.sync_open_file_poll_mtime();
-                self.status = if removed == 1 {
-                    String::from("Closed 1 tab")
-                } else {
-                    format!("Closed {removed} tabs")
-                };
-                self.poke_cursor();
-                self.collapse_split_if_empty();
-            }
+            MenuAction::CloseAllTabs => self.close_all_tabs(),
             MenuAction::CloseSavedTabs => self.close_saved_tabs(),
             MenuAction::KeepTabOpen(idx) => {
                 if self.editor.keep_open(idx) {
@@ -33433,6 +33415,34 @@ impl App {
     /// Close every saved (non-dirty) editor tab, keeping any with unsaved
     /// changes. Shared by the tab context menu and the `Cmd+K U` chord so both
     /// surfaces produce the same status line and split-collapse behavior.
+    /// Cmd+K W / tab context "Close All": close every tab in EVERY editor
+    /// group, not just the focused one, collapsing any split back to a single
+    /// blank pane. A side-by-side layout (e.g. `cgr duplicates` diffs) would
+    /// otherwise only empty the clicked group and look like a single close
+    /// once the blank group collapsed away.
+    fn close_all_tabs(&mut self) {
+        let mut removed = self.editor.close_all();
+        if self.editor_layout.is_split() {
+            removed += self
+                .editor_layout
+                .inactive_groups()
+                .iter()
+                .map(|g| g.editors.len())
+                .sum::<usize>();
+            self.editor_layout = editor_layout::EditorLayout::single();
+            self.editor_seams.clear();
+            self.disable_editor_image(1);
+            self.sync_focus_flags();
+        }
+        self.sync_open_file_poll_mtime();
+        self.status = if removed == 1 {
+            String::from("Closed 1 tab")
+        } else {
+            format!("Closed {removed} tabs")
+        };
+        self.poke_cursor();
+    }
+
     fn close_saved_tabs(&mut self) {
         let removed = self.editor.close_saved();
         if removed == 0 {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8301,6 +8301,39 @@ fn close_others_records_the_dropped_tabs_for_reopen() {
     assert_eq!(app.editor.path.as_deref(), Some(a.as_path()));
 }
 
+/// Tab context "Close All" must close the tabs in EVERY split group, not
+/// just the clicked one. With files open side by side (e.g. `cgr
+/// duplicates`), it used to empty only the focused group, whose blank pane
+/// then collapsed away and promoted the other group — so it looked like a
+/// single tab closed.
+#[test]
+fn close_all_closes_every_split_group() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a.rs");
+    let b = tmp.path().join("b.rs");
+    for f in [&a, &b] {
+        std::fs::write(f, "x\n").unwrap();
+    }
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open_pinned(&a).unwrap();
+    app.split_editor(); // right group (focused) duplicates a.rs
+    app.editor.open_pinned(&b).unwrap();
+    assert!(app.editor_layout.is_split(), "two groups before Close All");
+    let total: usize = std::iter::once(&app.editor)
+        .chain(app.editor_layout.inactive_groups())
+        .map(|g| g.editors.len())
+        .sum();
+    assert!(total >= 2, "tabs are spread over both groups");
+    app.dispatch_menu_action(MenuAction::CloseAllTabs, tmp.path().to_path_buf());
+    assert!(
+        !app.editor_layout.is_split(),
+        "Close All collapses the split back to a single group"
+    );
+    assert_eq!(app.editor.tab_count(), 1, "a single blank pane remains");
+    assert_eq!(app.editor.path, None, "no file stays open in any group");
+    assert_eq!(app.status, format!("Closed {total} tabs"));
+}
+
 #[test]
 fn cmd_k_arms_leader_then_unmatched_second_key_clears_it() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "Croft Light: the selected activity-bar icon no longer disappears. The icons are baked as images with a fixed tint, so on a light bar the selected one was painted white on white; the whole icon family now takes its ink from the theme, matching VS Code Light Modern.",
+    summary: "Close All now means all: the tab context menu's Close All (and Cmd+K W) closes the tabs in every split group and collapses the layout to a single pane. It used to empty only the clicked group, which then collapsed away — looking like a single tab closed.",
 }];


### PR DESCRIPTION
## Problem
With files open side by side (e.g. from `cgr duplicates`), right-clicking a tab and picking **Close All** only closed the tabs in the clicked group. The now-blank group then collapsed away and promoted the surviving group, so it looked like a single tab closed. The `⌘K W` chord had the same bug.

## Fix
Extract a shared `App::close_all_tabs` used by both the tab context menu and the `⌘K W` chord. It closes the tabs in **every** editor group, counts them all for the status line, and collapses any split back to a single blank pane (clearing seams, evicting the right image slot, and re-syncing focus flags — same cleanup as `collapse_split_if_empty`).

## Test
`close_all_closes_every_split_group`: opens a file, splits, opens a second file in the right group, dispatches `MenuAction::CloseAllTabs`, and asserts the split collapses, a single blank pane remains, and the status counts tabs from both groups.

Note: `app::tests::repositories_overview_lists_every_folder_and_a_pin_overrides_the_follow` fails on macOS on clean `main` too (/var vs /private/var canonicalization) — unrelated.