### PR TITLE
fix(tasks): de-duplicate discovered tasks by label, not command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.792"
+version = "0.1.793"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.792"
+version = "0.1.793"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Feature,
-    summary: "A debug compound's own preLaunchTask now runs before its configuration starts, waiting for it to exit 0 — so a compound that builds first launches instead of being refused.",
+    kind: NoteKind::Fix,
+    summary: "Task discovery no longer loses a label: a tasks.json entry that reuses a Makefile, Cargo or package.json command under its own name used to drop the convention task entirely, so a preLaunchTask or Tasks: Run Task pick by that name reported \"not found\". Tasks are now de-duplicated by label, the identifier everything looks up.",
 }];

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "Task discovery no longer loses a label: a tasks.json entry that reuses a Makefile, Cargo or package.json command under its own name used to drop the convention task entirely, so a preLaunchTask or Tasks: Run Task pick by that name reported \"not found\". Tasks are now de-duplicated by label, the identifier everything looks up.",
+    summary: "Task discovery no longer loses a label: a tasks.json entry that reuses a Makefile, Cargo or package.json command under its own name used to drop the convention task entirely, so a preLaunchTask or Tasks: Run Task pick by that name reported \"not found\". Tasks are now de-duplicated by label and command together, so a label the workspace declares always survives.",
 }];

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -383,7 +383,11 @@ pub(crate) fn strip_jsonc(text: &str) -> String {
 /// reported "not found" for a task the workspace plainly declared (#336).
 /// The one thing that still collapses is a true repeat: the same label
 /// running the same line. A user who relabels `cargo build` sees it listed
-/// under both names, by design.
+/// under both names, by design. Two tasks sharing a label with DIFFERENT
+/// commands both survive here; the lookups keyed on the label alone
+/// (`preLaunchTask`, task-pane reuse) then resolve to the first, so a
+/// workspace that reuses a label across commands gets first-source-wins at
+/// the lookup, not in this list.
 fn dedup(tasks: Vec<Task>) -> Vec<Task> {
     let mut seen = BTreeSet::new();
     tasks
@@ -578,9 +582,8 @@ mod tests {
     }
 
     /// Only a true repeat collapses: the same label running the same line.
-    /// A tasks.json entry that reuses a label with a different command is
-    /// first-source-wins on the label; one that relabels a convention
-    /// command lists under both names, by design.
+    /// One that relabels a convention command lists under both names, by
+    /// design.
     #[test]
     fn only_a_repeated_label_and_command_pair_collapses() {
         let tmp = tempfile::tempdir().unwrap();
@@ -590,27 +593,63 @@ mod tests {
             tmp.path().join(".vscode/tasks.json"),
             r#"{ "tasks": [
               { "label": "make build", "type": "shell", "command": "make build" },
-              { "label": "make build", "type": "shell", "command": "make build" },
               { "label": "Build", "type": "shell", "command": "make build" }
             ] }"#,
         )
         .unwrap();
         let tasks = discover_tasks(tmp.path());
-        let pairs: Vec<(&str, &str)> = tasks
+        let rows: Vec<(&str, &str, &str)> = tasks
             .iter()
-            .map(|t| (t.label.as_str(), t.command.as_str()))
+            .map(|t| (t.label.as_str(), t.command.as_str(), t.source.as_str()))
             .collect();
+        let repeats: Vec<_> = rows
+            .iter()
+            .filter(|r| (r.0, r.1) == ("make build", "make build"))
+            .collect();
+        assert_eq!(repeats.len(), 1, "the exact repeat folds to one: {rows:?}");
         assert_eq!(
-            pairs
-                .iter()
-                .filter(|p| **p == ("make build", "make build"))
-                .count(),
-            1,
-            "the exact repeat (tasks.json twice, then the Makefile) folds to one: {pairs:?}"
+            repeats[0].2, "tasks.json",
+            "and the first source wins over the Makefile's"
         );
         assert!(
-            pairs.contains(&("Build", "make build")),
-            "a relabelled command keeps its own entry: {pairs:?}"
+            rows.iter().any(|r| (r.0, r.1) == ("Build", "make build")),
+            "a relabelled command keeps its own entry: {rows:?}"
+        );
+    }
+
+    /// A label reused for a DIFFERENT command is not a repeat: both tasks
+    /// survive, and the label-keyed lookup (the `preLaunchTask` rule) takes
+    /// the first declared.
+    #[test]
+    fn a_label_reused_for_a_different_command_keeps_both_and_the_lookup_takes_the_first() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".vscode")).unwrap();
+        std::fs::write(
+            tmp.path().join(".vscode/tasks.json"),
+            r#"{ "tasks": [
+              { "label": "Build", "type": "shell", "command": "make a" },
+              { "label": "Build", "type": "shell", "command": "make b" }
+            ] }"#,
+        )
+        .unwrap();
+        let tasks = discover_tasks(tmp.path());
+        let builds: Vec<&str> = tasks
+            .iter()
+            .filter(|t| t.label == "Build")
+            .map(|t| t.command.as_str())
+            .collect();
+        assert_eq!(
+            builds,
+            ["make a", "make b"],
+            "both survive, declaration order kept"
+        );
+        assert_eq!(
+            tasks
+                .iter()
+                .find(|t| t.label == "Build")
+                .map(|t| t.command.as_str()),
+            Some("make a"),
+            "a lookup by label resolves to the first declared"
         );
     }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -42,7 +42,7 @@ pub struct Task {
 
 /// Every task the workspace's manifests declare, in source priority
 /// order (tasks.json first so an explicit VS Code default-build wins).
-/// Duplicate command lines are dropped, first source wins.
+/// Duplicate labels are dropped, first source wins.
 pub fn discover_tasks(root: &Path) -> Vec<Task> {
     let mut out = Vec::new();
     out.extend(vscode_tasks(root));
@@ -371,11 +371,17 @@ pub(crate) fn strip_jsonc(text: &str) -> String {
     out
 }
 
+/// One task per label, first source winning. The label is the identifier
+/// everything else keys on (`preLaunchTask`, the Run Task picker), so it is
+/// the only thing safe to collapse: de-duplicating by command line dropped
+/// a convention source's label whenever tasks.json reused its command under
+/// another name, and the lookup then reported "not found" for a task the
+/// workspace plainly declared (#336).
 fn dedup(tasks: Vec<Task>) -> Vec<Task> {
     let mut seen = BTreeSet::new();
     tasks
         .into_iter()
-        .filter(|t| seen.insert(t.command.clone()))
+        .filter(|t| seen.insert(t.label.clone()))
         .collect()
 }
 
@@ -505,6 +511,46 @@ mod tests {
                 .iter()
                 .any(|t| t.command == "cargo build" && t.is_build),
             "cargo build is the build task"
+        );
+    }
+
+    /// Everything that looks a task up does so by label, so de-duplication
+    /// must key on labels too: a tasks.json entry that reuses a convention
+    /// source's command line under its own name must not make the
+    /// convention label unfindable (#336).
+    #[test]
+    fn a_relabelled_command_keeps_the_convention_label_findable() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(tmp.path().join(".vscode")).unwrap();
+        std::fs::write(
+            tmp.path().join(".vscode/tasks.json"),
+            r#"{ "tasks": [ { "label": "Build Project", "type": "shell", "command": "cargo build" } ] }"#,
+        )
+        .unwrap();
+        let tasks = discover_tasks(tmp.path());
+        let labels: Vec<&str> = tasks.iter().map(|t| t.label.as_str()).collect();
+        assert!(labels.contains(&"Build Project"), "{labels:?}");
+        assert!(
+            labels.contains(&"cargo build"),
+            "the Cargo label must survive a tasks.json entry with the same command: {labels:?}"
+        );
+        // Identical labels still collapse, first source winning.
+        std::fs::write(
+            tmp.path().join(".vscode/tasks.json"),
+            r#"{ "tasks": [ { "label": "cargo build", "type": "shell", "command": "cargo build --release" } ] }"#,
+        )
+        .unwrap();
+        let tasks = discover_tasks(tmp.path());
+        let builds: Vec<&Task> = tasks.iter().filter(|t| t.label == "cargo build").collect();
+        assert_eq!(builds.len(), 1, "one task per label: {labels:?}");
+        assert_eq!(
+            builds[0].command, "cargo build --release",
+            "tasks.json comes first"
         );
     }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -42,7 +42,7 @@ pub struct Task {
 
 /// Every task the workspace's manifests declare, in source priority
 /// order (tasks.json first so an explicit VS Code default-build wins).
-/// Duplicate labels are dropped, first source wins.
+/// A repeated (label, command line) pair is dropped, first source wins.
 pub fn discover_tasks(root: &Path) -> Vec<Task> {
     let mut out = Vec::new();
     out.extend(vscode_tasks(root));
@@ -91,10 +91,13 @@ fn vscode_tasks(root: &Path) -> Vec<Task> {
                     line.push_str(a);
                 }
             }
+            // VS Code labels a label-less entry by its full command line,
+            // not the bare program: three label-less `npm` entries must
+            // stay three tasks, not collapse to one "npm".
             let label = t
                 .get("label")
                 .and_then(|l| l.as_str())
-                .unwrap_or(command)
+                .unwrap_or(&line)
                 .to_string();
             let is_build = match t.get("group") {
                 Some(serde_json::Value::String(s)) => s == "build",
@@ -371,17 +374,21 @@ pub(crate) fn strip_jsonc(text: &str) -> String {
     out
 }
 
-/// One task per label, first source winning. The label is the identifier
-/// everything else keys on (`preLaunchTask`, the Run Task picker), so it is
-/// the only thing safe to collapse: de-duplicating by command line dropped
-/// a convention source's label whenever tasks.json reused its command under
-/// another name, and the lookup then reported "not found" for a task the
-/// workspace plainly declared (#336).
+/// One task per (label, command line), first source winning. The label is
+/// the identifier everything else keys on (`preLaunchTask`, the Run Task
+/// picker), so a label the workspace declares must survive; the command is
+/// what runs, so a distinct command must survive too. De-duplicating by
+/// command line alone dropped a convention source's label whenever
+/// tasks.json reused its command under another name, and the lookup then
+/// reported "not found" for a task the workspace plainly declared (#336).
+/// The one thing that still collapses is a true repeat: the same label
+/// running the same line. A user who relabels `cargo build` sees it listed
+/// under both names, by design.
 fn dedup(tasks: Vec<Task>) -> Vec<Task> {
     let mut seen = BTreeSet::new();
     tasks
         .into_iter()
-        .filter(|t| seen.insert(t.label.clone()))
+        .filter(|t| seen.insert((t.label.clone(), t.command.clone())))
         .collect()
 }
 
@@ -539,18 +546,71 @@ mod tests {
             labels.contains(&"cargo build"),
             "the Cargo label must survive a tasks.json entry with the same command: {labels:?}"
         );
-        // Identical labels still collapse, first source winning.
+    }
+
+    /// A label-less tasks.json entry is labelled by its whole command line
+    /// (VS Code's rule), so several entries sharing a program stay distinct
+    /// tasks instead of collapsing to one bare "npm".
+    #[test]
+    fn label_less_entries_sharing_a_program_stay_distinct() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".vscode")).unwrap();
         std::fs::write(
             tmp.path().join(".vscode/tasks.json"),
-            r#"{ "tasks": [ { "label": "cargo build", "type": "shell", "command": "cargo build --release" } ] }"#,
+            r#"{ "tasks": [
+              { "type": "shell", "command": "npm", "args": ["run", "build"] },
+              { "type": "shell", "command": "npm", "args": ["run", "test"] },
+              { "type": "shell", "command": "npm", "args": ["run", "lint"] }
+            ] }"#,
         )
         .unwrap();
         let tasks = discover_tasks(tmp.path());
