### PR TITLE
test(terminal): quiesce the pane's shell before baking the image fixture

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -27915,6 +27915,14 @@ fn app_with_baked_terminal_image(
             quiet = 0;
         }
     }
+    // The deadline is a failure, not a fallback. Falling through it would hand
+    // the caller exactly the unsynchronised fixture this wait exists to
+    // prevent, and the resulting flake would look like the picture logic
+    // rather than a shell that never settled.
+    assert!(
+        quiet >= 2,
+        "the pane's shell never went quiet within 10s, so the fixture cannot bake against a stable grid"
+    );
     let h = app.terminals[0].last_inner.height as usize;
     app.terminals[0].feed_bytes_for_test("\r\n".repeat(h * 2).as_bytes());
     app.terminals[0].push_image_for_test(wide_short_png());

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -27897,6 +27897,24 @@ fn app_with_baked_terminal_image(
     let backend = ratatui::backend::TestBackend::new(100, 30);
     let mut term = ratatui::Terminal::new(backend).unwrap();
     term.draw(|f| app.render(f)).unwrap();
+    // The pane owns a REAL shell, and its startup output arrives whenever the
+    // machine gets round to it (#326). Every assertion built on this fixture
+    // reads the picture's position, so a prompt landing after the bake scrolls
+    // the grid out from under it and the test fails for a reason that has
+    // nothing to do with what it is testing. Wait for the shell to go quiet
+    // first: two consecutive idle reads, so a gap between two bursts is not
+    // mistaken for the end of them.
+    let mut quiet = 0;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while quiet < 2 && std::time::Instant::now() < deadline {
+        let _ = app.terminals[0].take_dirty();
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        if app.terminals[0].peek_pending_bytes() == 0 && !app.terminals[0].peek_dirty() {
+            quiet += 1;
+        } else {
+            quiet = 0;
+        }
+    }
     let h = app.terminals[0].last_inner.height as usize;
     app.terminals[0].feed_bytes_for_test("\r\n".repeat(h * 2).as_bytes());
     app.terminals[0].push_image_for_test(wide_short_png());


### PR DESCRIPTION
Fixes #326.

## The race

`app_with_baked_terminal_image` builds its picture on a pane that owns a **real shell**, and that shell's startup output arrives whenever the machine gets round to it. Every assertion built on the fixture reads the picture's position — `the_terminal_image_yields_to_an_open_context_menu` places its menu at `(l.cell_x, l.cell_y)` — so a prompt landing after the bake scrolls the grid, the menu no longer covers the image it was placed over, the payload survives, and the assert fires.

Observed once in a full-suite run at `RUST_TEST_THREADS=4` under two competing cargo builds; runs 2 and 3 of the same tree passed.

## Why it is not the #307 shape

Same trigger — a real process under load — but the inverse defect, and worth stating because the two get rediscovered together. #307 is a budget that was too small: the test waited for something that had to happen and gave up early. Here nothing waits at all. The test assumes output has **not** happened yet, so no amount of deadline scaling could reach it.

## The fix

The fixture waits for the shell to go quiet before feeding its rows: two consecutive idle reads rather than one, so a gap between two bursts of startup output is not mistaken for the end of them. Bounded at 10s so a shell that never settles fails rather than hangs.

Production is untouched.

## Teeth

Verified against the guard the test actually exercises, `context_menu_covers_rect` — reverting it fails the test.

Worth recording the wrong turn: I first mutated `menu_covers`, the test kept passing, and that reads exactly like a toothless test. It is not — `menu_covers` gates the *minimap*, while the terminal image goes through `context_menu_covers_rect`. A mutation aimed at the wrong function is indistinguishable from a test with no teeth unless you check which guard the path actually runs.

Six runs of both fixture users under twelve busy cores, all green. Full suite green (3578), clippy and fmt clean.

Test-only, so no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test stability by waiting for shell output to settle before continuing.
  * Prevented delayed prompt output from shifting captured screen content out of position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->