### PR TITLE
fix(workspace): relativise folders reached through a symlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.764"
+version = "0.1.765"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.764"
+version = "0.1.765"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27896,6 +27896,16 @@ impl App {
         if let Some(path) = path {
             let add = self.zoxide_add_folder;
             self.close_zoxide_jump();
+            // A zoxide row is a bare line from its database, so it can name a
+            // directory in a spelling nothing else in croft uses (a symlinked
+            // `/var/…` for `/private/var/…`). Normalise it here, where the
+            // untrusted path enters, so both branches agree: the folder store
+            // keys on `roots.primary().display()`, and two spellings of one
+            // directory would file and restore under different keys.
+            // `add_workspace_folder` canonicalises internally; the re-root
+            // path must not, since its callers rely on the root being exactly
+            // what they passed.
+            let path = path.canonicalize().unwrap_or(path);
             if add {
                 self.add_workspace_folder(path);
             } else {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -22487,10 +22487,22 @@ fn repositories_overview_lists_every_folder_and_a_pin_overrides_the_follow() {
 
     // Anchor the focus in folder A first, then pin B: the pin wins for
     // as long as the focus stays inside A (further A files included).
-    let a_canon = a.canonicalize().unwrap();
+    //
+    // Compare against the root in the form the workspace holds it, not a
+    // canonicalised one: `App::new` stores the primary root verbatim, and
+    // on macOS a tempdir arrives as `/var/…` for a `/private/var/…`
+    // directory. The app is self-consistent — the follow root derives from
+    // the same workspace roots — so canonicalising only this side compares
+    // two spellings of one path and fails everywhere `/var` is a symlink.
+    let a_root = app
+        .roots
+        .iter()
+        .find(|r| r.ends_with("repa"))
+        .expect("folder A is in the workspace")
+        .to_path_buf();
     app.editor.open_pinned(&a.join("f.txt")).unwrap();
     let _ = app.drain_git_responses();
-    assert_eq!(app.active_scm_root, a_canon);
+    assert_eq!(app.active_scm_root, a_root);
     app.scm_pin = Some(b_canon.clone());
     let _ = app.drain_git_responses();
     assert_eq!(
@@ -22510,7 +22522,7 @@ fn repositories_overview_lists_every_folder_and_a_pin_overrides_the_follow() {
     app.editor.open_pinned(&a.join("f.txt")).unwrap();
     let _ = app.drain_git_responses();
     assert_eq!(
-        app.active_scm_root, a_canon,
+        app.active_scm_root, a_root,
         "after release the panel follows the focus again"
     );
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -16621,6 +16621,54 @@ fn zoxide_jump_popup_anchors_over_the_explorer_column_not_centered() {
 }
 
 #[test]
+fn a_zoxide_row_re_roots_under_the_same_key_as_the_add_branch() {
+    // A zoxide row is a bare line from its database, so it can name a
+    // directory in a spelling nothing else in croft uses (a symlinked
+    // `/var/…` for `/private/var/…`). Both branches of the jump must land on
+    // the same spelling: the folder store keys on
+    // `roots.primary().display()`, so two spellings of one directory would
+    // file and restore under different keys.
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().canonicalize().unwrap().join("real");
+    std::fs::create_dir(&real).unwrap();
+    let link = tmp.path().canonicalize().unwrap().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    // Jump mode: re-root onto the symlinked spelling.
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    let mut jump = crate::widgets::zoxide_jump::ZoxideJump::new();
+    jump.set_results(Some(vec![link.clone()]));
+    app.zoxide_jump = Some(jump);
+    app.zoxide_add_folder = false;
+    app.apply_zoxide_jump_selection();
+    let jumped = app.roots.primary().to_path_buf();
+
+    // Add mode: the same row through the other branch.
+    let mut app2 = App::new(tmp.path().to_path_buf()).unwrap();
+    let mut jump2 = crate::widgets::zoxide_jump::ZoxideJump::new();
+    jump2.set_results(Some(vec![link.clone()]));
+    app2.zoxide_jump = Some(jump2);
+    app2.zoxide_add_folder = true;
+    app2.apply_zoxide_jump_selection();
+    let added = app2
+        .roots
+        .iter()
+        .find(|r| r.ends_with("real") || r.ends_with("link"))
+        .expect("the folder was added")
+        .to_path_buf();
+
+    assert_eq!(
+        jumped, added,
+        "both branches of one gesture must store the same spelling"
+    );
+    assert_eq!(
+        jumped,
+        link.canonicalize().unwrap(),
+        "and it is the canonical one, so the folder store keys agree"
+    );
+}
+
+#[test]
 fn cmd_z_in_explorer_opens_the_zoxide_jump_popup() {
     let tmp = tempfile::tempdir().unwrap();
     let mut app = App::new(tmp.path().to_path_buf()).unwrap();

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "Save Workspace As writes portable files again: a folder reached through a symlink (macOS hands croft /var for /private/var, and any symlinked home does the same) was written as an absolute path instead of a relative one, so the workspace file broke as soon as it moved.",
+    summary: "Save Workspace As writes portable files again: a folder reached through a symlink (macOS hands croft /var for /private/var, and any symlinked home does the same) was written as an absolute path instead of a relative one, so the file stopped travelling — it kept working where it was written but not on another machine, another checkout, or a different layout.",
 }];

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Feature,
-    summary: "Document links: Ctrl+click a URL, import, or path that the language server marks as a link and croft follows it — files open in the editor, web links in your browser. Non-web schemes are refused rather than handed to the system opener.",
+    kind: NoteKind::Fix,
+    summary: "Save Workspace As writes portable files again: a folder reached through a symlink (macOS hands croft /var for /private/var, and any symlinked home does the same) was written as an absolute path instead of a relative one, so the workspace file broke as soon as it moved.",
 }];

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -360,19 +360,9 @@ fn strip_jsonc(src: &str) -> String {
 pub fn write_workspace_file(path: &Path, folders: &[PathBuf]) -> Result<(), String> {
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let base_canon = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
-    // Both sides must be canonical or neither: `relative_or_absolute` walks
-    // components, so a base under `/private/var` and a folder under `/var`
-    // (the same directory through macOS's symlink) share only the root and
-    // fall back to an absolute path — which is exactly the non-portable
-    // file this function exists to avoid. The primary workspace root
-    // reaches here uncanonicalised, so this is reachable from Save
-    // Workspace As whenever croft was opened at a symlinked path.
     let entries: Vec<serde_json::Value> = folders
         .iter()
-        .map(|f| {
-            let f_canon = f.canonicalize().unwrap_or_else(|_| f.clone());
-            serde_json::json!({ "path": relative_or_absolute(&base_canon, &f_canon) })
-        })
+        .map(|f| serde_json::json!({ "path": relative_to_base(base, &base_canon, f) }))
         .collect();
     let doc = serde_json::json!({ "folders": entries });
     let json = serde_json::to_string_pretty(&doc).map_err(|e| e.to_string())?;
@@ -380,6 +370,35 @@ pub fn write_workspace_file(path: &Path, folders: &[PathBuf]) -> Result<(), Stri
         std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
     }
     std::fs::write(path, json).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+/// One folder's entry for the workspace file: relative to the file's own
+/// directory when the two really are related, absolute when they are not.
+///
+/// Tries the caller's spelling first, so a folder the user deliberately
+/// added through a symlink (`~/work` → `~/projects/alpha`) is persisted as
+/// they named it — this file is shareable, and resolving the link would
+/// bake in a target the user never typed and cannot recover from the file.
+/// Only when that spelling shares no useful prefix does it retry through
+/// canonical forms, which is what rescues the case where the two name one
+/// directory differently (macOS hands croft `/var/…` for `/private/var/…`).
+/// A folder that does not exist on disk cannot be canonicalised and simply
+/// keeps the first answer.
+fn relative_to_base(base: &Path, base_canon: &Path, target: &Path) -> String {
+    let direct = relative_or_absolute(base, target);
+    if !Path::new(&direct).is_absolute() {
+        return direct;
+    }
+    let Ok(target_canon) = target.canonicalize() else {
+        return direct;
+    };
+    let via_canon = relative_or_absolute(base_canon, &target_canon);
+    if Path::new(&via_canon).is_absolute() {
+        // Genuinely unrelated (different mount points): keep the caller's
+        // spelling rather than swapping in a resolved one for no gain.
+        return direct;
+    }
+    via_canon
 }
 
 /// `target` relative to `base` with `..` steps where they help (the
@@ -469,6 +488,49 @@ mod tests {
         assert!(ws.remove(Path::new("/w/b")), "a secondary root removes");
         assert!(!ws.is_multi());
         assert_eq!(ws.primary(), Path::new("/w/a"));
+    }
+
+    /// A symlink the USER chose is theirs to keep. The file is shareable,
+    /// so resolving `~/work` into `~/projects/alpha` would bake in a target
+    /// they never typed and cannot recover from the file. Only a spelling
+    /// that would otherwise go absolute gets retried through canonical
+    /// forms.
+    #[test]
+    fn a_deliberate_folder_symlink_is_written_as_the_user_named_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().canonicalize().unwrap();
+        let alpha = real.join("alpha");
+        std::fs::create_dir(&alpha).unwrap();
+        let work = real.join("work");
+        std::os::unix::fs::symlink(&alpha, &work).unwrap();
+
+        let file = real.join("proj.code-workspace");
+        write_workspace_file(&file, std::slice::from_ref(&work)).unwrap();
+        let raw = std::fs::read_to_string(&file).unwrap();
+        assert!(
+            raw.contains("\"work\""),
+            "the user's own spelling is persisted, not the link target: {raw}"
+        );
+        assert!(
+            !raw.contains("\"alpha\""),
+            "the symlink is not resolved away: {raw}"
+        );
+    }
+
+    /// A folder that is not on disk cannot be canonicalised. It must still
+    /// relativise off the caller's spelling rather than falling back to an
+    /// absolute path — the fix must not depend on the filesystem.
+    #[test]
+    fn a_missing_folder_still_relativises() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().canonicalize().unwrap();
+        let file = base.join("proj.code-workspace");
+        write_workspace_file(&file, &[base.join("ghost")]).unwrap();
+        let raw = std::fs::read_to_string(&file).unwrap();
+        assert!(
+            raw.contains("\"ghost\""),
+            "a folder that does not exist yet still writes relative: {raw}"
+        );
     }
 
     /// A folder reached through a symlink must still relativise. macOS

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -533,6 +533,42 @@ mod tests {
         );
     }
 
+    /// The written entry must RESOLVE to the right directory, not merely
+    /// look relative — including when the walk climbs out through a symlink
+    /// with `..`, where a lexical reading and the filesystem's disagree.
+    /// `parse_workspace_file` joins onto the file's own directory and then
+    /// canonicalises, so the OS resolves `..` after traversing the link,
+    /// which is what makes the round trip safe.
+    #[test]
+    fn a_relative_entry_resolves_through_a_symlinked_walk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let deep = root.join("deep");
+        std::fs::create_dir_all(deep.join("real")).unwrap();
+        // `shallow` reaches `deep/real` from a different depth.
+        let shallow = root.join("shallow");
+        std::os::unix::fs::symlink(deep.join("real"), &shallow).unwrap();
+        // Two same-named directories: the true target beside the link's
+        // resolved location, and a decoy beside the link itself. A lexical
+        // `..` would land on the decoy.
+        std::fs::create_dir(deep.join("sibling")).unwrap();
+        std::fs::write(deep.join("sibling").join("REAL"), "x").unwrap();
+        std::fs::create_dir(root.join("sibling")).unwrap();
+        std::fs::write(root.join("sibling").join("DECOY"), "x").unwrap();
+
+        let file = shallow.join("w.code-workspace");
+        write_workspace_file(&file, &[shallow.join("..").join("sibling")]).unwrap();
+        let parsed = parse_workspace_file(&file).unwrap();
+        assert!(
+            parsed[0].join("REAL").exists(),
+            "the entry resolves to the directory beside the link's TARGET: {parsed:?}"
+        );
+        assert!(
+            !parsed[0].join("DECOY").exists(),
+            "not the same-named one beside the link itself: {parsed:?}"
+        );
+    }
+
     /// A folder reached through a symlink must still relativise. macOS
     /// hands croft `/var/...` for a `/private/var/...` directory (and any
     /// symlinked home does the same), so canonicalising only the base left

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -360,9 +360,19 @@ fn strip_jsonc(src: &str) -> String {
 pub fn write_workspace_file(path: &Path, folders: &[PathBuf]) -> Result<(), String> {
     let base = path.parent().unwrap_or_else(|| Path::new("."));
     let base_canon = base.canonicalize().unwrap_or_else(|_| base.to_path_buf());
+    // Both sides must be canonical or neither: `relative_or_absolute` walks
+    // components, so a base under `/private/var` and a folder under `/var`
+    // (the same directory through macOS's symlink) share only the root and
+    // fall back to an absolute path — which is exactly the non-portable
+    // file this function exists to avoid. The primary workspace root
+    // reaches here uncanonicalised, so this is reachable from Save
+    // Workspace As whenever croft was opened at a symlinked path.
     let entries: Vec<serde_json::Value> = folders
         .iter()
-        .map(|f| serde_json::json!({ "path": relative_or_absolute(&base_canon, f) }))
+        .map(|f| {
+            let f_canon = f.canonicalize().unwrap_or_else(|_| f.clone());
+            serde_json::json!({ "path": relative_or_absolute(&base_canon, &f_canon) })
+        })
         .collect();
     let doc = serde_json::json!({ "folders": entries });
     let json = serde_json::to_string_pretty(&doc).map_err(|e| e.to_string())?;
@@ -459,6 +469,42 @@ mod tests {
         assert!(ws.remove(Path::new("/w/b")), "a secondary root removes");
         assert!(!ws.is_multi());
         assert_eq!(ws.primary(), Path::new("/w/a"));
+    }
+
+    /// A folder reached through a symlink must still relativise. macOS
+    /// hands croft `/var/...` for a `/private/var/...` directory (and any
+    /// symlinked home does the same), so canonicalising only the base left
+    /// the two sharing just the root component — `relative_or_absolute`
+    /// then wrote an ABSOLUTE path and the workspace file stopped being
+    /// portable, which is the one thing it promises.
+    #[test]
+    fn a_symlinked_folder_still_writes_relative() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let alpha = real.join("alpha");
+        std::fs::create_dir(&alpha).unwrap();
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // The caller passes the path it holds — through the symlink, and
+        // uncanonicalised, exactly as the primary workspace root arrives.
+        let file = link.join("proj.code-workspace");
+        write_workspace_file(&file, &[link.join("alpha")]).unwrap();
+        let raw = std::fs::read_to_string(&file).unwrap();
+        assert!(
+            raw.contains("\"alpha\""),
+            "a symlinked folder relativises like any other: {raw}"
+        );
+        assert!(
+            !raw.contains("/alpha\""),
+            "and is not written absolute: {raw}"
+        );
+        assert_eq!(
+            parse_workspace_file(&file).unwrap(),
+            vec![alpha.canonicalize().unwrap()],
+            "and round-trips back to the real directory"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`write_workspace_file` relativised each folder against a **canonicalised** base while passing the folder path through as given. When a symlink makes those disagree — macOS hands croft `/var/…` for a `/private/var/…` directory, and any symlinked home does the same — the two share only the root component, `relative_or_absolute`'s `common <= 1` guard trips, and every folder is written as an **absolute** path.

That silently breaks the one thing the format promises: a workspace file that survives being moved with its folders.

## How it is reachable

**Not** from a CLI launch — `cli.rs:781` canonicalises unconditionally before `App::new`, so an earlier framing of this PR (that any symlinked launch path triggered it) was wrong and has been removed.

The real trigger is a **zoxide jump**. `apply_zoxide_jump_selection` branches on one path: the add branch calls `add_workspace_folder`, which canonicalises internally; the jump branch calls `change_workspace_root`, which does not. Zoxide rows are bare lines from its database (`parse_query_output` is a plain `PathBuf::from` per line), so a jump could install a primary root spelled differently from every other entry point.

That has a second consequence beyond this file: `save_workspace_folders` / `restore_workspace_folders` key on `roots.primary().display().to_string()`, so the two spellings file and restore under **different keys for one directory**.

## The fix

**`relative_to_base(base, base_canon, target)`** — tries the caller's spelling first and only retries through canonical forms when that would go absolute, falling back to the caller's spelling if the canonical attempt is also absolute.

Trying the caller's spelling first is deliberate: canonicalising the *written* value would discard a symlink the user chose. Someone who adds `~/work` (a link to `~/projects/alpha`) would get `"alpha"` persisted into a file they may share, with their own spelling unrecoverable from it. It also means a folder that does not exist on disk still relativises, since that path needs no filesystem access.

**Normalisation at the zoxide call site**, not inside `change_workspace_root`. Canonicalising inside the function breaks 14 tests that assert subsystems — the LSP manager, test worker, search, terminal cwd — follow the root they were *given*. That is a real contract (rust-analyzer's project detection depends on it), so the untrusted path is normalised where it enters instead. Every other caller of `change_workspace_root` was audited and is already canonical: the workspace-file open goes through `parse_workspace_file`, Make Root descends from an already-canonical tree, post-clone derives from `tree.root`, and the CLI canonicalises.

## Tests

- `a_symlinked_folder_still_writes_relative` — the original defect.
- `a_deliberate_folder_symlink_is_written_as_the_user_named_it` — the user's spelling survives; fails against the earlier canonicalise-the-written-value approach.
- `a_missing_folder_still_relativises` — no filesystem dependency.
- `a_zoxide_row_re_roots_under_the_same_key_as_the_add_branch` — both branches of the jump store one spelling. Without the normalisation the jump branch stores `link` and the add branch stores `real`.

All four verified revert-sensitive against the specific defect each targets.

## Also here

`repositories_overview_lists_every_folder_and_a_pin_overrides_the_follow` **was** a genuine test-only issue: it compared `active_scm_root` against a canonicalised path while the app legitimately holds the root as given. I probed whether the two setters could disagree in practice and destabilise the follow guard — they cannot; the value is stable across frames. It now compares against the root as the workspace holds it.

Suite: 3504 passing, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * “Save Workspace As” now preserves portable relative paths when folders are accessed through symlinks.
  * Workspace files now retain supplied symlink paths where possible, improving consistency when reopened.
  * Folder selection now uses consistent path spelling, preventing duplicate workspace entries for equivalent locations.
* **Tests**
  * Added coverage for symlinked folders, missing paths, workspace round trips, and consistent folder selection behavior.
* **Release**
  * Updated the application version and release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->