### PR TITLE
ci: key the doc-ownership gate's methods by their enclosing impl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,13 @@ so in a commit message on the branch:
 
 ```text
 doc-removal: src/path/to/file.rs::some_function_name
+doc-removal: src/path/to/file.rs::SomeType::method_name
 ```
+
+The key after the path is the one the gate's own error names: a bare name
+for a free item, or the enclosing `impl` header for a method (`Foo::new`,
+`Display for Foo::fmt`), so a declared removal of one `new` cannot excuse
+another.
 
 The file qualifier matters: an exemption keyed on the bare name would excuse
 every function of that name in every changed file, so a deliberate removal of

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -12,8 +12,11 @@ comment and now has none is the exact fingerprint the insertion leaves behind,
 and it is what both known instances did.
 
 Deliberate removals are rare and are declared: put
-`doc-removal: <path>::<fn name>` in a commit message on the branch. The path
-qualifier keeps one declared removal from excusing a same-named function
+`doc-removal: <path>::<item key>` in a commit message on the branch, where
+the key is the one the gate's own error names: a bare name for a free item
+(`src/foo.rs::bar`), or the enclosing impl header for a method
+(`src/foo.rs::Foo::new`, `src/foo.rs::Display for Foo::fmt`). The path
+qualifier keeps one declared removal from excusing a same-named item
 elsewhere.
 
 Usage: check_doc_ownership.py <base-rev> <head-rev>
@@ -64,20 +67,39 @@ MISSING_PATH = re.compile(
 )
 
 
-# The head of an `impl` block. Its methods are keyed `<header>::<name>` so
-# that `new` in two impl blocks is two items, not one merged key whose "any
-# documented" reading hides a capture on either (#405). The whole header is
-# the key rather than the type alone: `impl Display for X` and `impl Debug
-# for X` both define `fmt`. Generics and lifetimes are stripped so a branch
-# that reformats them does not move every method to a new key.
-IMPL_HEADER = re.compile(
-    r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+)?impl\b(?P<rest>.*)$"
+# The head of an `impl` or `trait` block. Its methods are keyed
+# `<header>::<name>` so that `new` in two impl blocks is two items, not one
+# merged key whose "any documented" reading hides a capture on either
+# (#405). The whole header is the key rather than the type alone: `impl
+# Display for X` and `impl Debug for X` both define `fmt`. A trait's own
+# method declarations get the same treatment, keyed `trait Foo::id`, since
+# two traits declaring `id` are the same shape. Generics and lifetimes are
+# stripped so a branch that reformats them does not move every method to a
+# new key.
+BLOCK_HEADER = re.compile(
+    r"^\s*(?:(?:pub(?:\([^)]*\))?\s+)?trait|(?:unsafe\s+)?impl)\b(?P<rest>.*)$"
 )
 
-# String and char literals, so the braces inside them are not counted as
-# block structure. `format!("{x}")` is on most lines that matter, and one
+# Everything on a CODE line that is not block structure, in the order a
+# left-to-right scan meets it: a complete raw string (`r#"{"#` is not a
+# `"..."` and its braces are content), a complete ordinary string, a char
+# literal (exactly one, possibly escaped, character between quotes, which
+# is what keeps a lifetime `'a` from opening one), a raw string that runs
+# past its line, an ordinary one that does (a `"...\` continuation), and a
+# `//` comment. `format!("{x}")` is on most lines that matter, and one
 # miscounted brace keys every item after it to the wrong block.
-LITERAL = re.compile(r'"(?:\\.|[^"\\])*"' + r"|'(?:\\.|[^'\\])'")
+TOKEN = re.compile(
+    r'(?P<raw>b?r(?P<hashes>#*)"(?:(?!"(?P=hashes)).)*"(?P=hashes))'
+    r'|(?P<plain>b?"(?:\\.|[^"\\])*")'
+    r"|(?P<char>b?'(?:\\.|[^'\\])')"
+    r'|(?P<open_raw>b?r(?P<open_hashes>#*)")'
+    r'|(?P<open_plain>")'
+    r"|(?P<comment>//)"
+)
+
+# The first `"` not escaped by a backslash: where an ordinary string that
+# ran past its line ends.
+UNESCAPED_QUOTE = re.compile(r'(?<!\\)(?:\\\\)*"')
 
 
 def strip_generics(text):
