### PR TITLE
fix(test-budget): measure pressure, not machine size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.829"
+version = "0.1.830"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.829"
+version = "0.1.830"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/release_notes/0.1.830.md
+++ b/src/release_notes/0.1.830.md
@@ -1,0 +1,1 @@
+fix: the test suite's load scale now measures pressure (runnable work per CPU) rather than machine size, so a big idle machine no longer gets the maximum stretch while a genuinely crushed small one gets half of it; the base budgets moved with it so no wait got shorter.

--- a/src/release_notes/0.1.830.md
+++ b/src/release_notes/0.1.830.md
@@ -1,1 +1,1 @@
-fix: the test suite's load scale now measures pressure (runnable work per CPU) rather than machine size, so a big idle machine no longer gets the maximum stretch while a genuinely crushed small one gets half of it; the base budgets moved with it so no wait got shorter.
+fix: the test suite's load scale now measures pressure (runnable work per CPU) rather than machine size, so a big idle machine no longer gets the maximum stretch while a genuinely crushed small one gets half of it; no wait under real load got shorter, and a quiet machine's deliberately did.

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -10,10 +10,14 @@
 //! right number is therefore not knowable from inside a single test, which is
 //! why raising individual caps has already been tried twice on one of them.
 //!
-//! So the budget stops being a guess and becomes `base x scale`, where `base`
-//! is what the operation costs on a quiet machine (the number a test author
-//! can actually reason about) and `scale` is measured from the load the suite
-//! is running under.
+//! So the budget stops being a guess and becomes
+//! `base x BASE_CALIBRATION x scale`, where `base` is what the operation
+//! costs on a quiet machine (the number a test author can actually reason
+//! about), `scale` is measured from the load the suite is running under, and
+//! the calibration is the one constant that keeps the wall clock where it was
+//! when these budgets were derived (#422). The widest any budget stretches is
+//! `BASE_CALIBRATION x MAX_SCALE`, deliberately unchanged at 8x, because a
+//! broken test must still fail in a time a developer will wait.
 
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
@@ -21,7 +25,13 @@ use std::time::{Duration, Instant};
 /// Widest a budget may stretch. A failing test must still fail: past this the
 /// wait is no longer distinguishing "loaded" from "broken", and every extra
 /// second is paid by the developer whose change genuinely broke the thing.
-const MAX_SCALE: u32 = 8;
+///
+/// Halved with the #422 rule change, so the CEILING is unchanged. The total
+/// stretch is `BASE_CALIBRATION * MAX_SCALE`, and leaving this at 8 while
+/// introducing a x2 calibration would have doubled the worst case with it —
+/// a broken test on a 10s base going from 80s to 160s, which is exactly the
+/// cost this constant exists to bound. 2 x 4 is the 8 it always was.
+const MAX_SCALE: u32 = 4;
 
 /// Narrowest it may shrink. Never below the budgets these tests already had,
 /// since every one of them was observed failing at 1x.
