### PR TITLE
fix(test): scale spawned-process deadlines by suite parallelism (#307)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.779"
+version = "0.1.785"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.779"
+version = "0.1.785"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5182,13 +5182,14 @@ fn cmd_clicking_a_non_web_hyperlink_refuses_instead_of_opening() {
                 .map(|c| (r, c))
         })
     };
-    // 8s like the suite's other shell-startup waits (#165): a 5s cap
-    // missed under full parallel load while dozens of test shells spawn.
-    let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(8000) && linked_cell(&app).is_none()
-    {
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+    // 8s was already the second guess here (5s -> 8s, #165), which is the
+    // symptom #307 names: a per-test constant cannot budget for contention,
+    // because contention is a property of how many OTHER tests are spawning
+    // at the same moment. `await_cond` scales the isolated budget by the
+    // suite's parallelism instead of guessing a third time.
+    crate::test_wait::await_cond(std::time::Duration::from_millis(8000), || {
+        linked_cell(&app).is_some()
+    });
     term.draw(|f| app.render(f)).unwrap();
     let (row_idx, col) = linked_cell(&app).expect("shell must print the linked text within 8s");
 

--- a/src/gui_path.rs
+++ b/src/gui_path.rs
@@ -307,7 +307,13 @@ mod tests {
         } else {
             "/bin/sh"
         };
-        let path = probe(shell).expect("the login shell must report a PATH");
+        // `probe()` hardcodes PROBE_TIMEOUT, which is right for a login shell
+        // in isolation and too small under full-suite contention (#307).
+        // Calling `run_probe` with a scaled budget is the same code path with
+        // a number that responds to load, and matches how the sibling tests
+        // here already pass their own durations.
+        let path = run_probe(probe_cmd(shell), crate::test_wait::scaled(PROBE_TIMEOUT))
+            .expect("the login shell must report a PATH");
         assert!(path.contains("/bin"), "got {path:?}");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,8 @@ mod svg;
 mod tasks;
 mod terminal_session;
 mod termux;
+#[cfg(test)]
+mod test_wait;
 mod testing;
 mod theme;
 mod triggers;

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "`croft --version` prints a plain version number again; the build hash moved to the new `--build-info` flag.",
+    summary: "Tests that wait on a real spawned process now scale their deadline by how parallel the suite is, instead of each one guessing a fixed number that is generous alone and too small under load.",
 }];

