### PR TITLE
fix(pair): tell an unopenable host lock apart from a busy one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.793"
+version = "0.1.794"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.793"
+version = "0.1.794"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/MULTIPLAYER.md
+++ b/docs/MULTIPLAYER.md
@@ -612,8 +612,10 @@ interaction into turn-based driver/navigator pairing:
   `flock` on `<hash>.pair-host.lock` (`session::try_acquire_pair_host_lock`)
   guards it, so a second window is refused ("hosted by another croft
   window") instead of both claiming owner site 1 and corrupting the buffer.
-  The OS drops the lock when the holder exits, so a crashed host hands off
-  automatically. (The non-hosting window does not yet observe the owner's
+  A lock file that cannot be opened at all (a missing or read-only config
+  directory, an fd limit) is reported as exactly that, with the path and
+  the OS error, never as contention (#337). The OS drops the lock when the
+  holder exits, so a crashed host hands off automatically. (The non-hosting window does not yet observe the owner's
   edits as a guest — a documented follow-up; `croft attach` is the shared
   path for that today.)
 - **Ask turns (may edit).** Right-click the gutter ("Ask Navigator"), a
@@ -701,7 +703,8 @@ interaction into turn-based driver/navigator pairing:
   fixing the backend all re-activate. A window whose spawn failed also
   releases the single-host lock (and its same-tick owner self-appointment),
   so another croft window in the workspace can host instead; the losing
-  window announces the refusal once and keeps polling silently for
+  window announces the refusal once per reason (a busy lock that becomes
+  an unopenable one, or the reverse, is announced again) and keeps polling silently for
   takeover. Teardown on unseat runs on a
   detached thread so the 2s grace-kill never freezes the UI, and the exit
   paths (drop-to-local, self-update exec) reap the child synchronously

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3272,7 +3272,8 @@ pub struct App {
     /// repaint). The KIND is latched, not just the fact, so a refusal that
     /// changes reason (an fd limit clears and another window now holds the
     /// lock, or the reverse) is announced again rather than leaving a
-    /// message that is no longer true (#337).
+    /// message that is no longer true (#337). Per kind, not per message: an
+    /// open failure whose errno changes keeps the first announcement.
     pair_lock_denied: Option<PairLockDenial>,
     /// Proactive navigator looks (docs/MULTIPLAYER.md): a completed new
     /// construct plus a typing pause hands the seated navigator a

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20492,11 +20492,11 @@ impl App {
             // host (keep checking — take over when that croft exits).
             if self.pair_host_lock.is_none() {
                 match crate::session::try_acquire_pair_host_lock(&self.pair_host_lock_path) {
-                    Some(lock) => {
+                    Ok(lock) => {
                         self.pair_host_lock = Some(lock);
                         self.pair_lock_denied = false;
                     }
-                    None => {
+                    Err(e) => {
                         // Announced ONCE: the takeover poll keeps running
                         // every second, and re-announcing clobbered the
                         // window's status line forever at a 1 Hz repaint.
@@ -20504,10 +20504,21 @@ impl App {
                             return false;
                         }
                         self.pair_lock_denied = true;
-                        self.status = format!(
-                            "Navigator '{}' is hosted by another croft window in this workspace",
-                            record.name
-                        );
+                        // Busy and unopenable read the same from here (no
+                        // host this tick, poll again) but not to the user:
+                        // one has a window to close, the other has a path
+                        // to fix and no window anywhere (#337).
+                        self.status = match e {
+                            crate::session::PairHostLockError::Busy => format!(
+                                "Navigator '{}' is hosted by another croft window in this workspace",
+                                record.name
+                            ),
+                            crate::session::PairHostLockError::Io(e) => format!(
+                                "Navigator '{}': cannot open host lock {}: {e}",
+                                record.name,
+                                self.pair_host_lock_path.display()
+                            ),
+                        };
                         return true;
                     }
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -840,6 +840,14 @@ enum CreateKind {
     Folder,
 }
 
+/// Why the single-host lock was last refused, for announcing each reason
+/// once (see `App::pair_lock_denied`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PairLockDenial {
+    Busy,
+    Io,
+}
+
 /// State of a background self-update observed by a remote-launched croft.
 /// `Idle` is the steady state; `InProgress` paints an "Updating" hint in
 /// the status bar; `Ready` arms the re-exec into the freshly-shipped binary.
@@ -3258,11 +3266,14 @@ pub struct App {
     /// [`navigator_down`]. Content, not mtime: a same-grain rewrite on a
     /// coarse-timestamp filesystem keeps its mtime.
     last_pair_record_raw: Option<Vec<u8>>,
-    /// Whether the "hosted by another croft window" refusal has already
-    /// been announced: the losing window keeps polling for takeover every
-    /// second, and re-announcing each poll clobbered its status line
-    /// forever (and forced a 1 Hz repaint).
-    pair_lock_denied: bool,
+    /// Which host-lock refusal has already been announced: the losing
+    /// window keeps polling for takeover every second, and re-announcing
+    /// each poll clobbered its status line forever (and forced a 1 Hz
+    /// repaint). The KIND is latched, not just the fact, so a refusal that
+    /// changes reason (an fd limit clears and another window now holds the
+    /// lock, or the reverse) is announced again rather than leaving a
+    /// message that is no longer true (#337).
+    pair_lock_denied: Option<PairLockDenial>,
     /// Proactive navigator looks (docs/MULTIPLAYER.md): a completed new
     /// construct plus a typing pause hands the seated navigator a
     /// comment-only turn on its own. Opt-out via
@@ -4311,7 +4322,7 @@ impl App {
             pair_host_lock: None,
             navigator_down: false,
             last_pair_record_raw: None,
-            pair_lock_denied: false,
+            pair_lock_denied: None,
             pair_noted_files: std::collections::BTreeSet::new(),
             proactive_navigator_enabled: !loaded_prefs.disable_proactive_navigator,
             proactive_scanned: std::collections::HashMap::new(),
@@ -20449,7 +20460,7 @@ impl App {
             // Deactivation clears the death latch, so `croft pair --off`
             // then `croft pair` (or a palette off/on) re-activates.
             self.navigator_down = false;
-            self.pair_lock_denied = false;
+            self.pair_lock_denied = None;
             if let Some(host) = self.pair_host.take() {
                 // Drop tears the seat down; its parked caret goes with it.
                 let sites = host.caret_sites();
@@ -20494,16 +20505,20 @@ impl App {
                 match crate::session::try_acquire_pair_host_lock(&self.pair_host_lock_path) {
                     Ok(lock) => {
                         self.pair_host_lock = Some(lock);
-                        self.pair_lock_denied = false;
+                        self.pair_lock_denied = None;
                     }
                     Err(e) => {
-                        // Announced ONCE: the takeover poll keeps running
-                        // every second, and re-announcing clobbered the
-                        // window's status line forever at a 1 Hz repaint.
-                        if self.pair_lock_denied {
+                        // Announced ONCE per reason: the takeover poll keeps
+                        // running every second, and re-announcing clobbered
+                        // the window's status line forever at a 1 Hz repaint.
+                        let denial = match &e {
+                            crate::session::PairHostLockError::Busy => PairLockDenial::Busy,
+                            crate::session::PairHostLockError::Io(_) => PairLockDenial::Io,
+                        };
+                        if self.pair_lock_denied == Some(denial) {
                             return false;
                         }
-                        self.pair_lock_denied = true;
+                        self.pair_lock_denied = Some(denial);
                         // Busy and unopenable read the same from here (no
                         // host this tick, poll again) but not to the user:
                         // one has a window to close, the other has a path

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -27269,6 +27269,96 @@ fn only_one_croft_self_appoints_the_navigator_owner() {
     );
 }
 
+/// A lock file croft cannot open is not another window (#337): the status
+/// names the path and the error, never "another croft". And the refusal is
+/// latched by KIND: when the reason changes (the directory appears but a
+/// second window now holds the flock) the new reason is announced, and
+/// when the lock frees this window hosts.
+#[test]
+fn an_unopenable_host_lock_is_reported_as_such_and_re_announced_when_the_reason_changes() {
+    use std::time::{Duration, Instant};
+    let tmp = tempfile::tempdir().unwrap();
+    let socket = tmp.path().join("collab.sock");
+    {
+        let s = socket.clone();
+        std::thread::spawn(move || {
+            let _ = crate::collab::relay_serve(&s);
+        });
+    }
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !crate::session::is_alive(&socket) {
+        assert!(Instant::now() < deadline, "relay never came up");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let lock_dir = tmp.path().join("no-such-dir");
+    let lock_path = lock_dir.join("host.lock");
+    let mut b = App::new(tmp.path().to_path_buf()).unwrap();
+    b.pair_record_path = tmp.path().join("b.pair.json");
+    b.pair_socket = socket.clone();
+    b.pair_host_lock_path = lock_path.clone();
+    b.pair_spawn_override = Some(Box::new(local_test_spawn));
+    crate::session::write_pair_record(
+        &b.pair_record_path,
+        &crate::session::PairRecord {
+            model: None,
+            name: "nav".into(),
+            enabled: true,
+            task: None,
+            provider: None,
+            base_url: None,
+        },
+    )
+    .unwrap();
+    b.last_pair_check = None;
+    b.maybe_seat_navigator();
+    assert!(b.pair_host.is_none(), "cannot host without the lock");
+    assert!(
+        b.status.contains("cannot open host lock") && b.status.contains("no-such-dir"),
+        "an unopenable lock names the path and the error, got: {}",
+        b.status
+    );
+    assert!(
+        !b.status.to_lowercase().contains("another croft"),
+        "an open failure must never be blamed on another window: {}",
+        b.status
+    );
+
+    // Same reason next tick: quiet.
+    b.status = String::from("Saved src/foo.rs");
+    b.last_pair_check = None;
+    assert!(
+        !b.maybe_seat_navigator(),
+        "an unchanged refusal stays quiet"
+    );
+    assert_eq!(b.status, "Saved src/foo.rs");
+
+    // The directory appears, but another window holds the flock: the
+    // reason changed, so it is announced.
+    std::fs::create_dir_all(&lock_dir).unwrap();
+    let holder = crate::session::try_acquire_pair_host_lock(&lock_path).expect("holder acquires");
+    b.last_pair_check = None;
+    assert!(
+        b.maybe_seat_navigator(),
+        "a changed reason dirties the frame"
+    );
+    assert!(
+        b.status.to_lowercase().contains("another croft"),
+        "now it IS another window, got: {}",
+        b.status
+    );
+
+    // The holder exits: this window takes over.
+    drop(holder);
+    b.last_pair_check = None;
+    b.maybe_seat_navigator();
+    assert!(
+        b.pair_host.is_some(),
+        "B hosts once the lock frees: {}",
+        b.status
+    );
+    assert!(b.pair_host_lock.is_some());
+}
+
 /// A local-provider seat for tests: connects to the workspace relay but
 /// spawns no child process (the endpoint is never contacted until a turn).
 fn local_test_spawn(cfg: &crate::pair::PairConfig) -> anyhow::Result<crate::pair_host::PairHost> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -27347,6 +27347,19 @@ fn an_unopenable_host_lock_is_reported_as_such_and_re_announced_when_the_reason_
         b.status
     );
 
+    // The reverse transition: the holder is still there but the lock's
+    // directory vanishes, so the refusal is an open failure again - and
+    // that change of reason is announced too.
+    std::fs::remove_dir_all(&lock_dir).unwrap();
+    b.last_pair_check = None;
+    assert!(b.maybe_seat_navigator(), "Busy -> Io is a changed reason");
+    assert!(
+        b.status.contains("cannot open host lock"),
+        "the open failure is named again, got: {}",
+        b.status
+    );
+    std::fs::create_dir_all(&lock_dir).unwrap();
+
     // The holder exits: this window takes over.
     drop(holder);
     b.last_pair_check = None;

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "Task discovery no longer loses a label: a tasks.json entry that reuses a Makefile, Cargo or package.json command under its own name used to drop the convention task entirely, so a preLaunchTask or Tasks: Run Task pick by that name reported \"not found\". Tasks are now de-duplicated by label and command together, so a label the workspace declares always survives.",
+    summary: "A navigator host lock croft cannot create or open (a missing or read-only config directory, an fd limit) is now reported as exactly that, with the path and the error, instead of as \"hosted by another croft window\" when no other window exists.",
 }];

--- a/src/session.rs
+++ b/src/session.rs
@@ -79,21 +79,35 @@ pub(crate) fn pair_host_lock_path(workspace: &Path) -> PathBuf {
 
 /// Holds the workspace's pair-host lock; the flock releases when this (and its
 /// file) drop.
+#[derive(Debug)]
 pub(crate) struct PairHostLock {
     _file: std::fs::File,
 }
 
-/// Try to claim the single-host lock at `path` without blocking. `Some` means
-/// this croft may self-appoint owner; `None` means another croft already holds
+/// Why the single-host lock could not be taken. The two are kept apart
+/// because they call for opposite remedies: `Busy` means close the other
+/// window, `Io` means there is no other window and the lock file itself
+/// (its directory, its permissions, the fd table) needs fixing. Folding them
+/// together reported a missing config directory as contention (#337).
+#[derive(Debug)]
+pub(crate) enum PairHostLockError {
+    /// Another croft holds the lock.
+    Busy,
+    /// The lock file could not be created or opened.
+    Io(std::io::Error),
+}
+
+/// Try to claim the single-host lock at `path` without blocking. `Ok` means
+/// this croft may self-appoint owner; `Busy` means another croft already holds
 /// it and this one must not host (else two owners would both claim site 1 and
-/// corrupt the shared buffer).
-pub(crate) fn try_acquire_pair_host_lock(path: &Path) -> Option<PairHostLock> {
+/// corrupt the shared buffer); `Io` means the lock could not be opened at all.
+pub(crate) fn try_acquire_pair_host_lock(path: &Path) -> Result<PairHostLock, PairHostLockError> {
     let file = std::fs::OpenOptions::new()
         .create(true)
         .truncate(false)
         .write(true)
         .open(path)
-        .ok()?;
+        .map_err(PairHostLockError::Io)?;
     #[cfg(unix)]
     {
         use std::os::unix::io::AsRawFd;
@@ -102,10 +116,17 @@ pub(crate) fn try_acquire_pair_host_lock(path: &Path) -> Option<PairHostLock> {
         // instances. LOCK_NB: fail fast instead of blocking the tick.
         let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
         if rc != 0 {
-            return None;
+            // EWOULDBLOCK is contention; anything else (EBADF, ENOLCK, an
+            // interrupted call) is the environment, not another window.
+            let e = std::io::Error::last_os_error();
+            return Err(if e.kind() == std::io::ErrorKind::WouldBlock {
+                PairHostLockError::Busy
+            } else {
+                PairHostLockError::Io(e)
+            });
         }
     }
-    Some(PairHostLock { _file: file })
+    Ok(PairHostLock { _file: file })
 }
 
 /// What `croft pair` records for the workspace's resident navigator.
@@ -688,14 +709,32 @@ mod tests {
         let path = dir.path().join("x.pair-host.lock");
         let first = try_acquire_pair_host_lock(&path).expect("first acquires");
         assert!(
-            try_acquire_pair_host_lock(&path).is_none(),
-            "a second croft must be refused while the first holds the lock"
+            matches!(
+                try_acquire_pair_host_lock(&path),
+                Err(PairHostLockError::Busy)
+            ),
+            "a second croft must be refused as BUSY while the first holds the lock"
         );
         drop(first);
         assert!(
-            try_acquire_pair_host_lock(&path).is_some(),
+            try_acquire_pair_host_lock(&path).is_ok(),
             "the lock frees when the holder drops"
         );
+    }
+
+    /// A lock file croft cannot open is not another window holding it: the
+    /// two failures were folded into one `None` and the caller reported a
+    /// missing config directory as contention (#337).
+    #[test]
+    fn an_unopenable_lock_file_is_an_io_error_not_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("no-such-dir").join("x.pair-host.lock");
+        match try_acquire_pair_host_lock(&path) {
+            Err(PairHostLockError::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::NotFound, "{e}");
+            }
+            other => panic!("expected an io error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -114,18 +114,29 @@ pub(crate) fn try_acquire_pair_host_lock(path: &Path) -> Result<PairHostLock, Pa
         // flock is per open-file-description, so two independent opens contend
         // even within one process — the mutual exclusion we want across croft
         // instances. LOCK_NB: fail fast instead of blocking the tick.
-        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-        if rc != 0 {
-            // EWOULDBLOCK is contention; anything else (EBADF, ENOLCK, an
-            // interrupted call) is the environment, not another window.
+        // errno is read in the same breath as the call: anything run in
+        // between could overwrite it and turn a Busy into a spurious Io.
+        // EINTR carries no information for the user (nothing at the path
+        // to fix), so it is retried like every other syscall site here.
+        let e = loop {
+            let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
             let e = std::io::Error::last_os_error();
-            return Err(if e.kind() == std::io::ErrorKind::WouldBlock {
-                PairHostLockError::Busy
-            } else {
-                PairHostLockError::Io(e)
-            });
-        }
+            if rc == 0 {
+                return Ok(PairHostLock { _file: file });
+            }
+            if e.kind() != std::io::ErrorKind::Interrupted {
+                break e;
+            }
+        };
+        // EWOULDBLOCK is contention; anything else (ENOLCK, EROFS) is the
+        // environment, not another window.
+        Err(if e.kind() == std::io::ErrorKind::WouldBlock {
+            PairHostLockError::Busy
+        } else {
+            PairHostLockError::Io(e)
+        })
     }
+    #[cfg(not(unix))]
     Ok(PairHostLock { _file: file })
 }
 


### PR DESCRIPTION
## Summary
- `try_acquire_pair_host_lock` folded "another croft holds the flock" and "the lock file could not be opened" into one `None`; the caller reported both as *hosted by another croft window*, so a missing/read-only config directory or an fd limit sent the user after a window that does not exist (#337).
- It now returns `Result<PairHostLock, PairHostLockError>` with `Busy` and `Io(std::io::Error)`. A flock failure other than `EWOULDBLOCK` is `Io` as well.
- The caller keeps the existing wording for `Busy` and, for `Io`, names the lock path and the OS error. Both stay announced once per denial, as before.
- Bump to 0.1.794 with a matching release note.

## Test plan
- [x] Red: `an_unopenable_lock_file_is_an_io_error_not_busy` and the reshaped exclusivity test fail to compile against the old `Option` API.
- [x] Green: `session::tests::` (49 passed), `a_record_rewrite_re_arms_a_downed_navigator` passes, clippy `-D warnings` clean, `cargo fmt --check` clean.

Closes #337