### PR TITLE
fix(lsp): send and receive positions as UTF-16 code units (v0.1.766)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.765"
+version = "0.1.766"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.765"
+version = "0.1.766"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7404,6 +7404,9 @@ impl App {
             entry.push(crate::widgets::problems::ProblemItem {
                 line: d.line,
                 col: d.col,
+                // Build tools report characters (rustc counts code points),
+                // not the UTF-16 units an LSP position carries.
+                col_utf16: false,
                 severity: d.severity,
                 message: d.message,
                 source: d.source.to_string(),
@@ -7480,6 +7483,7 @@ impl App {
                         items.push(ProblemItem {
                             line: d.start_line,
                             col: d.start_char,
+                            col_utf16: true,
                             severity: d.severity,
                             message: d.message.clone(),
                             source: server.clone(),
@@ -30626,10 +30630,20 @@ impl App {
                     }
                     match self.problems.hit_at(m.row) {
                         Some(ProblemHit::Header(path)) => self.problems.toggle_collapse(&path),
-                        Some(ProblemHit::Diagnostic { path, line, col }) => {
-                            // The diagnostic's column is the server's UTF-16
-                            // `start_char`, not a character column.
-                            if let Err(e) = self.open_at_utf16(&path, line, col) {
+                        Some(ProblemHit::Diagnostic {
+                            path,
+                            line,
+                            col,
+                            col_utf16,
+                        }) => {
+                            // An LSP diagnostic's column is UTF-16; a build
+                            // tool's is already a character column.
+                            let opened = if col_utf16 {
+                                self.open_at_utf16(&path, line, col)
+                            } else {
+                                self.open_at(&path, line as usize, col as usize)
+                            };
+                            if let Err(e) = opened {
                                 self.status = format!("Open failed: {e}");
                             }
                         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6467,8 +6467,9 @@ impl App {
         let Some(path) = self.editor.path.clone() else {
             return;
         };
-        let line = self.editor.cursor_row as u32;
-        let character = self.editor.cursor_col as u32;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(lsp) = self.lsp.as_mut() else {
             return;
         };
@@ -6484,8 +6485,9 @@ impl App {
         let Some(path) = self.editor.path.clone() else {
             return;
         };
-        let line = self.editor.cursor_row as u32;
-        let character = self.editor.cursor_col as u32;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(lsp) = self.lsp.as_mut() else {
             return;
         };
@@ -6896,9 +6898,12 @@ impl App {
         // punctuation there is no symbol to describe, so show the diagnostic
         // alone right away.
         let word = self.editor.word_at(line, c).is_some();
+        // Converted before the match: `self.lsp.as_mut()` borrows self for the
+        // whole scrutinee, so the editor is unreachable inside the arm.
+        let (uline, uchar) = self.editor.pos_to_utf16(line, c);
         match (word, self.editor.path.clone(), self.lsp.as_mut()) {
             (true, Some(path), Some(lsp)) => {
-                let id = lsp.request_hover(path, line as u32, c as u32);
+                let id = lsp.request_hover(path, uline, uchar);
                 self.hover_request_id = Some(id);
             }
             _ => {
@@ -7719,7 +7724,8 @@ impl App {
                 col: self.editor.cursor_col,
             });
         }
-        match self.open_at(&path, line as usize, col as usize) {
+        // `col` is the server's UTF-16 column, not a character column.
+        match self.open_at_utf16(&path, line, col) {
             Ok(()) => {
                 self.status = format!("Jumped to {} line {}", self.status_path(&path), line + 1)
             }
@@ -8489,8 +8495,9 @@ impl App {
     /// Request the callers (`incoming`) or callees of the symbol at the
     /// cursor. Cmd+K H / Cmd+K Shift+H and the right-click menu rows.
     fn request_call_hierarchy_at_cursor(&mut self, incoming: bool) {
-        let row = self.editor.cursor_row;
-        let col = self.editor.cursor_col;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(path) = self.editor.path.clone() else {
             return;
         };
@@ -8498,7 +8505,7 @@ impl App {
             self.status = String::from("Call hierarchy: no language server for this file");
             return;
         };
-        let id = lsp.request_call_hierarchy(path, row as u32, col as u32, incoming);
+        let id = lsp.request_call_hierarchy(path, line, character, incoming);
         self.call_hierarchy_request_id = Some(id);
     }
 
@@ -8885,10 +8892,11 @@ impl App {
         if already_requested || self.occ_observed_at.elapsed() < OCCURRENCES_IDLE {
             return false;
         }
+        let (uline, uchar) = self.editor.pos_to_utf16(cur.1, cur.2);
         let Some(lsp) = self.lsp.as_mut() else {
             return false;
         };
-        let id = lsp.request_document_highlights(cur.0.clone(), cur.1 as u32, cur.2 as u32);
+        let id = lsp.request_document_highlights(cur.0.clone(), uline, uchar);
         self.occurrences_request = Some((id, cur.0, cur.1, cur.2, cur.3));
         false
     }
@@ -9472,6 +9480,29 @@ impl App {
         self.status = format!("Color Theme: {}", theme.label());
     }
 
+    /// [`Self::open_at`] for a position that came FROM a language server, whose
+    /// column counts UTF-16 code units rather than characters. The file has to
+    /// be open before the conversion can happen — the mapping needs the target
+    /// line's text — so this opens at column 0 and then re-seats the caret.
+    ///
+    /// Out-of-range answers are clamped rather than rejected, matching
+    /// `open_at`: a server that names a line past the end of a buffer we have
+    /// since edited should still land the user on the right file.
+    fn open_at_utf16(&mut self, path: &Path, line: u32, character: u32) -> Result<()> {
+        self.open_at(path, line as usize, 0)?;
+        let row = self.editor.cursor_row;
+        let col = self.editor.utf16_col_to_char_pub(row, character);
+        let max_col = self
+            .editor
+            .lines
+            .get(row)
+            .map(|l| l.chars().count())
+            .unwrap_or(0);
+        self.editor.cursor_col = col.min(max_col);
+        self.editor.ensure_cursor_col_visible();
+        Ok(())
+    }
+
     fn open_at(&mut self, path: &Path, row: usize, col: usize) -> Result<()> {
         self.hover_popup = None;
         self.hover_diagnostic = None;
@@ -9604,10 +9635,11 @@ impl App {
         let Some(path) = self.editor.path.clone() else {
             return;
         };
+        let (uline, uchar) = self.editor.pos_to_utf16(line, c);
         let Some(lsp) = self.lsp.as_mut() else {
             return;
         };
-        let id = lsp.request_definition(path, line as u32, c as u32);
+        let id = lsp.request_definition(path, uline, uchar);
         self.definition_request_id = Some(id);
     }
 
@@ -9617,8 +9649,9 @@ impl App {
     /// Alt+F12 / palette "Peek Definition": the definition request whose
     /// response opens an excerpt popup instead of jumping (#115).
     fn peek_definition_at_cursor(&mut self) {
-        let row = self.editor.cursor_row;
-        let col = self.editor.cursor_col;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(path) = self.editor.path.clone() else {
             self.status = String::from("No file open");
             return;
@@ -9627,21 +9660,22 @@ impl App {
             self.status = String::from("No language server for this file");
             return;
         };
-        let id = lsp.request_definition(path, row as u32, col as u32);
+        let id = lsp.request_definition(path, line, character);
         self.peek_definition_request_id = Some(id);
         self.status = String::from("Peeking definition");
     }
 
     fn request_definition_at_cursor(&mut self) {
-        let row = self.editor.cursor_row;
-        let col = self.editor.cursor_col;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(path) = self.editor.path.clone() else {
             return;
         };
         let Some(lsp) = self.lsp.as_mut() else {
             return;
         };
-        let id = lsp.request_definition(path, row as u32, col as u32);
+        let id = lsp.request_definition(path, line, character);
         self.definition_request_id = Some(id);
     }
 
@@ -9651,15 +9685,16 @@ impl App {
     /// no separate declaration site (e.g. Python); they diverge for C/C++ (header
     /// prototype) and TypeScript (`.d.ts`).
     fn request_declaration_at_cursor(&mut self) {
-        let row = self.editor.cursor_row;
-        let col = self.editor.cursor_col;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(path) = self.editor.path.clone() else {
             return;
         };
         let Some(lsp) = self.lsp.as_mut() else {
             return;
         };
-        let id = lsp.request_declaration(path, row as u32, col as u32);
+        let id = lsp.request_declaration(path, line, character);
         self.declaration_request_id = Some(id);
     }
 
@@ -9668,15 +9703,16 @@ impl App {
     /// item and the `⌃F12` keybinding. Jumps to where the *type* of the
     /// expression is defined, as opposed to the symbol itself (definition).
     fn request_type_definition_at_cursor(&mut self) {
-        let row = self.editor.cursor_row;
-        let col = self.editor.cursor_col;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(path) = self.editor.path.clone() else {
             return;
         };
         let Some(lsp) = self.lsp.as_mut() else {
             return;
         };
-        let id = lsp.request_type_definition(path, row as u32, col as u32);
+        let id = lsp.request_type_definition(path, line, character);
         self.type_definition_request_id = Some(id);
     }
 
@@ -9685,15 +9721,16 @@ impl App {
     /// item and the `⌘F12` keybinding. Meaningful on traits / interfaces /
     /// abstract methods; the server may return many, and croft jumps to the first.
     fn request_implementation_at_cursor(&mut self) {
-        let row = self.editor.cursor_row;
-        let col = self.editor.cursor_col;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(path) = self.editor.path.clone() else {
             return;
         };
         let Some(lsp) = self.lsp.as_mut() else {
             return;
         };
-        let id = lsp.request_implementation(path, row as u32, col as u32);
+        let id = lsp.request_implementation(path, line, character);
         self.implementation_request_id = Some(id);
     }
 
@@ -9702,15 +9739,16 @@ impl App {
     /// `⇧F12` keybinding. The server almost always returns many uses, which
     /// `drain_lsp_references` then offers as a picker.
     fn request_references_at_cursor(&mut self) {
-        let row = self.editor.cursor_row;
-        let col = self.editor.cursor_col;
+        let (line, character) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let Some(path) = self.editor.path.clone() else {
             return;
         };
         let Some(lsp) = self.lsp.as_mut() else {
             return;
         };
-        let id = lsp.request_references(path, row as u32, col as u32);
+        let id = lsp.request_references(path, line, character);
         self.references_request_id = Some(id);
     }
 
@@ -10604,8 +10642,11 @@ impl App {
             self.status = String::from("No file open");
             return;
         };
-        let row = self.editor.cursor_row as u32;
-        let col = self.editor.cursor_col as u32;
+        // `row`/`col` go to the server, so the column must be UTF-16;
+        // `diagnostics_in_line_range` takes a plain row and is unaffected.
+        let (row, col) = self
+            .editor
+            .pos_to_utf16(self.editor.cursor_row, self.editor.cursor_col);
         let diagnostics = self.editor.diagnostics_in_line_range(row, row);
         let Some(lsp) = self.lsp.as_mut() else {
             self.status = String::from("No language server for this file");
@@ -30586,7 +30627,9 @@ impl App {
                     match self.problems.hit_at(m.row) {
                         Some(ProblemHit::Header(path)) => self.problems.toggle_collapse(&path),
                         Some(ProblemHit::Diagnostic { path, line, col }) => {
-                            if let Err(e) = self.open_at(&path, line as usize, col as usize) {
+                            // The diagnostic's column is the server's UTF-16
+                            // `start_char`, not a character column.
+                            if let Err(e) = self.open_at_utf16(&path, line, col) {
                                 self.status = format!("Open failed: {e}");
                             }
                         }
@@ -36325,13 +36368,16 @@ impl App {
                     }
                     return;
                 }
+                // The prompt captured buffer coordinates; the server wants
+                // UTF-16, so convert here rather than casting the char column.
+                let (line, character) = self.editor.pos_to_utf16(row, col);
                 let Some(lsp) = self.lsp.as_mut() else {
                     if let Some(p) = self.prompt.as_mut() {
                         p.error = Some("No language server for this file".to_string());
                     }
                     return;
                 };
-                let id = lsp.request_rename(path, row as u32, col as u32, new_name);
+                let id = lsp.request_rename(path, line, character, new_name);
                 self.rename_request_id = Some(id);
                 self.prompt = None;
                 self.status = String::from("Renaming symbol");

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "Save Workspace As writes portable files again: a folder reached through a symlink (macOS hands croft /var for /private/var, and any symlinked home does the same) was written as an absolute path instead of a relative one, so the file stopped travelling — it kept working where it was written but not on another machine, another checkout, or a different layout.",
+    summary: "Code intelligence lands on the right symbol in files with emoji: hover, go-to-definition, completion, references, rename and friends now measure columns the way language servers do, so a line containing an emoji no longer shifts every result sideways.",
 }];

--- a/src/widgets/editor.rs
+++ b/src/widgets/editor.rs
@@ -13289,6 +13289,34 @@ mod tests {
         assert_eq!(empty.pos_to_utf16(0, 0), (0, 0));
     }
 
+    /// #288: every position-carrying LSP request sends UTF-16 columns and every
+    /// server answer comes back in them, so the two conversions must be exact
+    /// inverses. A char column used raw as UTF-16 (or the reverse) lands the
+    /// caret to the LEFT of the symbol on any line with a surrogate pair, which
+    /// is what made hover/definition/completion miss on emoji lines.
+    #[test]
+    fn utf16_and_char_columns_round_trip_across_surrogate_pairs() {
+        let e = editor_with("let 🙂 = 🙂🙂;");
+        let chars = e.lines[0].chars().count();
+        for col in 0..=chars {
+            let (_, u16col) = e.pos_to_utf16(0, col);
+            assert_eq!(
+                e.utf16_col_to_char_pub(0, u16col),
+                col,
+                "char col {col} must survive the round trip"
+            );
+        }
+        // The divergence the bug rode on: past three surrogate pairs the UTF-16
+        // column runs three units ahead of the character column.
+        let (_, after_three) = e.pos_to_utf16(0, 10);
+        assert_eq!(after_three, 13, "each pair costs one extra unit");
+        assert_eq!(
+            e.utf16_col_to_char_pub(0, 10),
+            9,
+            "reading a UTF-16 column as a char column would slip two to the left"
+        );
+    }
+
     /// A failed revert must not launder the buffer clean: clearing `dirty`
     /// before the fallible reload meant a file deleted between the conflict
     /// popup and the Enter left unsaved edits flagged clean — the tab lost

--- a/src/widgets/problems.rs
+++ b/src/widgets/problems.rs
@@ -39,11 +39,18 @@ const GLYPH_WARNING: char = '\u{ea6c}';
 const GLYPH_INFO: char = '\u{ea74}';
 
 /// One diagnostic in the Problems list, projected from a language server's
-/// published set. Positions are zero-based (LSP), shown one-based in the row.
+/// published set or a build tool's output. Positions are zero-based (LSP),
+/// shown one-based in the row.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProblemItem {
     pub line: u32,
     pub col: u32,
+    /// Whether `col` counts UTF-16 code units (a language server's
+    /// `Position.character`) or characters (a build tool's column — rustc
+    /// counts code points, and the matchers only rebase 1-based to 0-based).
+    /// The two sources share this list, so the unit has to travel with the
+    /// item: jumping to it needs to know which conversion to apply.
+    pub col_utf16: bool,
     pub severity: DiagnosticSeverity,
     pub message: String,
     /// The server that produced it (e.g. `rust-analyzer`, `ruff`), shown dim
@@ -114,7 +121,13 @@ pub enum ProblemHit {
     /// A file header: collapse/expand its group.
     Header(PathBuf),
     /// A diagnostic: jump the editor to `(path, line, col)` (zero-based).
-    Diagnostic { path: PathBuf, line: u32, col: u32 },
+    /// `col_utf16` carries the column's unit through from [`ProblemItem`].
+    Diagnostic {
+        path: PathBuf,
+        line: u32,
+        col: u32,
+        col_utf16: bool,
+    },
 }
 
 /// How many trailing characters of the free-text filter the toolbar
@@ -359,6 +372,7 @@ impl ProblemsPanel {
                     path: group.path.clone(),
                     line: item.line,
                     col: item.col,
+                    col_utf16: item.col_utf16,
                 })
             }
         }
@@ -710,6 +724,9 @@ mod tests {
         ProblemItem {
             line,
             col: 0,
+            // The helper's source is a build tool, so its column is a
+            // character column.
+            col_utf16: false,
             severity,
             message: msg.to_string(),
             source: "rustc".to_string(),
@@ -902,6 +919,7 @@ mod tests {
                 path: PathBuf::from("/repo/src/a.rs"),
                 line: 4,
                 col: 0,
+                col_utf16: false,
             }),
         );
         assert_eq!(
@@ -910,9 +928,41 @@ mod tests {
                 path: PathBuf::from("/repo/src/a.rs"),
                 line: 9,
                 col: 0,
+                col_utf16: false,
             }),
         );
         assert_eq!(p.hit_at(4), None, "below the last row");
+    }
+
+    /// #288: the list mixes language-server diagnostics (UTF-16 columns) with
+    /// build-tool diagnostics (character columns), so the unit has to reach the
+    /// jump. If the hit dropped it, every build diagnostic on a line with an
+    /// astral character would be converted a second time and land left of its
+    /// real column.
+    #[test]
+    fn hit_carries_the_column_unit_of_each_source() {
+        let mut lsp_item = diag(4, DiagnosticSeverity::Error, "from a server");
+        lsp_item.col = 7;
+        lsp_item.col_utf16 = true;
+        let mut build_item = diag(9, DiagnosticSeverity::Error, "from cargo");
+        build_item.col = 7;
+        let mut p = ProblemsPanel::new();
+        p.set_groups(vec![group("a.rs", vec![lsp_item, build_item])]);
+        render(&mut p, 60, 6);
+        let utf16_of = |hit| match hit {
+            Some(ProblemHit::Diagnostic { col_utf16, .. }) => Some(col_utf16),
+            _ => None,
+        };
+        assert_eq!(
+            utf16_of(p.hit_at(2)),
+            Some(true),
+            "the server's diagnostic keeps its UTF-16 column"
+        );
+        assert_eq!(
+            utf16_of(p.hit_at(3)),
+            Some(false),
+            "the build tool's identical column is NOT UTF-16"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #288.

## The bug

LSP positions count **UTF-16 code units**, not characters. Every position-carrying request except on-type formatting, range formatting, prepare-rename and linked editing sent the raw character column, so on any line containing a character outside the BMP (emoji, and plenty of CJK-adjacent symbols) the request pointed *left* of the caret — one unit per surrogate pair before it.

The audit found more sites than the issue listed. **13 send-path sites** were wrong:

`trigger_completion`, `trigger_signature_help`, `hover_at_cell`, definition (three entry points: keybinding, right-click, and **peek**), declaration, type definition, implementation, references, document highlights, call hierarchy, rename, and code action.

## The return path

The issue understates this half, and it is where the user-visible damage is worst. `go_to_definition` handed the server's UTF-16 column straight to `open_at` **as a character column**, so *every* definition jump, reference jump, and location-picker selection mis-seated the caret — including on files with no emoji on the caret line, as long as the **target** line had one. Clicking a diagnostic in the PROBLEMS panel did the same with `d.start_char`.

Fixed by adding `open_at_utf16`, which opens the file first (the conversion needs the target line's text) and then re-seats the caret. `open_at` itself is deliberately unchanged: terminal file links legitimately pass character columns through it.

## Notes on the approach

- **Routed through `pos_to_utf16`, not `cursor_position_utf16`.** The latter looks like the natural helper but indexes `self.lines[row]` after a `saturating_sub`, so it panics on an empty buffer — and `Editor::new()` starts with `lines: Vec::new()`. `pos_to_utf16` guards that case (the fix from #275).
- **Out-of-range answers clamp rather than reject**, matching `open_at`'s existing behaviour: a server naming a line past the end of a buffer we have since edited should still land the user on the right file. Documented on the helper so the choice is explicit rather than inherited.
- **Sites confirmed already correct** and left alone: `request_selection_ranges` (uses `cursor_positions_utf16()`), `request_color_presentations` (passes the server's own `item.character` back), plus on-type/range formatting, prepare-rename and linked editing. Breadcrumbs and the outline use row-only positions and are unaffected.

## Testing

`utf16_and_char_columns_round_trip_across_surrogate_pairs` walks every column of a line of surrogate pairs and asserts the two conversions are exact inverses, plus pins the specific divergence the bug rode on.

I verified the test actually catches the regression rather than merely passing: replacing the inverse conversion with the buggy shape (`u16_off as usize`) makes it **fail**, and restoring makes it pass.

`cargo fmt --check` clean, `clippy --bins --all-targets` clean, 6 UTF-16 tests and 147 LSP tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved code-intelligence features—including hover, navigation, references, diagnostics, and rename—to handle emoji and other Unicode characters correctly.
  - Fixed cursor positioning when opening locations returned by the language server, including proper column conversion and line-length clamping.

- **Tests**
  - Added coverage for accurate position round trips on lines containing multiple Unicode surrogate pairs.

- **Release**
  - Updated the package version to 0.1.766.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->