@@ -93,23 +115,102 @@ def strip_generics(text):
     return "".join(out)
 
 
-def impl_key(header):
-    """`impl<T> fmt::Display for Foo<T> where T: X {` -> `fmt::Display for Foo`.
+def block_key(kind, header):
+    """`impl<T> fmt::Display for Foo<T> where T: X {` -> `fmt::Display for Foo`;
+    `trait Foo: Bar {` -> `trait Foo`.
 
     Everything from the first `where` or `{` on is the block's body or
-    bounds, not its identity.
+    bounds, not its identity. A trait keeps its keyword so `trait Foo` and an
+    inherent `impl Foo` on a same-named type stay distinct.
     """
     rest = strip_generics(header)
-    rest = re.split(r"\bwhere\b|\{", rest, maxsplit=1)[0]
-    return " ".join(rest.split())
+    rest = re.split(r"\bwhere\b|\{|:", rest, maxsplit=1)[0] if kind == "trait" else re.split(r"\bwhere\b|\{", rest, maxsplit=1)[0]
+    rest = " ".join(rest.split())
+    return f"trait {rest}" if kind == "trait" else rest
 
 
-def brace_delta(line):
-    """Net `{` minus `}` on a CODE line, ignoring literals and a trailing
-    `//` comment."""
-    code = LITERAL.sub("", line)
-    code = code.split("//", 1)[0]
-    return code.count("{") - code.count("}")
+class BlockTracker:
+    """Which `impl`/`trait` block each line of a file is in.
+
+    Fed CODE lines in order. Counts braces after removing literals and a
+    trailing `//` comment; a string that runs past its line puts the tracker
+    in "content" mode until the terminator, so a multi-line raw string full
+    of JSON braces is invisible to it. A header whose `{` comes later (a
+    `where` clause, a rustfmt-wrapped `impl<T>\n Trait for X<T>\n{`) is
+    accumulated until that brace opens. A body-less `impl Eq for X {}` opens
+    and closes on one line and must not leak its key onto the next block.
+
+    The counter is line-based and therefore fallible in principle; the
+    invariants a caller can check are `depth == 0` and no open blocks at
+    EOF, and the test-suite asserts both over every file in `src/`. Depth is
+    floored at zero so one miscount cannot corrupt every later block.
+    """
+
+    def __init__(self):
+        self.depth = 0
+        # (depth the block opened at, key or None for a `mod`/`fn` body).
+        self.blocks = []
+        # Header text accumulated while waiting for its opening brace.
+        self.pending = None
+        # Terminator of a string that ran past its line, or None.
+        self.open_string = None
+
+    def scope(self):
+        """The innermost impl/trait key, or None. A block with no key (a
+        nested `fn` or `mod`) is transparent: it still lives in the impl."""
+        return next((k for _, k in reversed(self.blocks) if k), None)
+
+    def _code_of(self, line):
+        """The line with literals and comments removed, tracking strings
+        that span lines."""
+        if self.open_string is not None:
+            if self.open_string == '"':
+                m = UNESCAPED_QUOTE.search(line)
+                if not m:
+                    return ""
+                line = line[m.end():]
+            else:
+                at = line.find(self.open_string)
+                if at < 0:
+                    return ""
+                line = line[at + len(self.open_string):]
+            self.open_string = None
+        out = []
+        pos = 0
+        for m in TOKEN.finditer(line):
+            out.append(line[pos:m.start()])
+            pos = m.end()
+            if m.group("comment"):
+                return "".join(out)
+            if m.group("open_raw"):
+                self.open_string = '"' + m.group("open_hashes")
+                return "".join(out)
+            if m.group("open_plain"):
+                self.open_string = '"'
+                return "".join(out)
+        out.append(line[pos:])
+        return "".join(out)
+
+    def feed(self, line):
+        header = BLOCK_HEADER.match(line) if self.open_string is None else None
+        code = self._code_of(line)
+        if header:
+            kind = "trait" if "trait" in header.group(0)[: header.start("rest")] else "impl"
+            self.pending = (kind, header.group("rest"))
+        elif self.pending is not None and "{" not in code:
+            # Still inside a wrapped header: `impl<T>` / `Trait for X<T>`.
+            self.pending = (self.pending[0], self.pending[1] + " " + line.strip())
+        delta = code.count("{") - code.count("}")
+        if "{" in code:
+            if delta > 0:
+                key = block_key(*self.pending) if self.pending else None
+                self.blocks.append((self.depth, key))
+            # Opened and closed on one line (`impl Eq for X {}`): the header
+            # is spent either way.
+            self.pending = None
+        self.depth = max(self.depth + delta, 0)
+        while self.blocks and self.blocks[-1][0] >= self.depth:
+            self.blocks.pop()
 
 
 def git(*args, allow_missing_path=False, allow_fail=False):
@@ -220,7 +321,7 @@ def documented(text):
     """Map item key -> True when ANY definition under it carries a doc comment.
 
     Keyed by name because two revisions cannot be lined up by position, and
