### PR TITLE
docs: claim work with the `claimed` label before starting on it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,15 @@ And do not assume the shape is stable: the same bots on the same repo produce an
 empty `reviews[]` on one PR and dozens of entries on another, so "here the
 verdict lives in field X" is never a safe shortcut.
 
+**Work out which bot actually gates the merge, and read that one.** The bot with
+the strongest gate is not necessarily the one that shows up in the field you
+queried, and the two facts are unrelated. On the sibling repo, the bot whose
+score is required for merge contributes zero readable entries to `reviews[]`,
+while a different bot contributes six — so a checker reading that field reports
+six healthy artifacts while being blind to the only one that decides
+mergeability. That failure is confident, not silent, which makes it worse than
+undercounting.
+
 Anchor it to the head SHA. If the artifact names a commit other than the head
 you are about to merge, the review is stale and does not count, however good it
 looks. A stale review and a missing review have the same consequence: do not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,12 +86,19 @@ any earlier read stale.
 Query both `.comments[]` and `.reviews[]`: they carry different artifacts, not
 duplicates, and an entry can be present with an empty body — a container for
 inline threads rather than a verdict. Require the body to be non-empty *and* to
-carry the verdict you are looking for; presence alone is not evidence. Exclude
-the PR author, whose own inline replies land there as empty entries too,
-otherwise a PR looks more reviewed the more diligently its author answers
-feedback. And do not assume the shape is stable: the same bots on the same repo
-produce an empty `reviews[]` on one PR and dozens of entries on another, so
-"here the verdict lives in field X" is never a safe shortcut.
+carry the verdict you are looking for; presence alone is not evidence.
+
+**Filter on content, not on author.** It is tempting to just exclude the PR
+author, since their inline replies land there as empty entries and make a PR
+look more reviewed the more diligently its author answers feedback. But that is
+not sufficient: on one measured PR, excluding the author left 23 entries of
+which 17 were still empty bot containers — roughly a fourfold overstatement
+against the 6 entries that actually carried content. Author-exclusion narrows
+the error; only requiring a non-empty body with the verdict token removes it.
+
+And do not assume the shape is stable: the same bots on the same repo produce an
+empty `reviews[]` on one PR and dozens of entries on another, so "here the
+verdict lives in field X" is never a safe shortcut.
 
 Anchor it to the head SHA. If the artifact names a commit other than the head
 you are about to merge, the review is stale and does not count, however good it
@@ -103,5 +110,14 @@ Everything above is a habit, and a hurried session can skip a habit. The sibling
 code-graph-rag repo enforces the equivalent mechanically instead: a required
 `Greptile 5/5 Gate` job polls until a scored review names the exact head SHA,
 and fails on a stale, missing, or lower-scored one, so the merge is blocked
-rather than merely discouraged. croft has no such gate today. If these rules
-keep costing attention, porting it is the fix worth making.
+rather than merely discouraged. **croft has no such gate today** — do not treat
+this paragraph as a protection that exists here. If these rules keep costing
+attention, porting it is the fix worth making.
+
+Worth reading that job before reinventing any of this. Each of its decisions —
+reading the issue comments rather than the review objects, filtering to the bot
+login, requiring the score token rather than mere presence, walking candidates
+newest-first so a late edit to an old review cannot mask a valid one, resolving
+abbreviated commit refs to full SHAs for exact equality — is the fix for a
+specific trap above. The defences get reinvented because the traps are common;
+reading an existing gate is faster than rediscovering them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,23 @@ Two habits that avoid the common collisions:
 * **Never rewrite a branch you do not hold.** No force-pushes to another
   session's PR. If a branch needs main, merge main into it — that is the
   convention here, and it keeps the push a fast-forward.
