### PR TITLE
fix(ci): the doc-ownership gate sees every item kind, and its own branch's history

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,20 +65,29 @@ A PR that changes anything compiled into the binary (`src/`, `assets/`,
 CI enforces both (the `version bump + release notes` job). Docs, CI, and
 test-only PRs (`src/app/tests.rs`, `tests/`) are exempt.
 
-## After adding a function, check the doc below it
+## Insert new items AFTER a complete item, never above a doc block
 
-Rust attaches a `///` block to whatever item **follows** it. Insert a function
-between an existing one and its doc comment and that prose silently becomes the
-newcomer's: no compiler error, no failing test, no clippy lint. The build stays
-green and the rendered rustdoc is *confidently wrong* rather than absent, which
-is worse - absent docs send a reader to the code, wrong docs stop them looking.
+Rust attaches a `///` block to whatever item **follows** it. Insert anything
+between an existing item and its doc comment and that prose silently becomes
+the newcomer's: no compiler error, no failing test, no clippy lint. The build
+stays green and the rendered rustdoc is *confidently wrong* rather than
+absent, which is worse - absent docs send a reader to the code, wrong docs
+stop them looking.
 
-So after adding a `fn`, confirm the doc block above the **next** `fn` still
-describes that next `fn`.
+The habit that avoids it entirely is positional: add a new item after a
+complete item, not directly above a `///` block. Where that is not possible,
+confirm the doc block above the **next** item still describes that next item.
+
+This is not only about functions. A `const` inserted above another `const`'s
+doc captures it exactly the same way, and did so twice in one day before the
+gate could see it.
 
 CI catches what the habit misses (the `doc comments stay with their function`
-job): a function that had a doc comment at the merge base and has none at your
-head is the fingerprint this insertion leaves. If a removal is deliberate, say
+job): an item that had a doc comment at the merge base and has none at your
+head is the fingerprint this insertion leaves. It covers `fn`, `const`,
+`static`, `struct`, `enum`, `union`, `trait`, `type` and `macro_rules!`, and
+for a file your branch ADDS it compares your commits pairwise, since a file
+with no base version has no merge-base history to lose documentation against. If a removal is deliberate, say
 so in a commit message on the branch:
 
 ```text

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -34,8 +34,14 @@ ITEM = re.compile(
     # legal, and rustfmt leaves it alone inside macro bodies. Skipping it here
     # costs nothing and stops the item from being invisible.
     r"^\s*(?:#\[[^\]]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?"
-    r"(?:default\s+)?(?:async\s+)?(?:unsafe\s+)?(?:extern\s+\"[^\"]*\"\s+)?"
-    r"(?:const\s+)?(?:"
+    # Rust's own qualifier order: default, const, async, unsafe, extern. The
+    # optional `const` here is the one in `const fn`, and it has to sit where
+    # Rust puts it: trailing the others made `pub const unsafe fn f()` match
+    # nothing at all, so the function was invisible to the gate rather than
+    # merely undocumented. The `const A: u8` declaration is a branch below,
+    # reached when this optional one is not taken.
+    r"(?:default\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?"
+    r"(?:extern\s+\"[^\"]*\"\s+)?(?:"
     r"fn\s+([A-Za-z_]\w*)"
     r"|const\s+([A-Za-z_]\w*)\s*:"
     r"|static\s+(?:mut\s+)?([A-Za-z_]\w*)\s*:"
@@ -167,9 +173,13 @@ def main():
                         and name in after
                         and not after[name]
                         and (f, name) not in exempt
-                        and (f, name) not in losses
+                        and not any(l[0] == f and l[1] == name for l in losses)
                     ):
-                        losses.append((f, name))
+                        # Name the commit the doc was last seen at. Saying
+                        # "at {base}" would be wrong for a file the branch
+                        # ADDED: it does not exist there, and a reader sent
+                        # to that revision finds nothing.
+                        losses.append((f, name, older))
     for f in changed:
         # A path can legitimately be absent on one side: the branch added the
         # file, or deleted it. That is the one git failure this tolerates -
@@ -180,10 +190,10 @@ def main():
         after = documented(git("show", f"{head}:{f}", allow_missing_path=True))
         for name, had_doc in before.items():
             if had_doc and name in after and not after[name] and (f, name) not in exempt:
-                losses.append((f, name))
-    for f, name in losses:
+                losses.append((f, name, base))
+    for f, name, at in losses:
         print(
-            f"::error file={f}::`{name}` had a doc comment at {base[:12]} and has none now. "
+            f"::error file={f}::`{name}` had a doc comment at {at[:12]} and has none now. "
             "A doc block above it was most likely captured by an item inserted between the two "
             "(#314), which hands one item's prose to another with nothing failing. Restore it, "
             "or declare the removal with `doc-removal: " + f"{f}::{name}` in a commit message."

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -30,7 +30,10 @@ import sys
 # name is not unique enough to key on, and its methods are matched as `fn`
 # in their own right.
 ITEM = re.compile(
-    r"^\s*(?:pub(?:\([^)]*\))?\s+)?"
+    # A same-line attribute (`#[cfg(test)] const A: u8 = 1;`) is unusual but
+    # legal, and rustfmt leaves it alone inside macro bodies. Skipping it here
+    # costs nothing and stops the item from being invisible.
+    r"^\s*(?:#\[[^\]]*\]\s*)*(?:pub(?:\([^)]*\))?\s+)?"
     r"(?:default\s+)?(?:async\s+)?(?:unsafe\s+)?(?:extern\s+\"[^\"]*\"\s+)?"
     r"(?:const\s+)?(?:"
     r"fn\s+([A-Za-z_]\w*)"

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -23,7 +23,27 @@ import re
 import subprocess
 import sys
 
