### PR TITLE
fix(workspace): keep non-ASCII folder paths in a .code-workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.807"
+version = "0.1.808"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.807"
+version = "0.1.808"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/import_vscode.rs
+++ b/src/import_vscode.rs
@@ -325,9 +325,10 @@ fn read_jsonc(path: &Path) -> Result<Option<Value>> {
     }
     let raw =
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    // `crate::tasks::strip_jsonc` walks CHARS. The `workspace.rs` one walks
-    // bytes and mangles any non-ASCII value (#396), which a settings file
-    // carries routinely in paths and snippet bodies.
+    // `crate::tasks::strip_jsonc` walks CHARS. The copy that used to live in
+    // `workspace.rs` walked bytes and mangled any non-ASCII value (#396),
+    // which a settings file carries routinely in paths and snippet bodies;
+    // it was deleted in favour of this one rather than repaired.
     let stripped = crate::tasks::strip_jsonc(&raw);
     if stripped.trim().is_empty() {
         return Ok(None);

--- a/src/release_notes.rs
+++ b/src/release_notes.rs
@@ -60,6 +60,6 @@ pub struct ReleaseNote {
 
 /// What shipped in the current release. Replace on every version bump.
 pub const RELEASE_NOTES: &[ReleaseNote] = &[ReleaseNote {
-    kind: NoteKind::Feature,
-    summary: "croft theme-import turns a VS Code colour theme (.json) into a croft theme: workbench chrome, the 16 terminal colours, and the code palette, with a note for every colour croft had to derive because the theme did not name it.",
+    kind: NoteKind::Fix,
+    summary: "A .code-workspace file whose folder paths carry non-ASCII characters (accents, CJK, Cyrillic) now opens with those names intact instead of mojibake.",
 }];

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -734,6 +734,31 @@ mod tests {
         assert_eq!(v["b"], 1);
     }
 
+    /// The non-ASCII guarantee belongs on the function that carries it.
+    ///
+    /// Seven modules route their JSONC through here, and #396 was a second
+    /// copy in `workspace.rs` that walked BYTES: it rebuilt every multi-byte
+    /// character one byte at a time, so `caf\u{e9}` came back as `caf\u{c3}\u{a9}`
+    /// and the JSON still parsed. That copy is gone, but the only tests that
+    /// covered this were in the CALLERS, and each of those reaches this
+    /// function through file IO and a JSON parse. A future rewrite of this
+    /// stripper could reintroduce the defect for every module whose own
+    /// tests happen to be ASCII, which was all of them.
+    ///
+    /// Non-ASCII in a key as well as a value: a mangled key does not merely
+    /// arrive wrong, it makes the document fail to parse outright.
+    #[test]
+    fn strip_jsonc_preserves_non_ascii() {
+        let cleaned = strip_jsonc(
+            "{\n  // a comment, so the comment path actually runs\n  \"caf\u{e9}\": \"\u{4e2d}\u{6587} \u{444}\u{430}\u{439}\u{43b}\",\n}",
+        );
+        let v: serde_json::Value = serde_json::from_str(&cleaned).expect("valid strict JSON");
+        assert_eq!(
+            v["caf\u{e9}"],
+            "\u{4e2d}\u{6587} \u{444}\u{430}\u{439}\u{43b}"
+        );
+    }
+
     #[test]
     fn empty_workspace_has_no_tasks() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src/vscode_theme.rs
+++ b/src/vscode_theme.rs
@@ -230,9 +230,10 @@ fn load_chain(path: &Path, depth: usize, out: &mut Vec<RawTheme>) -> Result<()> 
 
 /// Parse one theme document, tolerating VS Code's JSONC extras.
 fn parse_theme(raw: &str) -> Result<RawTheme> {
-    // `crate::tasks::strip_jsonc` walks CHARS. The `workspace.rs` one walks
-    // bytes and turns a non-ASCII theme name ("Caf\u{e9} Noir") into mojibake,
-    // which is exactly the sort of theme most likely to carry one.
+    // `crate::tasks::strip_jsonc` walks CHARS. The copy that used to live in
+    // `workspace.rs` walked bytes and turned a non-ASCII theme name
+    // ("Caf\u{e9} Noir") into mojibake (#396); it was deleted in favour of
+    // this one, which is why there is only ever one of these.
     let stripped = crate::tasks::strip_jsonc(raw);
     let value: serde_json::Value = serde_json::from_str(&stripped)?;
     // `tokenColors` is camelCase in the file; take it by hand rather than
@@ -1163,10 +1164,11 @@ mod tests {
         );
     }
 
-    /// Review finding: the byte-walking `strip_jsonc` in `workspace.rs`
-    /// turned every non-ASCII character into mojibake, so a theme called
-    /// "Caf\u{e9} Noir" imported under a mangled name. The chars-based
-    /// stripper in `tasks.rs` is the right one.
+    /// Review finding: the byte-walking `strip_jsonc` that used to live in
+    /// `workspace.rs` turned every non-ASCII character into mojibake, so a
+    /// theme called "Caf\u{e9} Noir" imported under a mangled name. It was
+    /// deleted for the chars-based stripper in `tasks.rs` (#396); this pins
+    /// that the theme path keeps using the right one.
     #[test]
     fn a_non_ascii_theme_name_survives_the_jsonc_strip() {
         let src = r##"{

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -247,10 +247,8 @@ pub fn parse_workspace_file(path: &Path) -> Result<Vec<PathBuf>, String> {
     // so a workspace folder named "Caf\u{e9} Noir" arrived as "CafÃ© Noir"
     // with no error anywhere: the JSON still parsed (#396).
     //
-    // The two agreed on all eleven JSONC shapes probed (line and block
-    // comments, trailing commas in objects and arrays, comment markers inside
-    // strings, escaped quotes, CRLF, empty input) and differed on exactly the
-    // three non-ASCII ones, so this is the same behaviour minus the defect.
+    // The two treat comments, trailing commas and string literals alike, so
+    // the swap changes what happens to non-ASCII input and nothing else.
     let stripped = crate::tasks::strip_jsonc(&raw);
     let v: serde_json::Value =
         serde_json::from_str(&stripped).map_err(|e| format!("parse {}: {e}", path.display()))?;
@@ -542,7 +540,7 @@ mod tests {
     /// under a mangled name.
     #[test]
     fn a_non_ascii_folder_path_survives_the_jsonc_strip() {
-        let tmp = tempfile::TempDir::new().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
         // A directory whose name needs more than one byte per character, in
         // three scripts, since the corruption is per byte.
         for name in [

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -242,7 +242,16 @@ where
 /// workspace names at least one folder.
 pub fn parse_workspace_file(path: &Path) -> Result<Vec<PathBuf>, String> {
     let raw = std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
-    let stripped = strip_jsonc(&raw);
+    // `crate::tasks::strip_jsonc` walks CHARS. The copy that used to live
+    // here walked BYTES and rebuilt every multi-byte character as mojibake,
+    // so a workspace folder named "Caf\u{e9} Noir" arrived as "CafÃ© Noir"
+    // with no error anywhere: the JSON still parsed (#396).
+    //
+    // The two agreed on all eleven JSONC shapes probed (line and block
+    // comments, trailing commas in objects and arrays, comment markers inside
+    // strings, escaped quotes, CRLF, empty input) and differed on exactly the
+    // three non-ASCII ones, so this is the same behaviour minus the defect.
+    let stripped = crate::tasks::strip_jsonc(&raw);
     let v: serde_json::Value =
         serde_json::from_str(&stripped).map_err(|e| format!("parse {}: {e}", path.display()))?;
     let base = path.parent().unwrap_or_else(|| Path::new("."));
@@ -271,87 +280,6 @@ pub fn parse_workspace_file(path: &Path) -> Result<Vec<PathBuf>, String> {
         return Err(format!("{}: no folders", path.display()));
     }
     Ok(out)
-}
-
-/// Strip VS Code's JSONC extras so serde can parse: `//` and `/* */`
-/// comments outside strings, and trailing commas before `]`/`}` (#164
-/// review — `.code-workspace` files legitimately carry all three).
-fn strip_jsonc(src: &str) -> String {
-    let bytes = src.as_bytes();
-    let mut out = String::with_capacity(src.len());
-    let mut i = 0;
-    let mut in_str = false;
-    while i < bytes.len() {
-        let c = bytes[i] as char;
-        if in_str {
-            out.push(c);
-            if c == '\\' && i + 1 < bytes.len() {
-                out.push(bytes[i + 1] as char);
-                i += 2;
-                continue;
-            }
-            if c == '"' {
-                in_str = false;
-            }
-            i += 1;
-            continue;
-        }
-        match c {
-            '"' => {
-                in_str = true;
-                out.push(c);
-                i += 1;
-            }
-            '/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            '/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                i = (i + 2).min(bytes.len());
-            }
-            ',' => {
-                // Trailing comma: swallow it when the next non-space,
-                // non-comment token closes the container.
-                let mut j = i + 1;
-                loop {
-                    while j < bytes.len() && (bytes[j] as char).is_whitespace() {
-                        j += 1;
-                    }
-                    if j + 1 < bytes.len() && bytes[j] == b'/' && bytes[j + 1] == b'/' {
-                        while j < bytes.len() && bytes[j] != b'\n' {
-                            j += 1;
-                        }
-                        continue;
-                    }
-                    if j + 1 < bytes.len() && bytes[j] == b'/' && bytes[j + 1] == b'*' {
-                        j += 2;
-                        while j + 1 < bytes.len() && !(bytes[j] == b'*' && bytes[j + 1] == b'/') {
-                            j += 1;
-                        }
-                        j = (j + 2).min(bytes.len());
-                        continue;
-                    }
-                    break;
-                }
-                if j < bytes.len() && (bytes[j] == b']' || bytes[j] == b'}') {
-                    i += 1; // drop the comma; the closer re-processes
-                } else {
-                    out.push(c);
-                    i += 1;
-                }
-            }
-            _ => {
-                out.push(c);
-                i += 1;
-            }
-        }
-    }
-    out
 }
 
 /// Write the folder set as a `.code-workspace` (#163): paths relative to
@@ -602,6 +530,48 @@ mod tests {
             parse_workspace_file(&file).unwrap(),
             vec![alpha.canonicalize().unwrap()],
             "and round-trips back to the real directory"
+        );
+    }
+
+    /// A `.code-workspace` path carrying non-ASCII must survive the JSONC
+    /// strip (#396).
+    ///
+    /// The stripper that used to live in this module walked BYTES and treated
+    /// each as a char, so every multi-byte character was rebuilt as mojibake.
+    /// Nothing errored: the JSON still parsed and the folder simply arrived
+    /// under a mangled name.
+    #[test]
+    fn a_non_ascii_folder_path_survives_the_jsonc_strip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // A directory whose name needs more than one byte per character, in
+        // three scripts, since the corruption is per byte.
+        for name in [
+            "caf\u{e9}",
+            "\u{4e2d}\u{6587}",
+            "\u{444}\u{430}\u{439}\u{43b}",
+        ] {
+            std::fs::create_dir_all(tmp.path().join(name)).unwrap();
+        }
+        let ws = tmp.path().join("accents.code-workspace");
+        std::fs::write(
+            &ws,
+            "{\n  // a comment, so the stripper definitely runs\n  \"folders\": [\n                 { \"path\": \"caf\u{e9}\" },\n    { \"path\": \"\u{4e2d}\u{6587}\" },\n                 { \"path\": \"\u{444}\u{430}\u{439}\u{43b}\" },\n  ],\n}\n",
+        )
+        .unwrap();
+
+        let roots = parse_workspace_file(&ws).expect("a commented file with accents parses");
+        let names: Vec<String> = roots
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "caf\u{e9}",
+                "\u{4e2d}\u{6587}",
+                "\u{444}\u{430}\u{439}\u{43b}"
+            ],
+            "the folder names must arrive intact rather than as mojibake"
         );
     }
 


### PR DESCRIPTION
Closes #396.

## The defect

`workspace::strip_jsonc` walked the file as bytes and rebuilt it with `bytes[i] as char`. That maps each byte to the Latin-1 code point of the same value, so every multi-byte UTF-8 sequence came back out as one char per byte.

A `.code-workspace` listing a folder named `café` reached serde as `cafÃ©`. `中文` became three mojibake chars. Non-ASCII in a *key* made the document fail to parse outright (`key must be a string at line 2 column 3`).

## The fix

`tasks::strip_jsonc` already does the same job over `chars()`. The single caller now uses it, and the byte-walking copy is gone.

## Why the swap is safe

An equivalence probe ran both implementations over 14 JSONC shapes: line comments, block comments, trailing commas in objects and in arrays, comment markers inside string literals, escaped quotes, CRLF, empty input, and the three non-ASCII cases. Eleven agreed byte for byte. The three that differed are exactly the defect:

```
DIFF non-ascii value   workspace: "{ \"name\": \"CafÃ© Noir\" }"   tasks: "{ \"name\": \"Café Noir\" }"
DIFF non-ascii key     workspace: "{ \"ä¸­æ\u{96}\u{87}\": 1 }"      tasks: "{ \"中文\": 1 }"
DIFF emoji             workspace: "{ \"a\": \"ð\u{9f}\u{98}\u{80}\" }"  tasks: "{ \"a\": \"😀\" }"

PROBE 3 of 14 cases differ
```

So the consolidation changes behaviour on the broken cases and on nothing else.

## The test is a control

`a_non_ascii_folder_path_survives_the_jsonc_strip` opens a commented `.code-workspace` whose folders are `café`, `中文` and `файл`. Grafting it onto the previous implementation (`git show origin/main:src/workspace.rs`) turns it red with the defect spelled out:

```
assertion `left == right` failed: the folder names must arrive intact rather than as mojibake
  left: ["cafÃ©", "ä¸\u{ad}æ\u{96}\u{87}", "Ñ\u{84}Ð°Ð¹Ð»"]
 right: ["café", "中文", "файл"]
```

## Gate

- `cargo test --bin croft`: 3796 passed, 1 failed. The failure is `cmd_clicking_a_non_web_hyperlink_refuses_instead_of_opening`, the PTY-timing load-flake class tracked in #397; it passes in isolation and touches nothing in this diff.
- `cargo clippy --all-targets --all-features`: zero warnings.
- `scripts/check_doc_ownership.py origin/main HEAD`: no documentation lost.