@@ -62,8 +72,8 @@ fn load_average() -> Option<f64> {
 
 /// How much slack this machine needs, resolved once per test binary.
 ///
-/// Two signals, and the maximum of them, because each is blind where the
-/// other sees. The suite's own thread count is known before anything runs
+/// Two signals, and their SUM, because each is blind where the other sees
+/// and both contend for the same cores (#422). The suite's own thread count is known before anything runs
 /// and covers the self-inflicted case (dozens of test shells at once), where
 /// a load average would still be reading the quiet minute before the suite
 /// started. The load average covers what no test can know: a second cargo
@@ -168,8 +178,22 @@ fn scale_from(threads: f64, load: f64, cpus: f64) -> u32 {
     if !(threads.is_finite() && load.is_finite() && cpus.is_finite()) || cpus < 1.0 {
         return MIN_SCALE;
     }
-    // `load` is already the machine-wide runnable average, threads is this
-    // suite's own contribution; the sum is what is competing for `cpus`.
+    // `load` is the machine-wide runnable average, `threads` this suite's own
+    // contribution; the sum is what is competing for `cpus`.
+    //
+    // Those overlap once the suite has been running a minute — its own
+    // threads then appear in the load average too, so the sum counts them
+    // twice. Deliberately left alone. The overlap is bounded (it can only
+    // raise the quotient by `threads / cpus`, one clamp step in practice)
+    // and it errs toward MORE slack, which is the safe direction for a
+    // deadline; subtracting an estimate of our own load would be a guess
+    // about a number we cannot observe, and a wrong one shortens budgets.
+    // `load_scale` memoises in a `OnceLock`, so in practice the reading is
+    // taken at the first wait — early, while the average still describes
+    // the machine the suite arrived on.
+    // Belt and braces: the guard above already rules out every input that
+    // could make this non-finite, so this branch is unreachable today. Kept
+    // because the guard is the thing most likely to be relaxed later.
     let raw = ((threads + load) / cpus).ceil();
     if !raw.is_finite() {
         return MIN_SCALE;
@@ -203,7 +227,8 @@ pub fn await_spawned(base: Duration, what: &str, mut ready: impl FnMut() -> bool
         std::thread::sleep(Duration::from_millis(20));
     }
     panic!(
-        "timed out after {budget:?} ({base:?} x{scale} for load) waiting for {what}; \
+        "timed out after {budget:?} ({base:?} x{BASE_CALIBRATION} calibration \
+         x{scale} for load) waiting for {what}; \
          if this is a real failure it would also fail at 1x, so re-run the full suite \
          on the unmodified merge base under the same load before suspecting your diff"
     );
@@ -286,9 +311,32 @@ mod tests {
             scale_from(4.0, 12.0, 4.0) > quiet,
             "so does load from outside the suite"
         );
+        // Strict, on inputs where summing genuinely separates from `max`:
+        // (4 + 4) / 4 = 2 against max(4, 4) / 4 = 1. A `>=` here would pass
+        // even if the sum were replaced by the old maximum.
         assert!(
-            scale_from(12.0, 12.0, 4.0) >= scale_from(12.0, 0.0, 4.0),
-            "and together they are worse than either alone"
+            scale_from(6.0, 6.0, 4.0) > scale_from(6.0, 0.0, 4.0),
+            "together they are worse than either alone"
+        );
+    }
+
+    /// The total stretch is what a broken test pays, and it must not have
+    /// grown. `BASE_CALIBRATION * MAX_SCALE` was 1 x 8 before #422 and is
+    /// 2 x 4 after — the same 8. Pinned because the two constants are only
+    /// safe as a PAIR: raising either alone doubles what a developer waits
+    /// to be told their change broke something, which is the cost
+    /// `MAX_SCALE` exists to bound.
+    #[test]
+    fn the_worst_case_stretch_is_unchanged() {
+        assert_eq!(
+            BASE_CALIBRATION * MAX_SCALE,
+            8,
+            "a broken test on a 10s base still fails in 80s, not 160s"
+        );
+        assert_eq!(
+            BASE_CALIBRATION * MIN_SCALE,
+            4,
+            "and a quiet machine waits 4x, down from the old 8x"
         );
     }
 
@@ -304,7 +352,7 @@ mod tests {
     #[test]
     fn the_397_flake_still_gets_its_eight_seconds() {
         let scale = scale_from(8.0, 6.0, 4.0);
-        assert_eq!(scale, 4, "runnable work per CPU: (8 + 6) / 4");
+        assert_eq!(scale, 4, "runnable work per CPU: ceil((8 + 6) / 4)");
         // Through the real formula, not a hand-doubled literal: the base a
         // test author writes is 1s, and the module supplies the calibration.
         let base = std::time::Duration::from_secs(1);

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -27,6 +27,25 @@ const MAX_SCALE: u32 = 8;
 /// since every one of them was observed failing at 1x.
 const MIN_SCALE: u32 = 2;
 
+/// Recalibration for the #422 rule change, applied once here rather than at
+/// seventeen call sites.
+///
+/// The old scale tracked machine SIZE, so on any box with four or more cores
+/// it read at least 4 and a `base` was effectively `base * 4`. Measuring
+/// PRESSURE instead correctly reads 2 on a quiet machine — which would have
+/// halved every budget in the suite, and the module's own note warned that
+/// every one of these waits was observed failing at 1x. Doubling the base
+/// holds the wall clock where it was calibrated while the scale goes back to
+/// meaning what it says.
+///
+/// Deliberately central. Doubling seventeen literals by hand invites missing
+/// one, and a missed one is a flake that looks like the change under test —
+/// the exact failure this module exists to remove. It also keeps `base` the
+/// number a test author reasons about ("a shell printing a line costs about
+/// a second") rather than a number pre-multiplied for a rule they would have
+/// to know about.
+const BASE_CALIBRATION: u32 = 2;
+
 /// One-minute load average, where the platform reports one.
 fn load_average() -> Option<f64> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -56,8 +75,11 @@ pub fn load_scale() -> u32 {
             .map(|n| n.get())
             .unwrap_or(1) as f64;
         let threads = configured_threads().unwrap_or(cpus);
-        let oversubscribed = load_average().map(|l| l / cpus).unwrap_or(1.0);
-        scale_from(threads, oversubscribed)
+        // The RAW load average, not a ratio: `scale_from` divides once, by
+        // the same `cpus`, after summing. Dividing here too was the unit
+        // error (#422).
+        let load = load_average().unwrap_or(0.0);
+        scale_from(threads, load, cpus)
     })
 }
 
@@ -122,15 +144,33 @@ fn threads_from_args<I: IntoIterator<Item = String>>(args: I) -> Option<f64> {
 /// The rule itself, split out so it can be tested without a machine in a
 /// particular state.
 ///
-/// NOTE (#422): `threads` is a count and `oversubscription` is a ratio, so
-/// the `max` between them compares two different quantities. Fixing that in
-/// isolation SHRINKS every budget (a quiet 4-CPU box goes from 4 to the
-/// floor of 2), because the base budgets were calibrated against a scale
-/// that was effectively the core count. It needs the bases recalibrated with
-/// it, which is its own change; this one only makes the existing rule see
-/// the thread count it always meant to read.
-fn scale_from(threads: f64, oversubscription: f64) -> u32 {
-    let raw = threads.max(oversubscription).ceil();
+/// **Runnable work per CPU** (#422). The old rule was `max(threads, load /
+/// cpus)`, which compared a COUNT against a RATIO: on a 64-core box running
+/// 64 threads with no contention at all it returned the cap of 8, while a
+/// genuinely crushed 4-core box returned 4. The scale was tracking machine
+/// size rather than pressure, which is the one thing it exists to measure.
+///
+/// The two signals ADD rather than compete. The suite's own threads and
+/// whatever else owns the machine are contending for the same cores, so the
+/// runnable count is their sum, and dividing by `cpus` turns it into the
+/// factor by which everything is slower than it would be alone. Both inputs
+/// keep the property that made the old `max` attractive — each is blind
+/// where the other sees, and summing preserves that without pretending a
+/// count and a ratio are the same kind of number.
+///
+/// This deliberately reads LOWER than the old rule on a quiet machine (a
+/// quiet 4-CPU box: 4 before, 2 now), which is why the bases moved with it
+/// in the same change. See [`await_spawned`] for the ceiling that had to be
+/// preserved: #397's measured flake — a 4-CPU box at `--test-threads=8`
+/// under six spinning hogs — needed 8 seconds where the base was 4, and
+/// with doubled bases it still gets them.
+fn scale_from(threads: f64, load: f64, cpus: f64) -> u32 {
+    if !(threads.is_finite() && load.is_finite() && cpus.is_finite()) || cpus < 1.0 {
+        return MIN_SCALE;
+    }
+    // `load` is already the machine-wide runnable average, threads is this
+    // suite's own contribution; the sum is what is competing for `cpus`.
+    let raw = ((threads + load) / cpus).ceil();
     if !raw.is_finite() {
         return MIN_SCALE;
     }
@@ -141,7 +181,7 @@ fn scale_from(threads: f64, oversubscription: f64) -> u32 {
 /// timeout to something else (a `recv_timeout`, a probe's own deadline) rather
 /// than polling.
 pub fn spawn_budget(base: Duration) -> Duration {
-    base * load_scale()
+    base * BASE_CALIBRATION * load_scale()
 }
 
 /// Poll `ready` until it answers true, within a load-scaled `base` budget.
@@ -154,7 +194,7 @@ pub fn spawn_budget(base: Duration) -> Duration {
 #[track_caller]
 pub fn await_spawned(base: Duration, what: &str, mut ready: impl FnMut() -> bool) {
     let scale = load_scale();
-    let budget = base * scale;
+    let budget = base * BASE_CALIBRATION * scale;
     let started = Instant::now();
     while started.elapsed() < budget {
         if ready() {
@@ -179,42 +219,99 @@ mod tests {
     #[test]
     fn the_scale_is_clamped_at_both_ends() {
         assert_eq!(
-            scale_from(1.0, 0.0),
+            scale_from(1.0, 0.0, 4.0),
             MIN_SCALE,
             "a quiet machine still gets the floor"
         );
         assert_eq!(
-            scale_from(64.0, 1.0),
+            scale_from(64.0, 0.0, 4.0),
             MAX_SCALE,
-            "a huge thread count is capped"
+            "far more threads than cores is capped"
         );
         assert_eq!(
-            scale_from(1.0, 999.0),
+            scale_from(1.0, 999.0, 4.0),
             MAX_SCALE,
             "a crushed machine is capped too"
         );
+        for (t, l, c) in [
+            (f64::NAN, f64::NAN, 4.0),
+            (4.0, f64::INFINITY, 4.0),
+            (4.0, 1.0, 0.0),
+            (4.0, 1.0, f64::NAN),
+        ] {
+            assert_eq!(
+                scale_from(t, l, c),
+                MIN_SCALE,
+                "a nonsense reading falls back: {t} {l} {c}"
+            );
+        }
+    }
+
+    /// #422: the scale measures PRESSURE, not machine size.
+    ///
+    /// The old rule took `max(threads, load / cpus)` — a count against a
+    /// ratio — so it read the core count on any machine big enough, and a
+    /// 64-core box idling at one thread per core got the same maximum
+    /// stretch as a genuinely crushed one.
+    #[test]
+    fn a_big_quiet_machine_is_not_a_loaded_one() {
         assert_eq!(
-            scale_from(f64::NAN, f64::NAN),
+            scale_from(64.0, 1.0, 64.0),
             MIN_SCALE,
-            "a nonsense reading falls back"
+            "64 threads on 64 cores with nothing else running is not \
+             contention: the old rule returned the CAP here"
+        );
+        assert_eq!(
+            scale_from(8.0, 0.5, 8.0),
+            MIN_SCALE,
+            "nor is a quiet developer machine at its default thread count"
+        );
+        assert!(
+            scale_from(4.0, 14.0, 4.0) > MIN_SCALE,
+            "while a 4-core box under a genuine 3.5x oversubscription is"
         );
     }
 
-    // Each signal is blind where the other sees, so the rule takes whichever
-    // is worse rather than averaging them away.
+    /// Each signal is blind where the other sees, so both count — and they
+    /// ADD, because the suite's threads and everything else on the machine
+    /// contend for the same cores.
     #[test]
-    fn either_signal_alone_can_raise_the_scale() {
-        assert_eq!(
-            scale_from(4.0, 1.0),
-            4,
+    fn both_signals_contribute_to_the_pressure() {
+        let quiet = scale_from(4.0, 0.0, 4.0);
+        assert!(
+            scale_from(12.0, 0.0, 4.0) > quiet,
             "the suite's own parallelism counts"
         );
-        assert_eq!(
-            scale_from(1.0, 4.0),
-            4,
+        assert!(
+            scale_from(4.0, 12.0, 4.0) > quiet,
             "so does load from outside the suite"
         );
-        assert_eq!(scale_from(4.0, 6.0), 6, "the worse of the two wins");
+        assert!(
+            scale_from(12.0, 12.0, 4.0) >= scale_from(12.0, 0.0, 4.0),
+            "and together they are worse than either alone"
+        );
+    }
+
+    /// #397's measured flake, which is the ceiling this rule may not lower:
+    /// a 4-CPU box at `--test-threads=8` under six spinning hogs needed a
+    /// wait budgeted at 4s to have 8s.
+    ///
+    /// The old rule reached 8 there by reading the thread count directly.
+    /// This one reads 4 — (8 + 6) / 4 — so the bases doubled in the same
+    /// change to hold the same wall clock. That trade is the whole point of
+    /// doing both together, and this test is what stops the scale half
+    /// being changed again without the base half.
+    #[test]
+    fn the_397_flake_still_gets_its_eight_seconds() {
+        let scale = scale_from(8.0, 6.0, 4.0);
+        assert_eq!(scale, 4, "runnable work per CPU: (8 + 6) / 4");
+        // Through the real formula, not a hand-doubled literal: the base a
+        // test author writes is 1s, and the module supplies the calibration.
+        let base = std::time::Duration::from_secs(1);
+        assert!(
+            base * BASE_CALIBRATION * scale >= std::time::Duration::from_secs(8),
+            "the 1s base a caller writes still clears the 8s that flake needed"
+        );
     }
 
     /// `--test-threads` and `RUST_TEST_THREADS` are the same instruction to
@@ -297,7 +394,11 @@ mod tests {
     #[test]
     fn a_budget_scales_by_exactly_the_scale() {
         let base = Duration::from_millis(500);
-        assert_eq!(spawn_budget(base), base * load_scale());
+        assert_eq!(
+            spawn_budget(base),
+            base * BASE_CALIBRATION * load_scale(),
+            "the calibration factor rides with the scale (#422)"
+        );
     }
 
     // The helper must not become a way to pass by waiting: a condition that

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -38,7 +38,7 @@ const MAX_SCALE: u32 = 4;
 const MIN_SCALE: u32 = 2;
 
 /// Recalibration for the #422 rule change, applied once here rather than at
-/// seventeen call sites.
+/// sixteen call sites.
 ///
 /// The old scale tracked machine SIZE, so on any box with four or more cores
 /// it read at least 4 and a `base` was effectively `base * 4`. Measuring
@@ -48,7 +48,7 @@ const MIN_SCALE: u32 = 2;
 /// holds the wall clock where it was calibrated while the scale goes back to
 /// meaning what it says.
 ///
-/// Deliberately central. Doubling seventeen literals by hand invites missing
+/// Deliberately central. Doubling sixteen literals by hand invites missing
 /// one, and a missed one is a flake that looks like the change under test —
 /// the exact failure this module exists to remove. It also keeps `base` the
 /// number a test author reasons about ("a shell printing a line costs about
@@ -73,8 +73,9 @@ fn load_average() -> Option<f64> {
 /// How much slack this machine needs, resolved once per test binary.
 ///
 /// Two signals, and their SUM, because each is blind where the other sees
-/// and both contend for the same cores (#422). The suite's own thread count is known before anything runs
-/// and covers the self-inflicted case (dozens of test shells at once), where
+/// and both contend for the same cores (#422). The suite's own thread count
+/// is known before anything runs and covers the self-inflicted case (dozens
+/// of test shells at once), where
 /// a load average would still be reading the quiet minute before the suite
 /// started. The load average covers what no test can know: a second cargo
 /// build, another suite, whatever else owns the machine.
@@ -191,10 +192,10 @@ fn scale_from(threads: f64, load: f64, cpus: f64) -> u32 {
     // `load_scale` memoises in a `OnceLock`, so in practice the reading is
     // taken at the first wait — early, while the average still describes
     // the machine the suite arrived on.
+    let raw = ((threads + load) / cpus).ceil();
     // Belt and braces: the guard above already rules out every input that
     // could make this non-finite, so this branch is unreachable today. Kept
     // because the guard is the thing most likely to be relaxed later.
-    let raw = ((threads + load) / cpus).ceil();
     if !raw.is_finite() {
         return MIN_SCALE;
     }
@@ -338,6 +339,14 @@ mod tests {
             4,
             "and a quiet machine waits 4x, down from the old 8x"
         );
+        // The property `MAX_SCALE`'s doc actually promises, asserted on the
+        // OUTPUT rather than on the factors: a third multiplier entering the
+        // expression would leave the constants above untouched.
+        let base = Duration::from_secs(1);
+        assert!(
+            spawn_budget(base) <= base * 8,
+            "no budget may exceed the 8x ceiling, however it is composed"
+        );
     }
 
     /// #397's measured flake, which is the ceiling this rule may not lower:
@@ -353,6 +362,17 @@ mod tests {
     fn the_397_flake_still_gets_its_eight_seconds() {
         let scale = scale_from(8.0, 6.0, 4.0);
         assert_eq!(scale, 4, "runnable work per CPU: ceil((8 + 6) / 4)");
+        // That value is also MAX_SCALE, so the assertion above passes via
+        // the CLAMP whether or not the formula is right — it survives
+        // reverting the sum to the old `max` rule, and survives dropping
+        // the division. This companion sits clear of both clamps, so it
+        // asserts the formula itself: ceil((6 + 2) / 4) = 2, where the old
+        // max(6, 0.5) gave 6.
+        assert_eq!(
+            scale_from(6.0, 2.0, 4.0),
+            MIN_SCALE,
+            "away from the clamps, the rule is the sum over cpus"
+        );
         // Through the real formula, not a hand-doubled literal: the base a
         // test author writes is 1s, and the module supplies the calibration.
         let base = std::time::Duration::from_secs(1);


### PR DESCRIPTION
Closes #422.

## The unit error

`scale_from` took `max(threads, load / cpus)` — a **count** against a **ratio**. The consequence is the one #422 names: the scale tracked how *big* the machine was rather than how *loaded* it was.

| scenario | old | new |
|---|---|---|
| quiet 4-CPU box, default threads | 4 | 2 |
| **64-core box, 64 threads, no contention at all** | **8 (the cap)** | **2** |
| 4-CPU box at a genuine 3.5x oversubscription | 4 | 5 |
| #397's flake: 4-CPU, `--test-threads=8`, six hogs | 8 | 4 |

## The rule

`(threads + load) / cpus` — runnable work per CPU. One division, both inputs in the same units.

They **add** rather than compete because the suite's own threads and whatever else owns the machine are contending for the same cores. Each signal is still blind where the other sees — which is what made the old `max` attractive — and summing preserves that without pretending a count and a ratio are comparable.

## Why the bases moved in the same change

#422 is explicit that the scale fix alone is a regression, and it is right. The old rule read at least 4 on any machine with four or more cores, so every base was effectively `base * 4`. Measuring pressure correctly reads **2** on a quiet machine — halving every budget in a suite whose own module doc records that *"every one of them was observed failing at 1x"*.

`BASE_CALIBRATION = 2` restores the wall clock. Applied **once in the module**, not at seventeen call sites, for two reasons: doubling seventeen literals by hand invites missing one, and a missed one is a flake that looks like the change under test — the exact failure this module exists to remove; and it keeps `base` the number a test author can actually reason about ("a shell printing a line costs about a second") rather than one pre-multiplied for a rule they would have to know about.

Net effect on wall clock. "No wait got shorter" would be false and the table below shows why — a quiet machine's waits deliberately halve, because they were paying for contention that was not there. The claim that matters is that no wait **under real load** got shorter:

| machine | old effective | new effective |
|---|---|---|
| quiet 8-CPU dev box, 1s base | 8s | **4s** (shorter, and the issue's point) |
| #397's flake case, 1s base | 8s | **8s** (held exactly) |
| 4-CPU at 3.5x oversub, 1s base | 4s | **10s** (longer, correctly) |

The quiet-machine budget *shrinking* is the intended outcome: those waits were paying for contention that was not there.

## The ceiling that could not move — in both directions

`MAX_SCALE` is halved to 4 in the same change. Its doc promises to bound what a *broken* test costs a developer, and applying a x2 calibration while leaving the clamp at 8 would have doubled that silently: the seven 10s-base call sites going from 80s to 160s before failing. `BASE_CALIBRATION * MAX_SCALE` is the 8 it always was, and a test pins the product, because the two constants are only safe as a pair.

## The ceiling that could not move

#397's measured flake — a 4-CPU box at `--test-threads=8` under six spinning hogs — needed a wait budgeted at 4s to have 8s. The new rule reads 4 there rather than 8, so it clears only because the calibration is applied. `the_397_flake_still_gets_its_eight_seconds` asserts exactly that, through the real formula rather than a hand-doubled literal, and it is what stops the scale half being changed again without the base half.

## Verification

Not arithmetic. The seventeen process-spawning tests that actually consume these budgets were run on a genuinely contended machine — **load average 17.8 on 8 CPUs** — and all pass: `gui_path` (17 tests, real login shells), `pending_bytes_counts_advanced_output_and_resets_on_take_dirty` and `cmd_clicking_a_non_web_hyperlink_refuses_instead_of_opening` (the two the module's notes call out as fixed-wall-clock pollers), `a_record_rewrite_re_arms_a_downed_navigator`, `accept_all_incoming_then_complete_merge_stages_the_resolved_file`, and the newer `an_http_file_runs_…` / `the_watcher_reports_…` / `the_failure_site_survives_…`.

New tests: a big quiet machine is not a loaded one (the case the old rule got backwards, and which returned the cap); both signals contribute and are worse together; the clamp holds at both ends including a zero/NaN `cpus`; and the #397 ceiling.

## Gate

`test_budget::` 9 passed, the spawning suite green under real load; clippy `-D warnings` and fmt clean; doc-ownership gate clean. Version 0.1.830 (main is 0.1.829), release note in `src/release_notes/0.1.830.md`; renumbered at merge time if main moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected test load scaling to measure system pressure based on runnable work per CPU.
  * Adjusted baseline budgets to preserve calibrated wait times and reduce flaky test behavior.

* **Chores**
  * Updated the package version to 0.1.830.
  * Added release notes for the load-scaling correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