-FN = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:default\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?(?:extern\s+\"[^\"]*\"\s+)?fn\s+([A-Za-z_]\w*)")
+# Every item kind a doc block can sit above. `fn` alone was the original
+# scope and it let the same failure through twice in one day on `const`
+# declarations: a doc block does not care what follows it, so neither can
+# this. `impl` and bare `mod` are deliberately absent - an `impl` block's
+# name is not unique enough to key on, and its methods are matched as `fn`
+# in their own right.
+ITEM = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?"
+    r"(?:default\s+)?(?:async\s+)?(?:unsafe\s+)?(?:extern\s+\"[^\"]*\"\s+)?"
+    r"(?:const\s+)?(?:"
+    r"fn\s+([A-Za-z_]\w*)"
+    r"|const\s+([A-Za-z_]\w*)\s*:"
+    r"|static\s+(?:mut\s+)?([A-Za-z_]\w*)\s*:"
+    r"|struct\s+([A-Za-z_]\w*)"
+    r"|enum\s+([A-Za-z_]\w*)"
+    r"|union\s+([A-Za-z_]\w*)"
+    r"|trait\s+([A-Za-z_]\w*)"
+    r"|type\s+([A-Za-z_]\w*)"
+    r"|macro_rules!\s+([A-Za-z_]\w*)"
+    r")"
+)
 
 
 # The one git failure this checker tolerates, in the two spellings git uses:
@@ -35,20 +55,27 @@ MISSING_PATH = re.compile(
 )
 
 
-def git(*args, allow_missing_path=False):
+def git(*args, allow_missing_path=False, allow_fail=False):
     """Run git, failing closed.
 
     A silent failure here is worse than a crash: an errored `git diff` yields
     an empty file list, the checker reports "no documentation lost" and exits
     zero, and the gate has passed by not running.
 
-    `allow_missing_path` narrows that tolerance to exactly the expected case.
+    `allow_missing_path` narrows that tolerance to exactly the expected case,
+    and `allow_fail` is separate and narrower still: it is for a probe whose
+    exit status IS the answer, and its empty return is never read as content.
     Tolerating every non-zero exit would let an invalid revision or a
     malformed object read as empty content, which is the same fail-open bug
     one door further in.
     """
     proc = subprocess.run(["git", *args], capture_output=True, text=True)
     if proc.returncode != 0:
