### PR TITLE
ci: probe a file's existence at the base by exit status, not stdout

### DIFF
--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -213,33 +213,48 @@ class BlockTracker:
             self.blocks.pop()
 
 
-def git(*args, allow_missing_path=False, allow_fail=False):
+def git(*args, allow_missing_path=False):
     """Run git, failing closed.
 
     A silent failure here is worse than a crash: an errored `git diff` yields
     an empty file list, the checker reports "no documentation lost" and exits
     zero, and the gate has passed by not running.
 
-    `allow_missing_path` narrows that tolerance to exactly the expected case,
-    and `allow_fail` is separate and narrower still: it is for a probe whose
-    exit status IS the answer, and its empty return is never read as content.
+    `allow_missing_path` narrows that tolerance to exactly the expected case.
     Tolerating every non-zero exit would let an invalid revision or a
     malformed object read as empty content, which is the same fail-open bug
-    one door further in.
+    one door further in. A probe whose exit status IS the answer does not go
+    through here at all: see `exists_at`.
     """
     proc = subprocess.run(["git", *args], capture_output=True, text=True)
     if proc.returncode != 0:
-        # `allow_fail` is for a PROBE whose non-zero exit is the answer
-        # (`cat-file -e` asking whether a path exists), never for a command
-        # whose output is then read as content.
-        if allow_fail:
-            return ""
         if allow_missing_path and MISSING_PATH.search(proc.stderr):
             return ""
         raise SystemExit(
             f"git {' '.join(args)} failed ({proc.returncode}): {proc.stderr.strip()}"
         )
     return proc.stdout
+
+
+def exists_at(rev, path):
+    """Whether `path` is present at `rev`.
+
+    A probe: `git cat-file -e` prints nothing either way and answers with
+    its exit status. Reading its stdout, as the added-file detection once
+    did, made every changed file look branch-added: each took the pairwise
+    commit walk (minutes on a real branch, for nothing) and a capture in an
+    existing file was reported twice, once per loop.
+    """
+    proc = subprocess.run(
+        ["git", "cat-file", "-e", f"{rev}:{path}"], capture_output=True, text=True
+    )
+    return proc.returncode == 0
+
+
+def added_files(base, changed):
+    """The changed files that do not exist at `base`: the branch added them,
+    so their history lives only in its own commits."""
+    return [f for f in changed if not exists_at(base, f)]
 
 
 def is_doc(line):
@@ -389,7 +404,7 @@ def main():
     # empty and no loss can ever be reported in it: a doc captured within the
     # branch is invisible to a merge-base comparison. Those files are checked
     # commit-by-commit instead, which is the only place their history exists.
-    added = [f for f in changed if not git("cat-file", "-e", f"{base}:{f}", allow_missing_path=True, allow_fail=True)]
+    added = added_files(base, changed)
     if added:
         # What matters is the state at HEAD. A doc captured in one commit and
         # restored in a later one is not a loss: the branch is fine, and
@@ -420,9 +435,9 @@ def main():
     for f in changed:
         # A path can legitimately be absent on one side: the branch added the
         # file, or deleted it. That is the one git failure this tolerates -
-        # `allow_fail` exists for exactly it, and not passing it here made the
-        # gate abort on every PR that adds a Rust file, which is how it failed
-        # on the first one that did.
+        # `allow_missing_path` exists for exactly it, and not passing it here
+        # made the gate abort on every PR that adds a Rust file, which is how
+        # it failed on the first one that did.
         before = documented(git("show", f"{base}:{f}", allow_missing_path=True))
         after = documented(git("show", f"{head}:{f}", allow_missing_path=True))
         for name, had_doc in before.items():

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -9,6 +9,9 @@ about parsing: what a merge base can see, and what it cannot.
 
 from __future__ import annotations
 
+import contextlib
+import io
+import os
 import subprocess
 import sys
 import tempfile
@@ -433,6 +436,54 @@ class GitShapes(unittest.TestCase):
             repo.commit("a.rs", CAPTURED_CONST)
             self.assertEqual(
                 repo.exit_code(), 1, "the gate must fail on a captured doc"
+            )
+
+    def test_a_file_present_at_the_base_is_not_treated_as_added(self):
+        """`git cat-file -e` prints nothing on success, so a probe that read
+        its stdout took every changed file for a branch-added one: each
+        went through the pairwise commit walk (the slow path, minutes on a
+        real branch) and a capture in an existing file was reported twice,
+        once per loop. The probe must read the exit status."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", DOCUMENTED_CONST)
+            repo.branch("work")
+            repo.commit("a.rs", CAPTURED_CONST)
+            repo.commit("new.rs", "/// n\nfn n() {}\n")
+            cwd = os.getcwd()
+            os.chdir(repo.path)
+            try:
+                self.assertTrue(gate.exists_at("main", "a.rs"))
+                self.assertFalse(gate.exists_at("main", "new.rs"))
+                self.assertEqual(gate.added_files("main", ["a.rs", "new.rs"]), ["new.rs"])
+            finally:
+                os.chdir(cwd)
+
+    def test_a_capture_in_an_existing_file_is_reported_exactly_once(self):
+        """Two commits on the branch, so the pairwise walk has a pair to
+        compare: with every file mistaken for branch-added, the capture
+        was reported by that walk AND by the base comparison."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", DOCUMENTED_CONST)
+            repo.branch("work")
+            repo.commit("a.rs", DOCUMENTED_CONST + "\n/// Extra.\nconst EXTRA: u8 = 1;\n")
+            repo.commit("a.rs", CAPTURED_CONST + "\n/// Extra.\nconst EXTRA: u8 = 1;\n")
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            out = io.StringIO()
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            self.assertEqual(
+                out.getvalue().count("::error"),
+                1,
+                f"one loss, one annotation: {out.getvalue()}",
             )
 
     def test_a_capture_inside_a_file_the_branch_added_is_reported(self):


### PR DESCRIPTION
`git cat-file -e` prints nothing on success, so the added-file detection
that read its stdout took every changed file for a branch-added one:
each went through the pairwise commit walk (over origin/main~40..main
that was more than ten minutes of git show calls, for nothing) and a
capture in an existing file was reported twice, once by that walk and
once by the base comparison.

`exists_at` reads the exit status, `added_files` uses it, and `git()`
loses the `allow_fail` mode that only that probe used. The same 40
commits now take under a minute and report each of the two real
losses once. Two tests pin it: a file present at the base is not
"added", and a capture in an existing file yields exactly one
annotation.

## Control
- `scripts/check_doc_ownership.py origin/main~40 origin/main`: 2 annotations in 54 s (before: 4 annotations, the run did not finish inside 10 minutes).
- `python3 -m unittest scripts.tests.test_doc_ownership`: 26 passed; the two new tests were red on the parent (`AttributeError: exists_at`, and `2 != 1` annotations).

CI/scripts only: no version bump or release note.