-    a method's name is qualified by its enclosing `impl` header
+    a method's name is qualified by its enclosing `impl` or `trait` header
     (`Foo::new`, `Display for Foo::fmt`) because a bare name is not unique
     where it matters most: `new` across impl blocks is the common shape,
     and merging them let a capture on one hide behind the other's surviving
@@ -243,33 +344,19 @@ def documented(text):
     lines = text.splitlines()
     kinds = classify(lines)
     state = {}
-    # Enclosing blocks as (depth the block opened at, impl key or None).
-    # A `mod` or `fn` body pushes None so that only an impl qualifies.
-    blocks = []
-    depth = 0
-    # An impl header whose `{` is on a later line (a `where` clause), held
-    # until the brace that opens its body arrives.
-    pending = None
+    tracker = BlockTracker()
     for i, line in enumerate(lines):
+        # The scope an item belongs to is the one in force BEFORE its own
+        # line: `trait A {` is itself an item, keyed to whatever encloses
+        # it, not to the block it opens.
+        scope = tracker.scope()
         if kinds[i] == CODE:
-            header = IMPL_HEADER.match(line)
-            if header:
-                pending = impl_key(header.group("rest"))
-            delta = brace_delta(line)
-            if delta > 0:
-                blocks.append((depth, pending))
-                pending = None
-            depth += delta
-            while blocks and blocks[-1][0] >= depth:
-                blocks.pop()
+            tracker.feed(line)
         m = ITEM.match(line)
         if not m:
             continue
         # Exactly one alternative captures per match.
         name = next(g for g in m.groups() if g)
-        # The innermost impl on the stack, if any. A block with no key (a
-        # nested `fn` or `mod`) is transparent: it still lives in the impl.
-        scope = next((k for _, k in reversed(blocks) if k), None)
         if scope:
             name = f"{scope}::{name}"
         j = i - 1
@@ -289,7 +376,7 @@ def main():
     exempt = {
         (path, name)
         for path, name in re.findall(
-            r"doc-removal:\s*([\w./-]+\.rs)::((?:[A-Za-z_][\w:]*(?: for [A-Za-z_][\w:]*)?::)?[A-Za-z_]\w*)",
+            r"doc-removal:\s*([\w./-]+\.rs)::((?:(?:trait )?[A-Za-z_][\w:]*(?: for [A-Za-z_][\w:]*)?::)?[A-Za-z_]\w*)",
             declared,
         )
     }

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -64,6 +64,54 @@ MISSING_PATH = re.compile(
 )
 
 