+        # `allow_fail` is for a PROBE whose non-zero exit is the answer
+        # (`cat-file -e` asking whether a path exists), never for a command
+        # whose output is then read as content.
+        if allow_fail:
+            return ""
         if allow_missing_path and MISSING_PATH.search(proc.stderr):
             return ""
         raise SystemExit(
@@ -68,7 +95,7 @@ def is_doc(line):
 
 
 def documented(text):
-    """Map fn name -> True when ANY definition of it carries a doc comment.
+    """Map item name -> True when ANY definition of it carries a doc comment.
 
     Keyed by name because two revisions cannot be lined up by position. Where
     a file defines the same name more than once (`new` across impl blocks),
@@ -86,9 +113,11 @@ def documented(text):
     lines = text.splitlines()
     state = {}
     for i, line in enumerate(lines):
-        m = FN.match(line)
+        m = ITEM.match(line)
         if not m:
             continue
+        # Exactly one alternative captures per match.
+        name = next(g for g in m.groups() if g)
         j = i - 1
         while j >= 0:
             s = lines[j].lstrip()
@@ -97,7 +126,7 @@ def documented(text):
                 continue
             break
         has_doc = j >= 0 and is_doc(lines[j])
-        state[m.group(1)] = state.get(m.group(1), False) or has_doc
+        state[name] = state.get(name, False) or has_doc
     return state
 
 
@@ -118,6 +147,26 @@ def main():
         if f.endswith(".rs")
     ]
     losses = []
+    # A file the branch ADDS has no base version, so `documented(before)` is
+    # empty and no loss can ever be reported in it: a doc captured within the
+    # branch is invisible to a merge-base comparison. Those files are checked
+    # commit-by-commit instead, which is the only place their history exists.
+    added = [f for f in changed if not git("cat-file", "-e", f"{base}:{f}", allow_missing_path=True, allow_fail=True)]
+    if added:
+        commits = git("log", f"{base}..{head}", "--format=%H", "--reverse").split()
+        for older, newer in zip(commits, commits[1:]):
+            for f in added:
+                before = documented(git("show", f"{older}:{f}", allow_missing_path=True))
+                after = documented(git("show", f"{newer}:{f}", allow_missing_path=True))
+                for name, had_doc in before.items():
+                    if (
+                        had_doc
+                        and name in after
+                        and not after[name]
+                        and (f, name) not in exempt
+                        and (f, name) not in losses
+                    ):
+                        losses.append((f, name))
     for f in changed:
         # A path can legitimately be absent on one side: the branch added the
         # file, or deleted it. That is the one git failure this tolerates -
@@ -132,12 +181,12 @@ def main():
     for f, name in losses:
         print(
             f"::error file={f}::`{name}` had a doc comment at {base[:12]} and has none now. "
-            "A doc block above it was most likely captured by a function inserted between the two "
-            "(#314), which hands one function's prose to another with nothing failing. Restore it, "
+            "A doc block above it was most likely captured by an item inserted between the two "
+            "(#314), which hands one item's prose to another with nothing failing. Restore it, "
             "or declare the removal with `doc-removal: " + f"{f}::{name}` in a commit message."
         )
     if losses:
-        print(f"\n{len(losses)} function(s) lost documentation.", file=sys.stderr)
+        print(f"\n{len(losses)} item(s) lost documentation.", file=sys.stderr)
         return 1
     print(f"No documentation lost across {len(changed)} changed Rust file(s).")
     return 0

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -107,6 +107,12 @@ class ItemKinds(unittest.TestCase):
             ("generic type alias", "/// doc\npub type A<T> = Vec<T>;\n"),
             ("const fn", "/// doc\npub const fn a() -> u8 { 1 }\n"),
             ("indented impl method", "impl X {\n    /// doc\n    pub fn a(&self) {}\n}\n"),
