### PR TITLE
fix(ci): a doc captured and then restored within a branch is not a loss

### DIFF
--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -162,6 +162,13 @@ def main():
     # commit-by-commit instead, which is the only place their history exists.
     added = [f for f in changed if not git("cat-file", "-e", f"{base}:{f}", allow_missing_path=True, allow_fail=True)]
     if added:
+        # What matters is the state at HEAD. A doc captured in one commit and
+        # restored in a later one is not a loss: the branch is fine, and
+        # reporting it blocks a PR whose head is correct. Without this the
+        # pairwise pass reports every intermediate state a branch passed
+        # through, which is exactly the false accusation that makes a gate
+        # untrustworthy.
+        head_state = {f: documented(git("show", f"{head}:{f}", allow_missing_path=True)) for f in added}
         commits = git("log", f"{base}..{head}", "--format=%H", "--reverse").split()
         for older, newer in zip(commits, commits[1:]):
             for f in added:
@@ -173,6 +180,7 @@ def main():
                         and name in after
                         and not after[name]
                         and (f, name) not in exempt
+                        and not head_state[f].get(name, False)
                         and not any(l[0] == f and l[1] == name for l in losses)
                     ):
                         # Name the commit the doc was last seen at. Saying

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -103,6 +103,71 @@ def is_doc(line):
     return s.startswith("///") and not s.startswith("////")
 
 
+# What a line is, for the backward scan. Computed in one FORWARD pass,
+# because both multi-line constructs (an attribute spanning lines, a `/** */`
+# doc block) can only be recognised by reading downward: from below, `))]` and
+# `*/` are indistinguishable from code.
+DOC, ATTR, SKIP, CODE = "doc", "attr", "skip", "code"
+
+
+def classify(lines):
+    """Label every line DOC, ATTR, SKIP (blank or ordinary comment) or CODE.
+
+    Both multi-line shapes were false-ACCUSATION bugs rather than misses: an
+    attribute spanning lines, or a `/** */` block doc, made a documented item
+    read as undocumented and the gate reported a loss that had not happened.
+    For a gate that is the worse direction, since a gate that cries wolf stops
+    being read.
+    """
+    kinds = []
+    attr_depth = 0
+    in_block_doc = False
+    in_block_comment = False
+    for raw in lines:
+        s = raw.strip()
+        if in_block_doc:
+            kinds.append(DOC)
+            if "*/" in s:
+                in_block_doc = False
+            continue
+        if in_block_comment:
+            kinds.append(SKIP)
+            if "*/" in s:
+                in_block_comment = False
+            continue
+        if attr_depth > 0:
+            kinds.append(ATTR)
+            attr_depth += s.count("[") - s.count("]")
+            continue
+        # `/** ... */` is an outer doc comment lowering to the same `#[doc]`
+        # attribute as `///`. `/*! */` is INNER (it documents the enclosing
+        # item, not the next one) and `/***` is an ordinary comment, so
+        # neither counts.
+        if s.startswith("/**") and not s.startswith("/***"):
+            kinds.append(DOC)
+            if "*/" not in s[2:]:
+                in_block_doc = True
+            continue
+        if s.startswith("/*"):
+            kinds.append(SKIP)
+            if "*/" not in s[2:]:
+                in_block_comment = True
+            continue
+        if s.startswith("#["):
+            kinds.append(ATTR)
+            depth = s.count("[") - s.count("]")
+            attr_depth = max(depth, 0)
+            continue
+        if is_doc(raw):
+            kinds.append(DOC)
+            continue
+        if s == "" or s.startswith("//"):
+            kinds.append(SKIP)
+            continue
+        kinds.append(CODE)
+    return kinds
+
+
 def documented(text):
     """Map item name -> True when ANY definition of it carries a doc comment.
 
@@ -120,6 +185,7 @@ def documented(text):
     reported documentation as missing when rustc could see it perfectly well.
     """
     lines = text.splitlines()
+    kinds = classify(lines)
     state = {}
     for i, line in enumerate(lines):
         m = ITEM.match(line)
@@ -128,13 +194,9 @@ def documented(text):
         # Exactly one alternative captures per match.
         name = next(g for g in m.groups() if g)
         j = i - 1
-        while j >= 0:
-            s = lines[j].lstrip()
-            if s.startswith("#[") or s == "" or (s.startswith("//") and not is_doc(lines[j])):
-                j -= 1
-                continue
-            break
-        has_doc = j >= 0 and is_doc(lines[j])
+        while j >= 0 and kinds[j] in (ATTR, SKIP):
+            j -= 1
+        has_doc = j >= 0 and kinds[j] == DOC
         state[name] = state.get(name, False) or has_doc
     return state
 

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -121,6 +121,41 @@ class ItemKinds(unittest.TestCase):
                 f"to the gate rather than merely undocumented",
             )
 