+
+## Verifying a review actually happened
+
+Before merging on a bot review, confirm the review ARTIFACT exists rather than
+trusting an aggregate signal. CodeRabbit's check on this repo has reported
+`pass` while annotated "Review rate limited" — a green row meaning no review
+happened at all. Zero unresolved threads reads the same whether the bot found
+nothing or never ran, and a bot that edits its summary comment in place makes
+any earlier read stale.
+
+Query both `.comments[]` and `.reviews[]`: they carry different artifacts, not
+duplicates, and an entry can be present with an empty body — a container for
+inline threads rather than a verdict. Require the body to be non-empty *and* to
+carry the verdict you are looking for; presence alone is not evidence.
+
+Anchor it to the head SHA. If the artifact names a commit other than the head
+you are about to merge, the review is stale and does not count, however good it
+looks. A stale review and a missing review have the same consequence: do not
+merge yet. "No review yet" and "reviewed and clean" must never collapse into the
+same verdict.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# Working on croft as an agent
+
+Notes for AI agents (and anyone else) working this repo. Contributor workflow —
+the release gate, `target/` hygiene, test layout — lives in
+[CONTRIBUTING.md](CONTRIBUTING.md); this file covers what is specific to
+several agents working the same repo at once.
+
+## Claim work before you start: the `claimed` label
+
+Several sessions often work this repo in parallel, in separate clones and
+worktrees, with no shared view of each other. Two of them picking up the same
+PR means duplicated review rounds, conflicting pushes, and — in the worst case
+— one session force-pushing over another's work.
+
+**Before starting on a PR or an issue, check for the `claimed` label. If it is
+there, someone is already on it: leave it alone.** Ask the user before taking
+over anything that carries it.
+
+**When you start work, add the label. When you stop, remove it.**
+
+```bash
+gh pr view <n> --json labels --jq '[.labels[].name]'   # check first
+gh pr edit <n> --add-label claimed                     # claiming
+gh pr edit <n> --remove-label claimed                  # done, or handing off
+```
+
+Use `gh issue view` / `gh issue edit` for issues. To see everything currently
+claimed: `gh pr list --label claimed` and `gh issue list --label claimed`.
+
+Where to put it: **claim the PR once one exists**, since that is where the
+contended work happens — pushes, review rounds, the merge. Claim the issue only
+for work that has no PR yet, and move the claim to the PR when you open it.
+
+### Releasing it
+
+The label is a lock, and a lock nobody releases is worse than no lock. Remove it
+when you merge, when you stop working, and when you hand off. Merging usually
+deletes the branch but **not** the label, so drop it as part of the merge.
+
+It deliberately records no owner, so it cannot tell you *who* holds a claim or
+*when* they took it. That keeps it cheap, at the cost of being unable to
+distinguish an active claim from an abandoned one. If a claim looks stale, do
+not just assume it — the sessions working this repo can talk to each other, so
+ask the holder first, and ask the user if you cannot reach them.
+
+## Coordinating with other sessions
+
+Claiming is the cheap signal, not a substitute for talking. Peer sessions on the
+same machine are discoverable and can be messaged directly, which resolves
+ownership questions far more reliably than guessing from timestamps or commit
+authorship — every session commits under the same user identity, so neither one
+tells you which session did the work.
+
+Two habits that avoid the common collisions:
+
+* **Re-check state immediately before you act on it.** Both the version bump and
+  the pre-merge review sweep have been broken by state moving during the window
+  between deciding and merging. Re-read rather than reusing a value you fetched
+  minutes ago.
+* **Never rewrite a branch you do not hold.** No force-pushes to another
+  session's PR. If a branch needs main, merge main into it — that is the
+  convention here, and it keeps the push a fast-forward.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,7 @@ deletes the branch but **not** the label, so drop it as part of the merge.
 
 The two failure modes are not symmetric, which is why releasing belongs in the
 merge rather than in a follow-up step: forgetting to *claim* costs you one
-possible collision, while forgetting to *release* blocks the work indefinitely,
-and nothing about an abandoned claim distinguishes it from an active one.
+possible collision, while forgetting to *release* blocks the work indefinitely.
 
 It deliberately records no owner, so it cannot tell you *who* holds a claim or
 *when* they took it. That keeps it cheap, at the cost of being unable to
@@ -91,10 +90,12 @@ carry the verdict you are looking for; presence alone is not evidence.
 **Filter on content, not on author.** It is tempting to just exclude the PR
 author, since their inline replies land there as empty entries and make a PR
 look more reviewed the more diligently its author answers feedback. But that is
-not sufficient: on one measured PR, excluding the author left 23 entries of
-which 17 were still empty bot containers — roughly a fourfold overstatement
-against the 6 entries that actually carried content. Author-exclusion narrows
-the error; only requiring a non-empty body with the verdict token removes it.
+not sufficient: on one measured PR (`code-graph-rag#1425`), excluding the author
+still left about three quarters of the remaining entries as empty bot
+containers — a roughly fourfold overstatement against the entries that actually
+carried content. Author-exclusion narrows the error; only requiring a non-empty
+body with the verdict token removes it. Counts drift as new reviews land, so
+re-run the query rather than trusting these proportions.
 
 And do not assume the shape is stable: the same bots on the same repo produce an
 empty `reviews[]` on one PR and dozens of entries on another, so "here the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,10 +86,22 @@ any earlier read stale.
 Query both `.comments[]` and `.reviews[]`: they carry different artifacts, not
 duplicates, and an entry can be present with an empty body — a container for
 inline threads rather than a verdict. Require the body to be non-empty *and* to