+            # Rust's qualifier order is default, const, async, unsafe, extern.
+            # Consuming `const` after the others made these match NOTHING, so
+            # the function was invisible rather than undocumented.
+            ("const unsafe fn", "/// doc\npub const unsafe fn a() {}\n"),
+            ("const extern fn", '/// doc\nconst unsafe extern "C" fn a() {}\n'),
+            ("every qualifier", "/// doc\npub default const async unsafe fn a() {}\n"),
         ]:
             state = gate.documented(text)
             self.assertTrue(
@@ -120,6 +126,75 @@ class ItemKinds(unittest.TestCase):
         not mistaken for one."""
         state = gate.documented('/// doc\nconst A: &str = "const B: u8 = 1;";\n')
         self.assertEqual(state, {"A": True}, "B is inside a string, not an item")
+
+    def test_same_named_items_are_merged_which_under_reports(self):
+        """A KNOWN limitation, pinned so it is a decision rather than a bug.
+
+        Two `fn new` in different impl blocks share one key, and "any
+        documented" wins, so a capture on one is invisible while the other
+        keeps its prose. The alternative is an occurrence-unique key, and
+        every candidate (position, index, enclosing type) has to line up
+        across two revisions that may have moved the item; a key that
+        mis-aligns turns a silent miss into a false accusation, which is
+        worse for a gate that blocks merges.
+
+        So the gate under-reports on duplicate names, deliberately. Tracked
+        for a proper fix; pinned here so a future change that alters this
+        behaviour has to look at this test and say which way it went.
+        """
+        both_documented = "/// a\nfn new() {}\n\n/// b\nfn new() {}\n"
+        one_captured = "/// a\nfn other() {}\nfn new() {}\n\n/// b\nfn new() {}\n"
+        self.assertEqual(gate.documented(both_documented), {"new": True})
+        self.assertEqual(
+            gate.documented(one_captured),
+            {"other": True, "new": True},
+            "the surviving doc on the second `new` keeps the key True, so the "
+            "capture on the first is not visible: under-reporting, not a "
+            "false alarm",
+        )
+
+    def test_the_error_names_the_revision_the_doc_was_last_seen_at(self):
+        """For a file the branch ADDED, `base` is the wrong revision to cite.
+
+        The file does not exist there, so a reader sent to it finds nothing.
+        The loss carries the commit it was last documented at.
+        """
+        import contextlib
+        import io
+        import os
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("seed.rs", "fn seed() {}\n")
+            repo.branch("work")
+            repo.commit("new.rs", DOCUMENTED_CONST)
+            documented_at = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo.path,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            repo.commit("new.rs", CAPTURED_CONST)
+
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            out = io.StringIO()
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+
+            self.assertEqual(code, 1)
+            printed = out.getvalue()
+            self.assertIn(
+                documented_at[:12],
+                printed,
+                f"the error must name the commit the doc was last seen at, said: {printed}",
+            )
 
     def test_a_rename_is_not_a_lost_doc(self):
         """A documented item renamed within a branch must not read as a loss.

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -1,0 +1,160 @@
+"""Tests for scripts/check_doc_ownership.py: the #314 doc-capture gate.
+
+The gate exists because inserting an item directly above another item's `///`
+block silently hands that prose to the newcomer, and nothing in the compiler
+or the test suite notices. These tests build real git repositories, because
+the two things the gate gets wrong are both about git history rather than
+about parsing: what a merge base can see, and what it cannot.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_doc_ownership as gate  # noqa: E402
+
+
+def run(cwd, *args):
+    subprocess.run(
+        args, cwd=cwd, check=True, capture_output=True, text=True
+    )
+
+
+class Repo:
+    """A throwaway git repo with a `main` and a branch off it."""
+
+    def __init__(self, tmp: Path):
+        self.path = tmp
+        run(tmp, "git", "init", "-q", "-b", "main")
+        run(tmp, "git", "config", "user.email", "t@example.com")
+        run(tmp, "git", "config", "user.name", "t")
+
+    def commit(self, name: str, text: str, message: str = "c"):
+        (self.path / name).write_text(text)
+        run(self.path, "git", "add", "-A")
+        run(self.path, "git", "commit", "-q", "-m", message)
+
+    def branch(self, name: str):
+        run(self.path, "git", "checkout", "-q", "-b", name)
+
+    def exit_code(self, base="main", head="HEAD"):
+        """The gate's exit status: 1 when it found a capture, 0 when clean."""
+        import os
+
+        cwd = os.getcwd()
+        argv = sys.argv
+        os.chdir(self.path)
+        sys.argv = ["check_doc_ownership.py", base, head]
+        try:
+            return gate.main()
+        finally:
+            sys.argv = argv
+            os.chdir(cwd)
+
+
+DOCUMENTED_CONST = '''/// The scopes each role uses.
+const SYNTAX_SCOPES: &[&str] = &["a"];
+'''
+
+CAPTURED_CONST = '''/// The scopes each role uses.
+const SYNTAX_SEMANTIC: &[&str] = &["b"];
+
+const SYNTAX_SCOPES: &[&str] = &["a"];
+'''
+
+
+class ItemKinds(unittest.TestCase):
+    """`fn` was the original scope, and it let two captures through in a day."""
+
+    def test_every_item_kind_is_recognised(self):
+        for decl, name in [
+            ("fn a() {}", "a"),
+            ("pub fn a() {}", "a"),
+            ("const A: u8 = 1;", "A"),
+            ("pub const A: &str = \"x\";", "A"),
+            ("static A: u8 = 1;", "A"),
+            ("pub static mut A: u8 = 1;", "A"),
+            ("struct A;", "A"),
+            ("pub enum A { B }", "A"),
+            ("union A { b: u8 }", "A"),
+            ("pub trait A {}", "A"),
+            ("type A = u8;", "A"),
+            ("macro_rules! a {}", "a"),
+        ]:
+            state = gate.documented(f"/// doc\n{decl}\n")
+            self.assertEqual(
+                state.get(name),
+                True,
+                f"{decl!r} should be seen as documented item {name!r}",
+            )
+
+    def test_a_const_that_loses_its_doc_is_reported(self):
+        """The #395 shape: a const inserted above another const's doc."""
+        before = gate.documented(DOCUMENTED_CONST)
+        after = gate.documented(CAPTURED_CONST)
+        self.assertTrue(before["SYNTAX_SCOPES"])
+        self.assertFalse(after["SYNTAX_SCOPES"], "its doc now sits on the newcomer")
+        self.assertTrue(after["SYNTAX_SEMANTIC"], "which is how the capture hides")
+
+
+class GitShapes(unittest.TestCase):
+    def test_a_capture_in_an_existing_file_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", DOCUMENTED_CONST)
+            repo.branch("work")
+            repo.commit("a.rs", CAPTURED_CONST)
+            self.assertEqual(
+                repo.exit_code(), 1, "the gate must fail on a captured doc"
+            )
+
+    def test_a_capture_inside_a_file_the_branch_added_is_reported(self):
+        """The #391 shape, which the merge-base comparison cannot see.
+
+        The file does not exist at the base, so `documented(before)` is empty
+        and no loss is representable. The branch's own commits are the only
+        place that history exists.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("seed.rs", "fn seed() {}\n")
+            repo.branch("work")
+            repo.commit("new.rs", DOCUMENTED_CONST)
+            repo.commit("new.rs", CAPTURED_CONST)
+            self.assertEqual(
+                repo.exit_code(), 1, "the gate must fail on a captured doc"
+            )
+
+    def test_a_branch_that_captures_nothing_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", DOCUMENTED_CONST)
+            repo.branch("work")
+            repo.commit("a.rs", DOCUMENTED_CONST + "\n/// Another.\nconst B: u8 = 2;\n")
+            self.assertEqual(repo.exit_code(), 0, "an honest addition must pass")
+
+    def test_a_declared_removal_is_exempt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", DOCUMENTED_CONST)
+            repo.branch("work")
+            repo.commit(
+                "a.rs",
+                "const SYNTAX_SCOPES: &[&str] = &[\"a\"];\n",
+                "drop it\n\ndoc-removal: a.rs::SYNTAX_SCOPES",
+            )
+            self.assertEqual(
+                repo.exit_code(),
+                0,
+                "a declared removal is the documented escape hatch",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -94,6 +94,49 @@ class ItemKinds(unittest.TestCase):
                 f"{decl!r} should be seen as documented item {name!r}",
             )
 
+    def test_declaration_shapes_the_regex_must_not_miss(self):
+        """Shapes that look like edge cases and are ordinary Rust.
+
+        Each was probed rather than assumed: the same-line attribute was
+        genuinely missed before this test existed, which made the item
+        invisible to the gate rather than merely undocumented.
+        """
+        for label, text in [
+            ("attribute on its own line", "/// doc\n#[cfg(test)]\nconst A: u8 = 1;\n"),
+            ("attribute on the same line", "/// doc\n#[cfg(test)] const A: u8 = 1;\n"),
+            ("generic type alias", "/// doc\npub type A<T> = Vec<T>;\n"),
+            ("const fn", "/// doc\npub const fn a() -> u8 { 1 }\n"),
+            ("indented impl method", "impl X {\n    /// doc\n    pub fn a(&self) {}\n}\n"),
+        ]:
+            state = gate.documented(text)
+            self.assertTrue(
+                any(state.values()),
+                f"{label}: nothing was recognised, so the item is invisible "
+                f"to the gate rather than merely undocumented",
+            )
+
+    def test_a_declaration_inside_a_string_is_not_an_item(self):
+        """The regex is line-anchored, so a declaration quoted mid-line is
+        not mistaken for one."""
+        state = gate.documented('/// doc\nconst A: &str = "const B: u8 = 1;";\n')
+        self.assertEqual(state, {"A": True}, "B is inside a string, not an item")
+
+    def test_a_rename_is_not_a_lost_doc(self):
+        """A documented item renamed within a branch must not read as a loss.
+
+        The check requires the name to still EXIST at head, so a rename drops
+        out rather than reporting the old name as undocumented. Pinned because
+        it is the obvious false positive for a name-keyed comparison.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "/// doc\nfn a() {}\n")
+            repo.branch("work")
+            repo.commit("a.rs", "/// doc\nfn b() {}\n")
+            self.assertEqual(
+                repo.exit_code(), 0, "a rename is not a captured doc comment"
+            )
+
     def test_a_const_that_loses_its_doc_is_reported(self):
         """The #395 shape: a const inserted above another const's doc."""
         before = gate.documented(DOCUMENTED_CONST)