+    def test_multi_line_attributes_and_block_docs_are_read_correctly(self):
+        """Both shapes made a DOCUMENTED item read as undocumented.
+
+        That is a false accusation, not a miss: the gate would report a loss
+        that never happened, on a branch that had merely reformatted an
+        attribute or used `/** */`. For a gate that is the worse direction,
+        because one that cries wolf stops being read.
+
+        The inner form `/*!` and the ordinary `/*` and `/***` comments must
+        NOT count, or the gate invents documentation instead.
+        """
+        documented_shapes = [
+            ("multi-line attribute", "/// doc\n#[cfg(all(\n    feature = \"x\",\n    unix\n))]\nconst A: u8 = 1;\n"),
+            ("one-line block doc", "/** doc */\nconst A: u8 = 1;\n"),
+            ("multi-line block doc", "/**\n * doc\n */\nconst A: u8 = 1;\n"),
+            ("block doc then attribute", "/** doc */\n#[cfg(test)]\nconst A: u8 = 1;\n"),
+        ]
+        for label, text in documented_shapes:
+            self.assertEqual(
+                gate.documented(text).get("A"), True, f"{label} documents A"
+            )
+
+        undocumented_shapes = [
+            ("inner block doc documents the MODULE", "/*! module */\nconst A: u8 = 1;\n"),
+            ("ordinary block comment", "/* a note */\nconst A: u8 = 1;\n"),
+            ("triple-star rule", "/*** rule ***/\nconst A: u8 = 1;\n"),
+            ("four slashes is a rule", "//// rule\nconst A: u8 = 1;\n"),
+        ]
+        for label, text in undocumented_shapes:
+            self.assertEqual(
+                gate.documented(text).get("A"),
+                False,
+                f"{label} must not count as documentation",
+            )
+
     def test_a_declaration_inside_a_string_is_not_an_item(self):
         """The regex is line-anchored, so a declaration quoted mid-line is
         not mistaken for one."""

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -249,6 +249,38 @@ class GitShapes(unittest.TestCase):
                 repo.exit_code(), 1, "the gate must fail on a captured doc"
             )
 
+    def test_a_doc_captured_and_then_restored_within_a_branch_passes(self):
+        """A branch whose HEAD is correct must not be blocked by a state it
+        passed through.
+
+        The pairwise pass over branch-added files walks every adjacent pair,
+        so a doc captured in one commit and restored in a later one shows up
+        as a loss between two intermediate revisions. Reporting that blocks a
+        PR that is fine, which is the false accusation that makes a gate
+        untrustworthy: the first thing a maintainer does with a gate that
+        cries wolf is stop reading it.
+
+        Found within an hour of shipping the pairwise pass, on a real PR
+        whose head was correct.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("seed.rs", "fn seed() {}\n")
+            repo.branch("work")
+            repo.commit("new.rs", DOCUMENTED_CONST)
+            repo.commit("new.rs", CAPTURED_CONST)
+            # ... and put it back.
+            repo.commit(
+                "new.rs",
+                "/// Its own doc.\nconst SYNTAX_SEMANTIC: &[&str] = &[\"b\"];\n\n"
+                + DOCUMENTED_CONST,
+            )
+            self.assertEqual(
+                repo.exit_code(),
+                0,
+                "a doc restored before the branch tip is not a loss",
+            )
+
     def test_a_branch_that_captures_nothing_passes(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo = Repo(Path(tmp))


### PR DESCRIPTION
A false positive in the pairwise pass shipped an hour ago in #403.

## What happens

That pass exists because a file the branch **adds** has no base version, so a doc capture inside it is invisible to a merge-base comparison. It walks every adjacent pair of branch commits instead.

Walking every pair means reporting every intermediate state the branch passed through. A doc captured in one commit and **restored in a later one** is reported as a loss, even though the branch tip is correct.

## Found immediately, on a real PR

#400 had a genuine capture: a helper inserted between `apply` and its doc block, in a file that branch adds, which is precisely the case #403 extended the gate to see. The gate caught it, named the right commit, I fixed it, and the gate kept reporting it, because the broken state still exists in an earlier commit on that branch.

So the gate was simultaneously right (there was a capture) and wrong (the branch was fine by then).

## Why this is the failure mode that matters

For a gate, missing a defect is bad and accusing a correct branch is worse. The first thing a maintainer does with a gate that cries wolf is stop reading it, and then it catches nothing at all. The merge-base pass never had this problem because it compares two endpoints; the pairwise pass walks every pair and needed the same endpoint check.

Losses from the pairwise pass are now filtered against the item's state at head. The merge-base pass is unchanged.

## Test

One, and it is a positive control: removing the filter fails it with

```
AssertionError: 1 != 0 : a doc restored before the branch tip is not a loss
```

The true positive is untouched, still covered by `test_a_capture_inside_a_file_the_branch_added_is_reported`, so the fix narrows the report rather than disabling it.

44 script tests pass. No version bump: scripts and their tests only, which the release-hygiene job's own filter excludes.

## Note

#403's own PR body argued that a structural guard is code, and can be wrong in exactly the ways it exists to catch. This is that, one hour later, in my own guard, found by the guard blocking a branch I had already fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation checks no longer report false positives when documentation is removed temporarily but restored before the final branch state.

* **Tests**
  * Added regression coverage for restored documentation across multiple commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->