+# The head of an `impl` block. Its methods are keyed `<header>::<name>` so
+# that `new` in two impl blocks is two items, not one merged key whose "any
+# documented" reading hides a capture on either (#405). The whole header is
+# the key rather than the type alone: `impl Display for X` and `impl Debug
+# for X` both define `fmt`. Generics and lifetimes are stripped so a branch
+# that reformats them does not move every method to a new key.
+IMPL_HEADER = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+)?impl\b(?P<rest>.*)$"
+)
+
+# String and char literals, so the braces inside them are not counted as
+# block structure. `format!("{x}")` is on most lines that matter, and one
+# miscounted brace keys every item after it to the wrong block.
+LITERAL = re.compile(r'"(?:\\.|[^"\\])*"' + r"|'(?:\\.|[^'\\])'")
+
+
+def strip_generics(text):
+    """Drop every `<...>` group, nested ones included."""
+    out, depth = [], 0
+    for ch in text:
+        if ch == "<":
+            depth += 1
+        elif ch == ">" and depth > 0:
+            depth -= 1
+        elif depth == 0:
+            out.append(ch)
+    return "".join(out)
+
+
+def impl_key(header):
+    """`impl<T> fmt::Display for Foo<T> where T: X {` -> `fmt::Display for Foo`.
+
+    Everything from the first `where` or `{` on is the block's body or
+    bounds, not its identity.
+    """
+    rest = strip_generics(header)
+    rest = re.split(r"\bwhere\b|\{", rest, maxsplit=1)[0]
+    return " ".join(rest.split())
+
+
+def brace_delta(line):
+    """Net `{` minus `}` on a CODE line, ignoring literals and a trailing
+    `//` comment."""
+    code = LITERAL.sub("", line)
+    code = code.split("//", 1)[0]
+    return code.count("{") - code.count("}")
+
+
 def git(*args, allow_missing_path=False, allow_fail=False):
     """Run git, failing closed.
 
@@ -169,12 +217,20 @@ def classify(lines):
 
 
 def documented(text):
-    """Map item name -> True when ANY definition of it carries a doc comment.
+    """Map item key -> True when ANY definition under it carries a doc comment.
 
-    Keyed by name because two revisions cannot be lined up by position. Where
-    a file defines the same name more than once (`new` across impl blocks),
-    "any documented" is the deliberately conservative reading: the check fires
-    only when every definition of that name has lost its prose.
+    Keyed by name because two revisions cannot be lined up by position, and
+    a method's name is qualified by its enclosing `impl` header
+    (`Foo::new`, `Display for Foo::fmt`) because a bare name is not unique
+    where it matters most: `new` across impl blocks is the common shape,
+    and merging them let a capture on one hide behind the other's surviving
+    prose (#405). Items outside any impl, and items in a `mod` or a `fn`
+    body, keep the bare name, so every pre-existing key for those survives.
+    Where one key still covers several definitions (a `cfg`-gated pair, say)
+    "any documented" remains the deliberately conservative reading: the
+    check fires only when every definition under that key has lost its
+    prose. Under-reporting there is the safer direction for a gate that
+    blocks merges; a mis-aligned key would turn it into a false accusation.
 
     `///` lowers to an outer `#[doc]` attribute, and an attribute is not
     detached from its item by blank lines or ordinary comments - verified
@@ -187,12 +243,35 @@ def documented(text):
     lines = text.splitlines()
     kinds = classify(lines)
     state = {}
+    # Enclosing blocks as (depth the block opened at, impl key or None).
+    # A `mod` or `fn` body pushes None so that only an impl qualifies.
+    blocks = []
+    depth = 0
+    # An impl header whose `{` is on a later line (a `where` clause), held
+    # until the brace that opens its body arrives.
+    pending = None
     for i, line in enumerate(lines):
+        if kinds[i] == CODE:
+            header = IMPL_HEADER.match(line)
+            if header:
+                pending = impl_key(header.group("rest"))
+            delta = brace_delta(line)
+            if delta > 0:
+                blocks.append((depth, pending))
+                pending = None
+            depth += delta
+            while blocks and blocks[-1][0] >= depth:
+                blocks.pop()
         m = ITEM.match(line)
         if not m:
             continue
         # Exactly one alternative captures per match.
         name = next(g for g in m.groups() if g)
+        # The innermost impl on the stack, if any. A block with no key (a
+        # nested `fn` or `mod`) is transparent: it still lives in the impl.
+        scope = next((k for _, k in reversed(blocks) if k), None)
+        if scope:
+            name = f"{scope}::{name}"
         j = i - 1
         while j >= 0 and kinds[j] in (ATTR, SKIP):
             j -= 1
@@ -210,7 +289,8 @@ def main():
     exempt = {
         (path, name)
         for path, name in re.findall(
-            r"doc-removal:\s*([\w./-]+\.rs)::([A-Za-z_]\w*)", declared
+            r"doc-removal:\s*([\w./-]+\.rs)::((?:[A-Za-z_][\w:]*(?: for [A-Za-z_][\w:]*)?::)?[A-Za-z_]\w*)",
+            declared,
         )
     }
     changed = [

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -245,6 +245,88 @@ class ItemKinds(unittest.TestCase):
             gate.documented(text), {"a": True, "b": True, "X::c": True, "d": True}
         )
 
+    def test_a_bodyless_impl_does_not_qualify_the_next_block(self):
+        """`impl Eq for X {}` opens and closes on one line. Its header must
+        not survive onto the next block, or a `mod` after a marker impl has
+        every item keyed to that impl, and a capture inside it is filed under
+        a key the base revision never had: a missed report, on the exact
+        shape (`src/widgets/file_finder.rs`) the repo contains."""
+        text = "impl Eq for X {}\nmod util {\n    /// doc\n    pub fn go() {}\n}\n"
+        self.assertEqual(gate.documented(text), {"go": True})
+        # And the base-vs-head comparison still reports the capture.
+        captured = (
+            "impl Eq for X {}\nmod util {\n    /// doc\n    pub fn newcomer() {}\n"
+            "    pub fn go() {}\n}\n"
+        )
+        after = gate.documented(captured)
+        self.assertEqual(after.get("go"), False, f"go lost its doc: {after}")
+
+    def test_raw_strings_do_not_break_block_tracking(self):
+        """`r#"{"#` is not a `"..."`, and a multi-line raw string of JSON is
+        braces all the way down. Both left the counter inside a block that
+        had closed, on seven real files under src/."""
+        single = (
+            'impl Foo {\n    /// doc\n    fn m() {\n'
+            '        let j = r#"[{"key": "click"}]"#;\n    }\n}\n'
+            "/// top\nfn top() {}\n"
+        )
+        self.assertEqual(gate.documented(single), {"Foo::m": True, "top": True})
+        multi = (
+            'impl Foo {\n    /// doc\n    fn m() {\n'
+            '        let j = r#"{ "tasks": [\n'
+            '            { "label": "x" }\n'
+            '        ] }"#;\n    }\n}\n'
+            "/// top\nfn top() {}\n"
+        )
+        self.assertEqual(gate.documented(multi), {"Foo::m": True, "top": True})
+        plain_multi = (
+            'impl Foo {\n    /// doc\n    fn m() {\n'
+            '        let s = "{ opens here\n'
+            '            and closes here }";\n    }\n}\n'
+            "/// top\nfn top() {}\n"
+        )
+        self.assertEqual(gate.documented(plain_multi), {"Foo::m": True, "top": True})
+
+    def test_a_header_wrapped_by_rustfmt_keeps_its_key(self):
+        """`impl<T>` alone on the first line strips to nothing; the key must
+        come from the whole header, or a rewrap moves every method to a
+        bare key and a capture in that PR goes unreported."""
+        text = "impl<T>\n    Trait for X<T>\n{\n    /// doc\n    fn m() {}\n}\n"
+        self.assertEqual(gate.documented(text), {"Trait for X::m": True})
+
+    def test_trait_methods_are_keyed_by_their_trait(self):
+        """Two traits declaring `id` are the same shape as two impls
+        defining `new`."""
+        text = (
+            "trait A {\n    /// a\n    fn id(&self);\n}\n"
+            "trait B: Clone {\n    /// b\n    fn id(&self);\n}\n"
+        )
+        self.assertEqual(
+            gate.documented(text),
+            {"A": False, "trait A::id": True, "B": False, "trait B::id": True},
+            "the traits are items in their own scope; their methods are in theirs",
+        )
+
+    def test_the_block_tracker_is_balanced_at_eof_on_every_real_file(self):
+        """The counter is line-based, so the only proof it kept up with a
+        file is that it ends where it started: depth zero, no open block.
+        Run over every Rust file in the repo, so a new literal shape that
+        desyncs it fails here before it mis-keys anything."""
+        src = Path(__file__).resolve().parents[2] / "src"
+        files = sorted(src.rglob("*.rs"))
+        self.assertGreater(len(files), 50, "the control corpus is missing")
+        unbalanced = []
+        for f in files:
+            lines = f.read_text().splitlines()
+            kinds = gate.classify(lines)
+            t = gate.BlockTracker()
+            for line, kind in zip(lines, kinds):
+                if kind == gate.CODE:
+                    t.feed(line)
+            if t.depth != 0 or t.blocks or t.open_string is not None:
+                unbalanced.append((str(f.relative_to(src)), t.depth, t.blocks, t.open_string))
+        self.assertEqual(unbalanced, [], "the tracker lost count in these files")
+
     def test_same_named_items_in_the_same_scope_are_still_merged(self):
         """Two definitions under ONE key (a `cfg`-gated pair, say) keep the
         conservative "any documented" reading: the gate under-reports there

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -162,31 +162,117 @@ class ItemKinds(unittest.TestCase):
         state = gate.documented('/// doc\nconst A: &str = "const B: u8 = 1;";\n')
         self.assertEqual(state, {"A": True}, "B is inside a string, not an item")
 