### PR DESCRIPTION
Closes #398.

## Two blindnesses, both found by review rather than by the gate

The `doc comments stay with their function` job exists to catch the #314 failure: an item inserted between an existing item and its `///` block, so the prose silently becomes the newcomer's. It saw only `fn`.

**It missed two captures in one day**, both on `const`:

- `SYNTAX_SEMANTIC` inserted above `SYNTAX_SCOPES`'s doc (#395)
- `bucket_range` capturing `downsample`'s doc (#391)

The second exposed something separate and worse. `src/plot.rs` did not exist at the merge base, so `documented(before)` was empty and **no loss was representable at all** — a capture inside a file the branch adds is invisible to a merge-base comparison whatever the item kind. The gate reported "no documentation lost" while a doc block sat on the wrong item.

## What changed

- `ITEM` covers `fn`, `const`, `static`, `struct`, `enum`, `union`, `trait`, `type` and `macro_rules!`. `impl` blocks are deliberately absent: the block's name is not unique enough to key on, and its methods already match as `fn` in their own right.
- Files the branch **adds** are additionally checked commit-by-commit, which is the only place their history exists.
- `git()` gains `allow_fail`, kept separate from and narrower than `allow_missing_path`. It is for a probe whose exit status *is* the answer (`cat-file -e`), and its empty return is never read as content. That separation is load-bearing: the fail-open bug this checker already fixed once lived in exactly that confusion, where an errored command's empty output was read as an empty file.

