### PR TITLE
test(pair): wait for the seat's site ids, not for a neighbouring caret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.794"
+version = "0.1.795"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.794"
+version = "0.1.795"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -2733,10 +2733,12 @@ mod tests {
         harness.wait_until("the ask turn's caret", |h| {
             h.carets().iter().any(|(n, r, _)| n == "asker" && *r == 1)
         });
-        assert!(
-            !asker.caret_sites().is_empty(),
-            "the seat exposes its per-file site ids (its wire identity)"
-        );
+        // The caret reaching the owner and the seat recording its site id
+        // are two arrivals, not one: the assertion must wait for the state
+        // it checks, not for a neighbour that usually lands first (#338).
+        harness.wait_until("the seat's per-file site ids (its wire identity)", |_| {
+            !asker.caret_sites().is_empty()
+        });
 
         let mut cmd = Command::new("cat");
         cmd.stdin(Stdio::piped());

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -61,5 +61,5 @@ pub struct ReleaseNote {
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
     kind: NoteKind::Fix,
-    summary: "A navigator host lock croft cannot create or open (a missing or read-only config directory, an fd limit) is now reported as exactly that, with the path and the error, instead of as \"hosted by another croft window\" when no other window exists.",
+    summary: "No user-facing change: a load-sensitive navigator test now waits for the state it asserts (the seat's per-file site ids) rather than for the caret that usually lands just before it.",
 }];


### PR DESCRIPTION
## Summary
- `ask_and_reply_turns_park_the_navigator_caret` waited for the ask turn's caret to reach the owner, then asserted that the seat had recorded its per-file site ids — a different arrival that usually, but not always, lands first (#338).
- The assertion is now a `wait_until` on the state it checks. No behaviour change in the code under test.
- Bump to 0.1.795 (CI requires it for any `src/` change) with a release note saying so.

## Test plan
- [x] Test passes 3/3 locally; clippy `-D warnings` clean; `cargo fmt --check` clean.
- [ ] The flake only reproduces under the whole suite's load, so the proof is CI staying green over the next runs rather than a single local pass.

Closes #338