-carry the verdict you are looking for; presence alone is not evidence.
+carry the verdict you are looking for; presence alone is not evidence. Exclude
+the PR author, whose own inline replies land there as empty entries too,
+otherwise a PR looks more reviewed the more diligently its author answers
+feedback. And do not assume the shape is stable: the same bots on the same repo
+produce an empty `reviews[]` on one PR and dozens of entries on another, so
+"here the verdict lives in field X" is never a safe shortcut.
 
 Anchor it to the head SHA. If the artifact names a commit other than the head
 you are about to merge, the review is stale and does not count, however good it
 looks. A stale review and a missing review have the same consequence: do not
 merge yet. "No review yet" and "reviewed and clean" must never collapse into the
 same verdict.
+
+Everything above is a habit, and a hurried session can skip a habit. The sibling
+code-graph-rag repo enforces the equivalent mechanically instead: a required
+`Greptile 5/5 Gate` job polls until a scored review names the exact head SHA,
+and fails on a stale, missing, or lower-scored one, so the merge is blocked
+rather than merely discouraged. croft has no such gate today. If these rules
+keep costing attention, porting it is the fix worth making.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ PR means duplicated review rounds, conflicting pushes, and — in the worst case
 — one session force-pushing over another's work.
 
 **Before starting on a PR or an issue, check for the `claimed` label. If it is
-there, someone is already on it: leave it alone.** Ask the user before taking
-over anything that carries it.
+there, someone is already on it: leave it alone.** If you think you need it
+anyway, ask the holder first and the user if you cannot reach them.
 
 **When you start work, add the label. When you stop, remove it.**
 
@@ -37,6 +37,11 @@ The label is a lock, and a lock nobody releases is worse than no lock. Remove it
 when you merge, when you stop working, and when you hand off. Merging usually
 deletes the branch but **not** the label, so drop it as part of the merge.
 
+The two failure modes are not symmetric, which is why releasing belongs in the
+merge rather than in a follow-up step: forgetting to *claim* costs you one
+possible collision, while forgetting to *release* blocks the work indefinitely,
+and nothing about an abandoned claim distinguishes it from an active one.
+
 It deliberately records no owner, so it cannot tell you *who* holds a claim or
 *when* they took it. That keeps it cheap, at the cost of being unable to
 distinguish an active claim from an abandoned one. If a claim looks stale, do
@@ -57,6 +62,14 @@ Two habits that avoid the common collisions:
   the pre-merge review sweep have been broken by state moving during the window
   between deciding and merging. Re-read rather than reusing a value you fetched
   minutes ago.
+
+  For the version specifically, note that the release gate **cannot** catch a
+  collision itself — it is answering a different question. It compares your head
+  against the merge base, so it passes as long as your branch is above main *at
+  that point*, which means two branches can both pass legitimately and only the
+  second one to merge conflicts. Running the gate later would not help. Re-read
+  `git show origin/main:Cargo.toml` in the same breath as the final
+  `gh pr checks`, and bump again if main has moved.
 * **Never rewrite a branch you do not hold.** No force-pushes to another
   session's PR. If a branch needs main, merge main into it — that is the
   convention here, and it keeps the push a fast-forward.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@ Thanks for hacking on croft. Build, run, and platform setup live in the
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md). This guide covers the day to day
 developer workflow concerns that do not belong in any of those.
 
+If you are an AI agent, read [CLAUDE.md](CLAUDE.md) as well: it covers claiming
+work so concurrent sessions do not collide, and verifying that a review actually
+happened before merging. Everything in this guide applies to you too.
+
 ## Every shipped change is a release
 
 A PR that changes anything compiled into the binary (`src/`, `assets/`,


### PR DESCRIPTION
## Why

Several agent sessions work this repo in parallel, in separate clones and worktrees, with no shared view of each other. Last night that produced duplicated review rounds on #278 and a near-miss where two sessions independently prepared to merge #279. Ownership was only ever resolvable by asking sessions directly — commit authorship is identical across all of them, and timestamp correlation actively misleads.

## What

Adds a root `CLAUDE.md` recording the claiming convention:

- **Check for the `claimed` label before starting** on a PR or issue; leave it alone if present.
- **Add the label when you start, remove it when you stop** — including as part of merging, since merging deletes the branch but not the label.
- **Claim the PR once one exists** (that is where pushes, review rounds, and merges contend); claim the issue only for work with no PR yet.

The `claimed` label already exists on the repo.

It deliberately records no owner, which keeps it cheap but means it cannot distinguish an active claim from an abandoned one. The doc says so explicitly and tells you to ask rather than assume when a claim looks stale.

Also records the two coordination habits that would have prevented the collisions actually hit:

- **Re-check state immediately before acting on it.** Both the version bump and the pre-merge review sweep have been broken by state moving between deciding and merging — 0.1.760 and 0.1.761 were each claimed by two branches minutes apart.
- **Never rewrite a branch you do not hold.** Merge main in rather than force-pushing; that is already the convention here and keeps the push a fast-forward.

## Notes

Docs-only, so exempt from the `version bump + release notes` gate (`CLAUDE.md` matches none of the shipped paths). No code changes.