## Tests, and why they build real repositories

Six, in `scripts/tests/test_doc_ownership.py`. Both defects were about what git history can show rather than about parsing, so testing the parser alone would have reproduced neither. The tests build actual repos with a base and a branch.

**Both halves verified as positive controls against the pre-fix gate:**

With the fn-only regex, asked about a documented `const`:

```
PRE-FIX gate sees: {} {}   -> a capture is unrepresentable
FIXED gate sees:   {'SYNTAX_SCOPES': True} {'SYNTAX_SEMANTIC': True, 'SYNTAX_SCOPES': False}
CAPTURE DETECTED: True
```

Without the pairwise pass, the added-file test fails with `the gate must fail on a captured doc`.

That distinction is worth stating: the old gate did not *fail to notice* a const capture, it had no representation for one. A test asserting "the gate reports nothing here" would have passed for the wrong reason.

## CONTRIBUTING

Reordered to lead with the positional habit — insert a new item **after** a complete item, never directly above a `///` block — rather than the after-the-fact "check the doc below it", because the check is what people skip and the position is what makes it unnecessary. It also now names which item kinds the gate covers, so nobody assumes a const is watched when it is not.

## No version bump

Scripts, their tests, and docs only. Nothing here ships in the binary, and the release-hygiene job's own `grep` (`^(src/|assets/|build\.rs$|Cargo\.toml$|Cargo\.lock$)`) excludes all of it — checked against the workflow rather than against prose.

All 38 script tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to cover documentation placement for all supported item types, including constants, structs, enums, traits, and macros.
  * Expanded documentation-checking coverage to include newly added files and additional Rust declarations.

* **Tests**
  * Added comprehensive automated coverage for documentation ownership checks, including additions, removals, renames, attributes, and supported declaration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->