--- a/src/test_wait.rs
+++ b/src/test_wait.rs
@@ -1,0 +1,155 @@
+//! Load-scaled deadlines for tests that wait on a real spawned process.
+//!
+//! A test that spawns a real process and waits a fixed wall-clock budget will
+//! flake on a loaded machine, and the budget looks generous right up until it
+//! is not (#307). The budget cannot be chosen from inside the test, because
+//! the thing it must absorb — contention — is a property of how many *other*
+//! tests are spawning processes at the same moment.
+//!
+//! So the number stops being a per-test guess: callers state the budget that
+//! is right for their operation *in isolation*, and [`scaled`] widens it by
+//! the parallelism the suite is actually running under.
+
+use std::time::{Duration, Instant};
+
+/// How many test threads this suite is running under.
+///
+/// `RUST_TEST_THREADS` is what CI pins and what a developer overrides, so it
+/// wins; otherwise the harness defaults to the machine's parallelism.
+fn test_threads() -> usize {
+    std::env::var("RUST_TEST_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1)
+        })
+}
+
+/// Widen `base` by the suite's parallelism.
+///
+/// Serial runs keep `base` unchanged: with one test thread there is no
+/// suite-induced contention to absorb, so scaling there would only slow a
+/// failing test down. Above that the factor grows with the thread count but
+/// is capped, because a 64-way machine does not make a shell 64 times slower
+/// — past a point the bottleneck stops being CPU and an uncapped budget just
+/// converts a real hang into a very long wait.
+pub fn scaled(base: Duration) -> Duration {
+    scaled_for(base, test_threads())
+}
+
+/// [`scaled`]'s arithmetic, as a pure function of the thread count.
+///
+/// Split out so the scaling policy is testable without mutating
+/// `RUST_TEST_THREADS`: env vars are process-global, so a test that sets one
+/// races every other test in the binary.
+fn scaled_for(base: Duration, threads: usize) -> Duration {
+    base * threads.clamp(1, MAX_SCALE) as u32
+}
+
+/// Ceiling on the scale factor. Four covers CI's pin and typical dev boxes.
+const MAX_SCALE: usize = 4;
+
+/// Poll `cond` until it returns true or the scaled budget expires.
+///
+/// Returns whether the condition was observed. Callers assert on the result
+/// so the failure names the thing that never happened, not the timeout.
+pub fn await_cond(base: Duration, mut cond: impl FnMut() -> bool) -> bool {
+    let deadline = scaled(base);
+    let started = Instant::now();
+    loop {
+        if cond() {
+            return true;
+        }
+        if started.elapsed() >= deadline {
+            // Re-check once after the deadline: on a loaded machine the last
+            // sleep can overshoot past a condition that became true during it,
+            // which would report a timeout for work that actually completed.
+            return cond();
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Gap between polls, matching the 20ms the hand-rolled loops used.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole point of #307: the budget must respond to load rather than
+    /// being a constant a test author guessed.
+    #[test]
+    fn the_budget_widens_when_the_suite_runs_parallel() {
+        assert_eq!(
+            scaled_for(Duration::from_millis(1000), 4),
+            Duration::from_millis(4000),
+            "a 4-way suite must widen a 1s isolated budget, or the number is \
+             still a per-test guess that flakes under contention"
+        );
+    }
+
+    /// A serial run has no suite-induced contention, so widening there would
+    /// only make a genuinely failing test take longer to say so.
+    #[test]
+    fn a_serial_run_keeps_the_isolated_budget() {
+        assert_eq!(
+            scaled_for(Duration::from_millis(1000), 1),
+            Duration::from_millis(1000),
+            "one test thread means nothing to absorb"
+        );
+    }
+
+    /// Uncapped scaling turns a real hang into a wait nobody sits through.
+    #[test]
+    fn a_huge_thread_count_is_capped() {
+        assert_eq!(
+            scaled_for(Duration::from_millis(1000), 64),
+            Duration::from_millis(MAX_SCALE as u64 * 1000),
+            "past the cap the bottleneck is not CPU, and an uncapped budget \
+             converts a hang into a very long wait"
+        );
+    }
+
+    /// A condition already true must not pay the poll interval, or every
+    /// converted call site gets slower for nothing.
+    #[test]
+    fn an_already_true_condition_returns_immediately() {
+        let started = Instant::now();
+        assert!(await_cond(Duration::from_secs(30), || true));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "took {:?}: the condition was true on entry, so it must not sleep",
+            started.elapsed()
+        );
+    }
+
+    /// The budget must actually bound a condition that never comes true.
+    #[test]
+    fn a_condition_that_never_holds_times_out_and_reports_false() {
+        let started = Instant::now();
+        assert!(
+            !await_cond(Duration::from_millis(100), || false),
+            "a condition that never holds must report false, not hang"
+        );
+        assert!(
+            started.elapsed() >= Duration::from_millis(100),
+            "returned after {:?}: it must wait out the budget before giving up, \
+             or it is not a deadline",
+            started.elapsed()
+        );
+    }
+
+    /// A condition that becomes true partway through must be observed.
+    #[test]
+    fn a_condition_that_turns_true_midway_is_observed() {
+        let flip = Instant::now() + Duration::from_millis(60);
+        assert!(
+            await_cond(Duration::from_secs(5), || Instant::now() >= flip),
+            "the condition turned true well inside the budget"
+        );
+    }
+}

--- a/src/widgets/terminal.rs
+++ b/src/widgets/terminal.rs
@@ -6673,11 +6673,13 @@ mod tests {
             tmp.path(),
         )
         .unwrap();
-        let mut waited_ms = 0u32;
-        while waited_ms < 4000 && term.peek_pending_bytes() == 0 {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            waited_ms += 20;
-        }
+        // 4s is the right budget for a `/bin/echo` round trip IN ISOLATION.
+        // Under full-suite contention it is not, and the right number is not
+        // knowable from inside this test -- see #307. `await_cond` widens it
+        // by the parallelism the suite is actually running under.
+        crate::test_wait::await_cond(std::time::Duration::from_millis(4000), || {
+            term.peek_pending_bytes() > 0
+        });
         assert!(
             term.peek_pending_bytes() > 0,
             "the reader thread must accumulate the bytes it advanced so the main loop can tell echo from a bulk stream"


### PR DESCRIPTION
Closes the three conversions #307 asks for, with the helper it proposes.

## The defect shape

Several tests spawn a real external process and wait a **fixed wall-clock budget**. Each budget is defensible against its own operation measured in isolation, and too small under full-suite contention. They present as unrelated intermittent failures; they are one shape.

The number cannot be chosen from inside a test, because the thing it must absorb — contention — is a property of how many *other* tests are spawning at that moment. `await_cond(base, cond)` takes the budget that is right in isolation and widens it by the suite's parallelism.

## Converted

| test | was | note |
|---|---|---|
| `widgets::terminal` `pending_bytes_…` | `while waited < 4000` on `/bin/echo` | plain poll |
| `app::tests` `cmd_clicking_a_non_web_hyperlink_…` | `Instant::elapsed < 8000` | **8s was already the second guess** (5s→8s per its own comment) — the exact symptom this issue names, so this stops guessing rather than guessing a third time |
| `gui_path` `probing_a_real_shell_…` | `probe()`, which hardcodes `PROBE_TIMEOUT` | structurally different: now `run_probe(cmd, scaled(PROBE_TIMEOUT))`, the same code path with a load-responsive number, and the idiom sibling tests in that module already use |

## Teeth — the criterion that mattered

The issue requires each converted test to **still fail when the behaviour it guards is reverted**, not be weakened into always passing. That is the real risk: a longer deadline can turn a genuine failure into a slow pass.

```
PHASE A (as shipped)       EXIT=0    ok. 1 passed; 0 failed
PHASE B (behaviour gone)   EXIT=101  FAILED. 0 passed; 1 failed   (16.02s)
  "the reader thread must accumulate the bytes it advanced…"
```

Mutation (`peek_pending_bytes` always returns 0) verified applied before scoring, tree verified restored after. The 16s runtime is itself evidence the scaling is live — it waited out the full widened budget before failing at its named claim.

## Design notes

- **`src/testing/` is the shipped Test Runner feature, not test support.** A helper there would ship dead code to users. This is a new `#[cfg(test)] mod test_wait`.
- **Scaling is a pure function of the thread count.** Reading `RUST_TEST_THREADS` inside a test would need env mutation, and env vars are process-global — a test that sets one races every other test in the binary.
- **Serial runs keep the base budget.** One test thread means no suite-induced contention to absorb; scaling there would only slow a genuinely failing test down.
- **The factor is capped.** A 64-way machine does not make a shell 64× slower, and an uncapped budget converts a real hang into a very long wait.
- **`await_cond` re-checks once after the deadline expires.** On a loaded machine the final sleep can overshoot a condition that became true during it — reporting a timeout for completed work would reintroduce this issue's own bug inside its fix.

## Scope: 26 poll sites remain, and there is a third idiom

The issue's table names three tests. Surveying `origin/main` found the shape is broader, including an idiom the table does not mention:

| idiom | sites on main |
|---|---|
| `while waited < N` | 18 (`widgets/terminal.rs` 16, `app/tests.rs` 2) |
| `started.elapsed() < N` | 12 (`app/tests.rs` 10, `app/mod.rs` 1, `session_host.rs` 1) |

Four distinct magic numbers: `4000`, `8000`, `6000`, plus `Duration`-based ones. **This PR converts 3 and leaves 26.** Not widening scope unilaterally — the remaining ones are mechanical now that the helper exists, and are better as a follow-up than as a 29-site diff riding on the same review.

(Correcting my own earlier comment on the issue: I first reported 24 remaining, from a narrower grep. 26 is the accurate figure.)

## Verification

```
SUITE: 3589 passed; 1 failed
FMT_CHECK=0    CLIPPY=0
```

The one failure is `terminal_session_restores_pane_layout_names_and_focus_across_restarts` — `restored pane's shell is not alive`. Discharged:

1. **Reachability** — zero matches for session/restore/pane_layout in this diff (24 insertions), with a control confirming the diff is searchable.
2. **Cross-branch** — the *same test with the same message* failed on `feat/config-sync` earlier today, an unrelated branch. A defect in this diff cannot fail on a branch that does not contain it: that rules the diff out by reachability rather than by resampling.
3. **Mechanism** — it spawns a real shell and waits for liveness, which is this issue's own primary class. It is a candidate for conversion in the follow-up.

Version `0.1.785`, above every in-flight branch (`780`/`782`/`783`/`784`) so the release gate cannot collide.