-        let builds: Vec<&Task> = tasks.iter().filter(|t| t.label == "cargo build").collect();
-        assert_eq!(builds.len(), 1, "one task per label: {labels:?}");
+        let pairs: Vec<(&str, &str)> = tasks
+            .iter()
+            .map(|t| (t.label.as_str(), t.command.as_str()))
+            .collect();
+        for cmd in ["npm run build", "npm run test", "npm run lint"] {
+            assert!(
+                pairs.contains(&(cmd, cmd)),
+                "{cmd} must survive as its own task, labelled by its line: {pairs:?}"
+            );
+        }
+    }
+
+    /// Only a true repeat collapses: the same label running the same line.
+    /// A tasks.json entry that reuses a label with a different command is
+    /// first-source-wins on the label; one that relabels a convention
+    /// command lists under both names, by design.
+    #[test]
+    fn only_a_repeated_label_and_command_pair_collapses() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Makefile"), "build:\n\ttrue\n").unwrap();
+        std::fs::create_dir_all(tmp.path().join(".vscode")).unwrap();
+        std::fs::write(
+            tmp.path().join(".vscode/tasks.json"),
+            r#"{ "tasks": [
+              { "label": "make build", "type": "shell", "command": "make build" },
+              { "label": "make build", "type": "shell", "command": "make build" },
+              { "label": "Build", "type": "shell", "command": "make build" }
+            ] }"#,
+        )
+        .unwrap();
+        let tasks = discover_tasks(tmp.path());
+        let pairs: Vec<(&str, &str)> = tasks
+            .iter()
+            .map(|t| (t.label.as_str(), t.command.as_str()))
+            .collect();
         assert_eq!(
-            builds[0].command, "cargo build --release",
-            "tasks.json comes first"
+            pairs
+                .iter()
+                .filter(|p| **p == ("make build", "make build"))
+                .count(),
+            1,
+            "the exact repeat (tasks.json twice, then the Makefile) folds to one: {pairs:?}"
+        );
+        assert!(
+            pairs.contains(&("Build", "make build")),
+            "a relabelled command keeps its own entry: {pairs:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- `discover_tasks` de-duplicated by **command line** while every lookup (`preLaunchTask`, Tasks: Run Task) keys on **label**, so a `tasks.json` entry reusing a convention source's command under its own name made the convention label unfindable.
- De-duplication now keys on the label. Identical labels still collapse to the first source; a relabelled command no longer erases the original task.
- Bump to 0.1.793 with a matching release note.

## Test plan
- [x] Red: new `a_relabelled_command_keeps_the_convention_label_findable` failed on main with `["Build Project", "cargo test", "cargo clippy", "cargo run"]` — exactly the issue's demonstration.
- [x] Green after the fix; `tasks::` module passes (11 tests); clippy `-D warnings` clean; `cargo fmt --check` clean.

Closes #336