-    def test_same_named_items_are_merged_which_under_reports(self):
-        """A KNOWN limitation, pinned so it is a decision rather than a bug.
+    def test_methods_are_keyed_by_their_enclosing_impl(self):
+        """Two `fn new` in different impl blocks are two items (#405).
 
-        Two `fn new` in different impl blocks share one key, and "any
-        documented" wins, so a capture on one is invisible while the other
-        keeps its prose. The alternative is an occurrence-unique key, and
-        every candidate (position, index, enclosing type) has to line up
-        across two revisions that may have moved the item; a key that
-        mis-aligns turns a silent miss into a false accusation, which is
-        worse for a gate that blocks merges.
-
-        So the gate under-reports on duplicate names, deliberately. Tracked
-        for a proper fix; pinned here so a future change that alters this
-        behaviour has to look at this test and say which way it went.
+        Keyed by bare name, "any documented" merged them and a capture on
+        one was invisible while the other kept its prose. The enclosing
+        `impl` header is the occurrence-unique key that still lines up
+        across revisions: an edit above the block moves it, but does not
+        change what it is an impl of.
         """
-        both_documented = "/// a\nfn new() {}\n\n/// b\nfn new() {}\n"
-        one_captured = "/// a\nfn other() {}\nfn new() {}\n\n/// b\nfn new() {}\n"
-        self.assertEqual(gate.documented(both_documented), {"new": True})
+        both_documented = (
+            "impl A {\n    /// a\n    fn new() {}\n}\n\n"
+            "impl B {\n    /// b\n    fn new() {}\n}\n"
+        )
+        one_captured = (
+            "impl A {\n    /// a\n    fn other() {}\n    fn new() {}\n}\n\n"
+            "impl B {\n    /// b\n    fn new() {}\n}\n"
+        )
+        self.assertEqual(
+            gate.documented(both_documented), {"A::new": True, "B::new": True}
+        )
         self.assertEqual(
             gate.documented(one_captured),
-            {"other": True, "new": True},
-            "the surviving doc on the second `new` keeps the key True, so the "
-            "capture on the first is not visible: under-reporting, not a "
-            "false alarm",
+            {"A::other": True, "A::new": False, "B::new": True},
+            "the capture on A::new is visible even though B::new kept its doc",
         )
+
+    def test_trait_impls_for_the_same_type_are_distinct_blocks(self):
+        """`impl Display for X` and `impl Debug for X` both define `fmt`;
+        the type alone is not a unique key, so the whole header is."""
+        text = (
+            "impl fmt::Display for X {\n    /// d\n    fn fmt(&self) {}\n}\n"
+            "impl fmt::Debug for X {\n    fn fmt(&self) {}\n}\n"
+        )
+        self.assertEqual(
+            gate.documented(text),
+            {"fmt::Display for X::fmt": True, "fmt::Debug for X::fmt": False},
+        )
+
+    def test_impl_header_shapes(self):
+        """Generics, lifetimes, a `where` clause with the brace on its own
+        line, and a trait impl: each still yields the same key, so a branch
+        that reformats the header does not move the item to a new key."""
+        for label, header in [
+            ("plain", "impl Foo {"),
+            ("generic", "impl<'a, T: Clone> Foo<'a, T> {"),
+            ("where clause, brace on the next line", "impl<T> Foo<T>\nwhere\n    T: Clone,\n{"),
+            ("unsafe impl", "unsafe impl Foo {"),
+        ]:
+            state = gate.documented(f"{header}\n    /// doc\n    fn new() {{}}\n}}\n")
+            self.assertEqual(state, {"Foo::new": True}, label)
+        state = gate.documented(
+            "impl<T> Iterator for Foo<T> {\n    /// doc\n    fn next(&mut self) {}\n}\n"
+        )
+        self.assertEqual(state, {"Iterator for Foo::next": True})
+
+    def test_braces_in_strings_and_chars_do_not_break_block_tracking(self):
+        """Format strings are full of braces. Counting them would leave the
+        scanner inside a block that has closed, and key the next top-level
+        item to an impl it is not in."""
+        text = (
+            "impl Foo {\n"
+            "    /// doc\n"
+            '    fn new() { let _ = format!("{{ {x} }}"); let c = \'{\'; }\n'
+            "}\n"
+            "/// top\n"
+            "fn top() {}\n"
+        )
+        self.assertEqual(gate.documented(text), {"Foo::new": True, "top": True})
+
+    def test_items_outside_any_impl_keep_the_bare_name(self):
+        """Top-level items, and items inside `mod` or `fn` bodies, are keyed
+        by name as before: the impl header is the only qualifier, so every
+        existing key for a free item survives unchanged."""
+        text = (
+            "/// a\nfn a() {}\n"
+            "mod m {\n    /// b\n    pub fn b() {}\n}\n"
+            "impl X {\n    /// c\n    fn c() {}\n}\n"
+            "/// d\nfn d() {}\n"
+        )
+        self.assertEqual(
+            gate.documented(text), {"a": True, "b": True, "X::c": True, "d": True}
+        )
+
+    def test_same_named_items_in_the_same_scope_are_still_merged(self):
+        """Two definitions under ONE key (a `cfg`-gated pair, say) keep the
+        conservative "any documented" reading: the gate under-reports there
+        rather than accusing the wrong twin."""
+        text = "/// a\nfn new() {}\n\n/// b\nfn new() {}\n"
+        one_captured = "/// a\nfn other() {}\nfn new() {}\n\n/// b\nfn new() {}\n"
+        self.assertEqual(gate.documented(text), {"new": True})
+        self.assertEqual(gate.documented(one_captured), {"other": True, "new": True})
+
+    def test_a_capture_on_one_impl_of_a_shared_method_name_is_reported(self):
+        """End to end: the #405 shape blocks the merge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit(
+                "a.rs",
+                "impl A {\n    /// a\n    fn new() {}\n}\n"
+                "impl B {\n    /// b\n    fn new() {}\n}\n",
+            )
+            repo.branch("work")
+            repo.commit(
+                "a.rs",
+                "impl A {\n    /// a\n    fn other() {}\n    fn new() {}\n}\n"
+                "impl B {\n    /// b\n    fn new() {}\n}\n",
+            )
+            self.assertEqual(repo.exit_code(), 1, "A::new lost its doc")
+            # The declared-removal escape hatch takes the qualified key.
+            repo.commit("a.rs", "// nudge\n" + (repo.path / "a.rs").read_text(), "ok\n\ndoc-removal: a.rs::A::new")
+            self.assertEqual(repo.exit_code(), 0, "a declared A::new removal is exempt")
 
     def test_the_error_names_the_revision_the_doc_was_last_seen_at(self):
         """For a file the branch ADDED, `base` is the wrong revision to cite.


### PR DESCRIPTION
The gate keyed its before/after comparison by bare item name, and where
a file defined the same name more than once took "any definition
documented" as documented. `new` across impl blocks is the common
shape, so a capture on one `new` hid behind the other's surviving doc
and the gate reported no loss (#405).

Methods are now keyed `<impl header>::<name>` (`Foo::new`,
`Display for Foo::fmt`), with generics and lifetimes stripped so a
reformatted header does not move the key. The header is the whole
`Trait for Type` rather than the type alone, since two trait impls on
one type both define `fmt`. Block structure is tracked by brace depth
with string and char literals removed first, so a format string's
braces do not leave the scanner inside a block that has closed. Items
outside any impl, and items in a `mod` or `fn` body, keep the bare
name, so every existing key for those survives; where one key still
covers several definitions the conservative "any documented" reading
stays.

`doc-removal:` accepts the qualified key (`a.rs::A::new`).

Control: the original and the new gate report the same two items over
origin/main~40..origin/main, so the new keys add no false accusation on
real history.

Closes #405