### PR TITLE
ci: add SonarQube Cloud analysis (free plan)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -43,13 +43,15 @@ jobs:
         with:
           key: sonarcloud
       - name: Generate the Clippy report
+        if: env.SONAR_TOKEN != ''
         # No `-D warnings` here: the `clippy + tests` job in ci.yml is the
         # gate. This run only produces the JSON report SonarQube imports, so
         # warnings must land in the report, not kill the job.
-        run: cargo clippy --all-targets --message-format=json > clippy-report.json
-        if: env.SONAR_TOKEN != ''
+        #
+        # `|| true`: a compile error is already reported by ci.yml's gate job;
+        # failing here too would only add a second red X and skip the import
+        # of whatever diagnostics Clippy did emit before dying.
+        run: cargo clippy --all-targets --message-format=json > clippy-report.json || true
       - name: SonarQube Cloud scan
         if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@v8
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,55 @@
+name: SonarQube Cloud
+
+# Static analysis on sonarcloud.io (free plan for public repos, #284).
+# Project binding lives in sonar-project.properties; the analysis is CI-based
+# (Rust needs a real `cargo clippy` run, which SonarQube Cloud's automatic
+# analysis cannot do), so Automatic Analysis must stay OFF in the SonarCloud
+# project settings or every scan fails with a conflict.
+#
+# Every step is gated on SONAR_TOKEN so the job is a green no-op on fork PRs
+# (secrets are withheld there) and on checkouts where the secret has not been
+# configured yet - analysis coverage degrades, CI does not break.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  sonarcloud:
+    name: SonarQube Cloud analysis
+    runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      - name: Skip without a token
+        if: env.SONAR_TOKEN == ''
+        run: echo "::notice::SONAR_TOKEN is not available (fork PR, or the secret is not configured); skipping SonarQube Cloud analysis."
+      - uses: actions/checkout@v4
+        if: env.SONAR_TOKEN != ''
+        with:
+          # Full history: SonarQube Cloud needs blame data to attribute issues
+          # and to tell new code from old on PRs.
+          fetch-depth: 0
+      # rust-toolchain.toml is the single source of truth; `rustup show`
+      # installs exactly the pinned channel and its components (clippy
+      # included). The scanner's own Clippy execution is disabled in
+      # sonar-project.properties precisely so this pinned run is the only one.
+      - name: Install the pinned toolchain
+        if: env.SONAR_TOKEN != ''
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2
+        if: env.SONAR_TOKEN != ''
+        with:
+          key: sonarcloud
+      - name: Generate the Clippy report
+        # No `-D warnings` here: the `clippy + tests` job in ci.yml is the
+        # gate. This run only produces the JSON report SonarQube imports, so
+        # warnings must land in the report, not kill the job.
+        run: cargo clippy --all-targets --message-format=json > clippy-report.json
+        if: env.SONAR_TOKEN != ''
+      - name: SonarQube Cloud scan
+        if: env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@v8
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ preview*.svg
 # Local secrets (Codeberg token, etc.) — never commit
 .env
 .env.*
+
+# SonarQube Cloud scan artifacts (see .github/workflows/sonarcloud.yml)
+/clippy-report.json
+/.scannerwork/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,14 @@ sonar.organization=vitali87
 sonar.projectName=croft
 
 sonar.sources=src,build.rs
-sonar.tests=tests
+# src/app/tests.rs (29k lines) and tests/ are compiled out of release builds
+# (see ci.yml's release-hygiene filter): they are tests, not shipped source.
+# Left under sonar.sources they would dominate every duplication/complexity
+# metric and fail quality gates on test-table churn. Inline #[cfg(test)]
+# modules cannot be split out by path and stay in sources - accepted.
+sonar.tests=tests,src/app/tests.rs
+# Fixture data, not source.
+sonar.exclusions=src/mcp/testdata/**
 sonar.sourceEncoding=UTF-8
 
 # CI generates the Clippy report itself with the PINNED toolchain (see

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+# SonarQube Cloud project binding (free plan, public repo). The keys must
+# match what sonarcloud.io generated when the repository was imported:
+# organization = the GitHub login, projectKey = <org>_<repo>.
+sonar.projectKey=vitali87_croft
+sonar.organization=vitali87
+sonar.projectName=croft
+
+sonar.sources=src,build.rs
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+
+# CI generates the Clippy report itself with the PINNED toolchain (see
+# .github/workflows/sonarcloud.yml) and hands it over here. Left enabled, the
+# scanner would run `cargo clippy` a second time with whatever toolchain it
+# finds - slower, unpinned, and every issue would show up twice.
+sonar.rust.clippy.enabled=false
+sonar.rust.clippy.reportPaths=clippy-report.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,8 +12,10 @@ sonar.sources=src,build.rs
 # metric and fail quality gates on test-table churn. Inline #[cfg(test)]
 # modules cannot be split out by path and stay in sources - accepted.
 sonar.tests=tests,src/app/tests.rs
-# Fixture data, not source.
-sonar.exclusions=src/mcp/testdata/**
+# sonar.sources=src would otherwise ALSO claim src/app/tests.rs, and a file
+# in both scopes fails the scan outright - it has to be subtracted here.
+# Fixture data is not source either.
+sonar.exclusions=src/app/tests.rs,src/mcp/testdata/**
 sonar.sourceEncoding=UTF-8
 
 # CI generates the Clippy report itself with the PINNED toolchain (see


### PR DESCRIPTION
Closes #284.

## What

- **`.github/workflows/sonarcloud.yml`** — runs on every PR and push to `main`: installs the pinned toolchain, generates a Clippy JSON report (`cargo clippy --all-targets --message-format=json`), and uploads it via `SonarSource/sonarqube-scan-action@v8`.
- **`sonar-project.properties`** — project binding (`vitali87` / `vitali87_croft`) plus `sonar.rust.clippy.enabled=false` so the scanner imports our pinned-toolchain report instead of running its own unpinned Clippy (which would be slower and duplicate every issue).

No `-D warnings` in the Sonar clippy run — the existing `clippy + tests` job stays the gate; this run only feeds the report.

Every step is gated on `SONAR_TOKEN`, so the job is a **green no-op** on fork PRs (secrets are withheld) and until the one-time setup below is done — CI never breaks on a missing token.

## One-time setup (needs the repo owner)

1. Sign in at [sonarcloud.io](https://sonarcloud.io) with GitHub (free plan covers public repos) and import `vitali87/croft`. If the generated keys differ from `vitali87` / `vitali87_croft`, fix `sonar-project.properties` to match.
2. In the SonarCloud project: **Administration → Analysis Method → turn Automatic Analysis OFF** (CI-based analysis conflicts with it).
3. Create a token (My Account → Security) and add it as the `SONAR_TOKEN` repository secret in GitHub.

Until step 3, the job logs a notice and passes.

## Scope

CI-only (`.github/` + `sonar-project.properties`): nothing ships, so no version bump / release-notes change per the #285 gate rules. Coverage import (`cargo llvm-cov` → lcov) is possible later, but croft's suite spawns real PTYs/zsh/poppler, so that's a deliberate follow-up rather than a freebie here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated SonarQube Cloud code-quality scanning for changes to the main branch and pull requests.
  * Configured Rust analysis, test paths, fixture exclusions, and Clippy report integration.
  * Added safeguards to avoid scan failures when credentials are unavailable.
  * Excluded generated analysis artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->