### PR TITLE
feat(explorer): dot the files an agent changed until you review them (#345)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.835"
+version = "0.1.838"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.835"
+version = "0.1.838"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/agent_lane.rs
+++ b/src/agent_lane.rs
@@ -237,6 +237,22 @@ impl AgentLedger {
         rows
     }
 
+    /// Every unreviewed file across every lane, deduplicated.
+    ///
+    /// One set rather than per-agent lists, because the consumer is the
+    /// Explorer's dot (#345) and a file two agents both wrote is one file
+    /// with one row. [`Self::unreviewed_files`] counts the same thing; this
+    /// hands back the paths so a caller can test membership per row, which
+    /// is what the Explorer's decoration needs.
+    pub fn unreviewed_paths(&self) -> std::collections::HashSet<PathBuf> {
+        self.lanes
+            .values()
+            .flat_map(|lane| lane.values())
+            .filter(|f| f.unreviewed())
+            .map(|f| f.path.clone())
+            .collect()
+    }
+
     /// Every agent that has a lane, in name order.
     pub fn agents(&self) -> Vec<&str> {
         self.lanes.keys().map(String::as_str).collect()
@@ -372,14 +388,15 @@ impl AgentLedger {
     /// Distinct FILES awaiting review across every lane. A shared row is one
     /// file to open, not two: a count that drops by two when the user
     /// reviews one file is telling them something untrue.
+    ///
+    /// Derived from [`Self::unreviewed_paths`] rather than counted
+    /// separately, so it cannot disagree with the set the Explorer draws.
+    /// It allocates that set to do it, which is why the status chip counts
+    /// the Explorer's own cached copy instead of calling this on every
+    /// frame — this is for callers that have no cache to hand.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn unreviewed_files(&self) -> usize {
-        self.lanes
-            .values()
-            .flat_map(|lane| lane.values())
-            .filter(|f| f.unreviewed())
-            .map(|f| &f.path)
-            .collect::<std::collections::BTreeSet<_>>()
-            .len()
+        self.unreviewed_paths().len()
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -948,6 +948,35 @@ struct PendingCapture {
     identity_lost: bool,
 }
 
+/// Canonicalise `path` even when it no longer exists.
+///
+/// `std::fs::canonicalize` stats the final component, so it fails on a path
+/// that has been deleted — and a deletion event carries exactly such a path.
+/// Resolving the deepest ancestor that still exists and re-attaching the tail
+/// gives the same answer for a live path and a usable one for a dead path,
+/// which is what lets a removal clear the row it created (#345).
+///
+/// `None` when nothing on the way to the filesystem root resolves, and also
+/// for a path with no file name to strip — a bare root, or one ending in
+/// `..` — which cannot be climbed any further.
+fn canonicalize_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut probe = path.to_path_buf();
+    loop {
+        if let Ok(canon) = std::fs::canonicalize(&probe) {
+            let mut out = canon;
+            for part in tail.iter().rev() {
+                out.push(part);
+            }
+            return Some(out);
+        }
+        // `file_name` is None for a root or `..`; either way there is
+        // nothing further to climb.
+        tail.push(probe.file_name()?.to_os_string());
+        probe = probe.parent()?.to_path_buf();
+    }
+}
+
 /// State of a background self-update observed by a remote-launched croft.
 /// `Idle` is the steady state; `InProgress` paints an "Updating" hint in
 /// the status bar; `Ready` arms the re-exec into the freshly-shipped binary.
@@ -11363,8 +11392,12 @@ impl App {
         // Attribute the writes to whichever agents were working when they
         // landed (#345). Done after the reload so an agent's write to the
         // ACTIVE tab is hashed from the content the user is about to see.
-        if !drain.changed_files.is_empty() {
-            self.attribute_writes_to_working_agents(&drain.changed_files);
+        if !drain.changed_files.is_empty()
+            && self.attribute_writes_to_working_agents(&drain.changed_files)
+        {
+            // Only when the ledger actually moved: the Explorer's dots must
+            // match it, and a decoration that lags is worse than none.
+            self.sync_agent_lane_decorations();
         }
         // A rescan means the watcher dropped events, so the queue is a
         // LOWER BOUND from here until it is emptied (#345). Recorded in the
@@ -15132,7 +15165,12 @@ impl App {
         // The review queue rides the same chip (#345): a file an agent
         // changed while you were looking elsewhere is the thing you most
         // need to be told about, and it outlives the agent's own pane.
-        let unreviewed = self.agent_ledger.unreviewed_files();
+        // The set the Explorer is drawing, not a fresh count off the ledger:
+        // this is the per-frame render path, and `unreviewed_files` clones
+        // every path to build a set it then throws away. Reading the cache
+        // also makes the chip and the dots the SAME number by construction
+        // rather than by two code paths agreeing.
+        let unreviewed = self.tree.agent_touched.len();
         if seated > 0 || unreviewed > 0 {
             // With nothing seated the agent half would read "0 agents",
             // which is not what the chip is reporting any more: the queue
@@ -28333,6 +28371,10 @@ impl App {
                     .any(|t| t.agent().is_some_and(|a| a.name == *agent))
             {
                 let agent = agent.clone();
+                // No decoration sync needed here, and deliberately so: the
+                // guard above only lets this run when the lane has NOTHING
+                // unreviewed, so it removes no row the Explorer is drawing
+                // a dot for (#345).
                 self.agent_ledger.forget(&agent);
             }
             if let crate::agents::AgentEvent::Waiting { pane, agent } = ev {
@@ -28392,14 +28434,29 @@ impl App {
     ) -> bool {
         let working = self.working_agents();
         let mut any = false;
+        // Resolved once: the roots cannot change inside this loop, and on a
+        // symlinked root the direct check never hits, so leaving it inside
+        // would pay `files x roots` canonicalisations on every drain.
+        let root_canons = self.root_canons();
         for path in changed {
             // Only workspace files: an agent editing its own config under
             // $HOME is not part of this workspace's review queue. ANY root
             // counts, not just the primary — a secondary folder's files are
             // as much this session's work as the first folder's (#345).
-            if self.roots.owning_root(path).is_none() {
+            // Compare in the same spelling on both sides. The watcher reports
+            // the realpath, while a root is stored as the user gave it — so on
+            // macOS a workspace under /var arrives as /private/var and matches
+            // no root. Every agent write was silently dropped and the queue
+            // stayed empty with nothing failing. Any root reached through a
+            // symlink has the same shape, which is ordinary on Linux too.
+            //
+            // The path is recorded in the form the ROOT uses, so the ledger's
+            // keys match what the Explorer's rows are keyed on and a later
+            // "mark reviewed" finds the row instead of adding a second.
+            let Some(under_root) = self.path_under_roots(&root_canons, path) else {
                 continue;
-            }
+            };
+            let path = &under_root;
             match crate::agent_lane::read_baseline(path) {
                 // Attribution needs someone to attribute to; a quiet
                 // agent's pane is no reason to blame it for the user's
@@ -28420,10 +28477,110 @@ impl App {
         any
     }
 
+    /// `path` expressed under whichever workspace root owns it, or `None`
+    /// when no root does.
+    ///
+    /// Tries the path as given first — the common case, costing nothing —
+    /// then compares canonicalised, which is what a file watcher's realpath
+    /// needs to match a root the user spelled with a symlink in it. The
+    /// returned path is rooted the way the ROOT is spelled, so everything
+    /// keyed on it agrees with the Explorer's rows.
+    ///
+    /// A DELETED path still resolves. `canonicalize` stats the final
+    /// component and fails with `ENOENT` on a path that is gone — which is
+    /// exactly what a deletion event carries, so resolving the whole path
+    /// would make the ledger's `forget_path` arm unreachable and strand rows
+    /// on files that no longer exist. The walk therefore resolves the
+    /// deepest ancestor that DOES exist and re-attaches the tail: a deleted
+    /// file's parent directory is almost always still there, and when it is
+    /// not the walk keeps climbing.
+    ///
+    /// Longest prefix wins, mirroring `WorkspaceRoots::owning_root`: with
+    /// nested roots the deeper one owns the path, and picking the first
+    /// match instead would make the ledger's key depend on the order the
+    /// user added folders.
+    /// The roots are resolved by the CALLER so a loop over many changed
+    /// paths can hoist the canonicalisation, which depends only on the root
+    /// set and cannot change between iterations. Not a cache — there is
+    /// nothing to invalidate, because the value does not outlive the loop
+    /// that computes it.
+    fn path_under_roots(&self, root_canons: &[(PathBuf, PathBuf)], path: &Path) -> Option<PathBuf> {
+        // The direct check FIRST, and that ordering is load-bearing rather
+        // than merely quick. If an intermediate directory is itself a
+        // symlink pointing outside the workspace, resolving the whole path
+        // would land the result outside the root; hitting on the spelled
+        // path here means the walk below never sees that case.
+        if self.roots.owning_root(path).is_some() {
+            return Some(path.to_path_buf());
+        }
+        let canon = canonicalize_existing_ancestor(path)?;
+        root_canons
+            .iter()
+            .cloned()
+            .filter_map(|(spelled, canon_root)| {
+                let rel = canon.strip_prefix(&canon_root).ok()?;
+                Some((canon_root.components().count(), spelled.join(rel)))
+            })
+            .max_by_key(|(depth, _)| *depth)
+            .map(|(_, joined)| joined)
+    }
+
+    /// Each root as `(spelling, canonical)`.
+    ///
+    /// Recomputed per call rather than cached on `App`: the set is one or
+    /// two entries in practice, and this runs only when a path failed the
+    /// direct check — i.e. on a symlinked root, where it is the price of the
+    /// feature working at all. A cache here would need invalidating from
+    /// every root mutation, which is more ways to be wrong than it saves.
+    fn root_canons(&self) -> Vec<(PathBuf, PathBuf)> {
+        self.roots
+            .iter()
+            .map(|r| {
+                (
+                    r.to_path_buf(),
+                    std::fs::canonicalize(r).unwrap_or_else(|_| r.to_path_buf()),
+                )
+            })
+            .collect()
+    }
+
+    /// Called from every place the ledger's CONTENT changes, rather than on
+    /// a schedule: a decoration that lags the thing it describes is worse
+    /// than none, because "no dot" is exactly what a reviewed file looks
+    /// like, so a stale one says the user reviewed something they did not.
+    ///
+    /// Every site that mutates the ledger's content calls this, and here is
+    /// why that is all of them. `record_write`
+    /// and `forget_path` both run under the fs-watch drain, behind
+    /// `attribute_writes_to_working_agents`'s return; `mark_reviewed` under
+    /// `mark_agent_file_reviewed`; `mark_lane_reviewed` under
+    /// `mark_agent_lane_reviewed`; `forget_path` again from
+    /// `remove_workspace_folder`. Of the ledger's other `&mut self`
+    /// methods, `note_dropped_events` and `settle_if_empty` move only the
+    /// incomplete flag and cannot change the set, and `forget` is reachable
+    /// only behind a guard that requires the lane to be empty already.
+    fn sync_agent_lane_decorations(&mut self) {
+        let paths = self.agent_ledger.unreviewed_paths();
+        // Skip the Arc swap when both sides are empty, which is the common
+        // shape early in a session and after a review clears the queue.
+        if paths.is_empty() && self.tree.agent_touched.is_empty() {
+            return;
+        }
+        self.tree.agent_touched = std::sync::Arc::new(paths);
+    }
+
     /// Mark one file reviewed in one agent's lane (#345): the content on
     /// DISK now becomes the baseline, so the row returns only on a later
     /// write.
     pub(crate) fn mark_agent_file_reviewed(&mut self, agent: &str, path: &Path) -> bool {
+        let changed = self.mark_agent_file_reviewed_inner(agent, path);
+        if changed {
+            self.sync_agent_lane_decorations();
+        }
+        changed
+    }
+
+    fn mark_agent_file_reviewed_inner(&mut self, agent: &str, path: &Path) -> bool {
         match crate::agent_lane::read_baseline(path) {
             crate::agent_lane::Baseline::Hash(hash) => {
                 self.agent_ledger.mark_reviewed(agent, path, hash)
@@ -28458,6 +28615,9 @@ impl App {
             1 => format!("{agent}: 1 file marked reviewed{gone}"),
             n => format!("{agent}: {n} files marked reviewed{gone}"),
         };
+        if reviewed + dropped > 0 {
+            self.sync_agent_lane_decorations();
+        }
         reviewed + dropped
     }
 
@@ -37212,6 +37372,19 @@ impl App {
             return;
         }
         self.tree.remove_root(&path);
+        // The removed folder's review queue goes with it (#345). Its rows
+        // leave the tree, so no stale DOT renders — but the status chip
+        // counts the same set, and a count that outlives the folder it
+        // describes sends the user looking for rows that are not there.
+        for gone in self
+            .agent_ledger
+            .unreviewed_paths()
+            .into_iter()
+            .filter(|p| p.starts_with(&path))
+        {
+            self.agent_ledger.forget_path(&gone);
+        }
+        self.sync_agent_lane_decorations();
         self.git_extra.retain(|(r, _)| r != &path);
         self.git_head_oids.remove(&path);
         if self.active_scm_root == path {
@@ -37433,6 +37606,11 @@ impl App {
         self.tree.set_root(new_root.clone());
         self.tree_clipboard = None;
         self.compare_anchor = None;
+        // The agent review queue belongs to the workspace that was left
+        // (#345). `set_root` has just cleared the Explorer's copy; this
+        // clears the ledger it is drawn from, so the two cannot come back
+        // apart the moment an agent writes under the new root.
+        self.agent_ledger = crate::agent_lane::AgentLedger::new();
         self.fs_watch.rebind(&new_root, &self.tree);
         // A re-root collapses the workspace to one folder: the secondary
         // watchers go with their roots (#147).

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -36582,6 +36582,270 @@ fn an_http_file_runs_requests_and_keeps_secrets_out_of_history_and_the_tab() {
     );
     assert!(app.http_run.is_none(), "nothing was sent");
 }
+/// #345: the Explorer's unreviewed dots track the ledger, on every path
+/// that changes it.
+///
+/// The predicate and the painting are tested in `file_tree`; this is the
+/// wiring between them, which is where a decoration feature actually breaks.
+/// A dot that lags the ledger is worse than no dot at all, because "no dot"
+/// is precisely what a reviewed file looks like — so a stale one tells the
+/// user they have reviewed something they have not.
+///
+/// **The drain is driven for real, not stood in for.** An earlier version of
+/// this test called `attribute_writes_to_working_agents` and then
+/// `sync_agent_lane_decorations` by hand, which tests the helper and not the
+/// wiring: deleting the drain's own sync left every assertion passing. Since
+/// the drain is the path that fires on every agent write, that was the one
+/// call site the feature cannot afford to have untested.
+#[test]
+fn the_explorer_dots_follow_the_agent_ledger() {
+    let tmp = tempfile::tempdir().unwrap();
+    let touched = tmp.path().join("touched.rs");
+    std::fs::write(&touched, "fn a() {}\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    assert!(
+        app.tree.agent_touched.is_empty(),
+        "staging: nothing decorated before an agent writes"
+    );
+
+    app.terminals[0].set_agent(Some(crate::agents::AgentLane {
+        name: String::from("claude"),
+        status: crate::agents::AgentStatus::Working,
+    }));
+
+    // Let the watcher establish itself first, as the other fs-watch tests
+    // do: a write racing the initial registration is simply not delivered,
+    // which would make this test flaky rather than wrong.
+    for _ in 0..20 {
+        let _ = app.drain_fs_events();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // Through the real drain: write the file, let the watcher deliver it,
+    // and call the function the event loop calls. No explicit sync here —
+    // that is the property under test.
+    std::fs::write(&touched, "fn a() { todo!() }\n").unwrap();
+    let mut waited = 0;
+    while !app.tree.agent_touched.contains(&touched) && waited < 4000 {
+        app.drain_fs_events();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        waited += 20;
+    }
+    assert!(
+        app.tree.agent_touched.contains(&touched),
+        "the drain must light the row it attributed, without a nudge \
+         (waited {waited}ms; ledger has {} unreviewed)",
+        app.agent_ledger.unreviewed_files()
+    );
+    assert!(app.tree.is_agent_touched(&touched));
+    // The chip counts the set the tree draws. Asserted HERE, where both
+    // sides are 1: after the lane is cleared below they are both 0, and an
+    // equality that only ever compares 0 to 0 cannot fail.
+    assert_eq!(
+        app.agent_ledger.unreviewed_files(),
+        app.tree.agent_touched.len(),
+        "the badge and the dots must be the same number"
+    );
+
+    // Reviewing goes through the public entry point, which syncs itself.
+    assert!(app.mark_agent_file_reviewed("claude", &touched));
+    assert!(
+        !app.tree.agent_touched.contains(&touched),
+        "marking reviewed must clear the dot without a further nudge"
+    );
+
+    // Mark-the-whole-lane reviewed is the other syncing entry point.
+    let mut changed = std::collections::BTreeSet::new();
+    changed.insert(touched.clone());
+    std::fs::write(&touched, "fn a() { 1 }\n").unwrap();
+    assert!(app.attribute_writes_to_working_agents(&changed));
+    app.sync_agent_lane_decorations();
+    assert!(
+        app.tree.agent_touched.contains(&touched),
+        "staging: lit again"
+    );
+    app.mark_agent_lane_reviewed("claude");
+    assert!(
+        app.tree.agent_touched.is_empty(),
+        "marking the lane reviewed must clear every dot"
+    );
+}
+
+/// #345: a write reported through a symlinked root is still attributed.
+///
+/// Found by driving the real fs-watch drain rather than calling the
+/// attribution helper directly. The watcher reports a file's REALPATH while
+/// a root is stored as the user spelled it, so a workspace reached through a
+/// symlink — `/var` on macOS, which is `/private/var`, and any symlinked
+/// checkout on Linux — matched no root and every agent write was dropped.
+/// The queue stayed empty and nothing failed, which is why a test that
+/// substituted for the drain could not see it.
+#[test]
+#[cfg(unix)]
+fn a_write_under_a_symlinked_root_is_still_the_agents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let real = tmp.path().join("real");
+    std::fs::create_dir(&real).unwrap();
+    let link = tmp.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    // The workspace is opened through the LINK; the file is written and
+    // reported through the real path, as a watcher would.
+    let via_link = link.join("f.rs");
+    std::fs::write(&via_link, "fn a() {}\n").unwrap();
+    let mut app = App::new(link.clone()).unwrap();
+    app.terminals[0].set_agent(Some(crate::agents::AgentLane {
+        name: String::from("claude"),
+        status: crate::agents::AgentStatus::Working,
+    }));
+
+    let mut changed = std::collections::BTreeSet::new();
+    changed.insert(real.join("f.rs"));
+    assert!(
+        app.attribute_writes_to_working_agents(&changed),
+        "a realpath write under a symlinked root must still be attributed"
+    );
+
+    // And it is keyed the way the ROOT is spelled, so the Explorer's rows —
+    // which come from the tree, not the watcher — find it.
+    app.sync_agent_lane_decorations();
+    assert!(
+        app.tree.agent_touched.contains(&via_link),
+        "the ledger keyed the row under the realpath, so no tree row matches \
+         it: {:?}",
+        app.tree.agent_touched
+    );
+
+    // And a DELETION clears it. `canonicalize` stats the final component, so
+    // resolving the whole path fails on a file that is gone — which would
+    // make the ledger's forget-path arm unreachable and strand the row on a
+    // file that no longer exists, with no later write able to clear it. That
+    // is strictly worse than the original bug, which dropped writes and
+    // deletions alike and so at least stayed self-consistent.
+    std::fs::remove_file(&via_link).unwrap();
+    assert!(
+        app.attribute_writes_to_working_agents(&changed),
+        "a deletion reported by realpath must reach the ledger too"
+    );
+    app.sync_agent_lane_decorations();
+    assert!(
+        app.tree.agent_touched.is_empty(),
+        "the row outlived the file it described: {:?}",
+        app.tree.agent_touched
+    );
+
+    // The parent going too, which makes the walk climb more than one level.
+    // A tail-reattachment bug hides here rather than in the single-level
+    // case: the key the delete resolves to must still be the key the write
+    // created, or `forget_path` finds nothing to forget.
+    let sub = link.join("sub");
+    std::fs::create_dir(&sub).unwrap();
+    let nested = sub.join("g.rs");
+    std::fs::write(&nested, "fn g() {}\n").unwrap();
+    let mut deep = std::collections::BTreeSet::new();
+    deep.insert(real.join("sub/g.rs"));
+    assert!(app.attribute_writes_to_working_agents(&deep));
+    app.sync_agent_lane_decorations();
+    assert!(
+        app.tree.agent_touched.contains(&nested),
+        "staging: the nested file is queued"
+    );
+
+    std::fs::remove_dir_all(&sub).unwrap();
+    assert!(
+        app.attribute_writes_to_working_agents(&deep),
+        "a deletion whose PARENT is gone must still resolve"
+    );
+    app.sync_agent_lane_decorations();
+    assert!(
+        app.tree.agent_touched.is_empty(),
+        "the row outlived its whole directory: {:?}",
+        app.tree.agent_touched
+    );
+}
+
+/// #345: removing a workspace folder takes its review queue with it.
+///
+/// The rows leave the tree on their own, so no stale dot renders — but the
+/// status chip counts the same set, and a count that outlives the folder it
+/// describes sends the user hunting for rows that are not there.
+#[test]
+fn removing_a_folder_drops_its_rows_from_the_review_queue() {
+    let primary = tempfile::tempdir().unwrap();
+    let secondary = tempfile::tempdir().unwrap();
+    let in_second = secondary.path().join("s.rs");
+    std::fs::write(&in_second, "fn s() {}\n").unwrap();
+    let mut app = App::new(primary.path().to_path_buf()).unwrap();
+    app.roots.add(secondary.path().to_path_buf());
+
+    app.terminals[0].set_agent(Some(crate::agents::AgentLane {
+        name: String::from("claude"),
+        status: crate::agents::AgentStatus::Working,
+    }));
+    let mut changed = std::collections::BTreeSet::new();
+    changed.insert(in_second.clone());
+    assert!(app.attribute_writes_to_working_agents(&changed));
+    app.sync_agent_lane_decorations();
+    assert_eq!(
+        app.tree.agent_touched.len(),
+        1,
+        "staging: the secondary root's file is queued"
+    );
+
+    app.remove_workspace_folder(secondary.path().to_path_buf());
+    assert!(
+        app.tree.agent_touched.is_empty(),
+        "the removed folder's rows outlived it: {:?}",
+        app.tree.agent_touched
+    );
+    assert_eq!(app.agent_ledger.unreviewed_files(), 0);
+}
+
+/// #345: a re-root leaves no dots from the workspace the user left.
+///
+/// The paths in the set are ABSOLUTE, and Make Root's documented use is
+/// re-rooting into a CHILD — where the new tree's paths are exactly the ones
+/// still in the set. Left behind, every stale dot re-renders on the new tree
+/// describing a lane that is gone, which is the precise staleness this
+/// decoration exists to avoid.
+#[test]
+fn a_re_root_drops_the_previous_workspaces_review_queue() {
+    let tmp = tempfile::tempdir().unwrap();
+    let child = tmp.path().join("child");
+    std::fs::create_dir(&child).unwrap();
+    let inside = child.join("in_child.rs");
+    std::fs::write(&inside, "fn a() {}\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+
+    app.terminals[0].set_agent(Some(crate::agents::AgentLane {
+        name: String::from("claude"),
+        status: crate::agents::AgentStatus::Working,
+    }));
+    let mut changed = std::collections::BTreeSet::new();
+    changed.insert(inside.clone());
+    assert!(app.attribute_writes_to_working_agents(&changed));
+    app.sync_agent_lane_decorations();
+    assert!(
+        app.tree.agent_touched.contains(&inside),
+        "staging: the file is decorated before the re-root"
+    );
+
+    // Re-root INTO the child: the file's absolute path is unchanged and it
+    // is still on screen, so a surviving set would re-decorate it.
+    app.change_workspace_root(child.clone());
+    assert!(
+        app.tree.agent_touched.is_empty(),
+        "the Explorer kept the old workspace's dots: {:?}",
+        app.tree.agent_touched
+    );
+    assert_eq!(
+        app.agent_ledger.unreviewed_files(),
+        0,
+        "the ledger kept the old workspace's queue"
+    );
+    assert!(!app.tree.is_agent_touched(&inside));
+}
+
 /// #345: the agent lane attributes workspace writes to whichever agents
 /// were WORKING when they landed, keeps a review baseline per file, and
 /// never blames an agent for the user's own saves.

--- a/src/release_notes/0.1.838.md
+++ b/src/release_notes/0.1.838.md
@@ -1,0 +1,1 @@
+feature: the Explorer marks a file an agent changed with a dot until you mark it reviewed, so the review queue is visible in the tree rather than only in the agent lane.

--- a/src/widgets/file_tree.rs
+++ b/src/widgets/file_tree.rs
@@ -38,6 +38,18 @@ pub struct FileTree {
     /// in the set — or under a dir in the set — render their name in the
     /// theme's dimmed foreground, VS Code's ignored-resource decoration.
     pub ignored: Arc<HashSet<PathBuf>>,
+    /// Workspace files an agent changed and the user has not reviewed
+    /// (#345), absolute. Rows in this set take a TRAILING dot in the theme's
+    /// yellow; it clears when the file is marked reviewed.
+    ///
+    /// One colour, not one per agent: `AgentLane` carries no colour today,
+    /// and inventing one here would put the mapping in the wrong place.
+    ///
+    /// Membership is EXACT, unlike `ignored`, which covers a directory's
+    /// descendants. A directory is not something an agent wrote and not
+    /// something "mark reviewed" can clear, so a dot on one would be a mark
+    /// no gesture removes. Fed from `AgentLedger` on the app's sync.
+    pub agent_touched: Arc<HashSet<PathBuf>>,
     pub last_inner: Rect,
     pub last_area: Rect,
     pub last_scrollbar: Rect,
@@ -72,6 +84,11 @@ pub struct FileTree {
     pub header_views_btn: Rect,
 }
 
+/// The unreviewed-file marker (#345). A middle dot rather than a filled
+/// circle: it must read as a small annotation beside a filename, not compete
+/// with the file-type icon at the start of the row.
+const AGENT_DOT: char = '\u{b7}';
+
 impl FileTree {
     pub fn new(root: PathBuf) -> Self {
         let mut tree = Self {
@@ -89,6 +106,7 @@ impl FileTree {
             focus_gradient: false,
             theme: crate::theme::Theme::default(),
             ignored: Arc::default(),
+            agent_touched: Arc::default(),
             last_inner: Rect::default(),
             last_area: Rect::default(),
             last_scrollbar: Rect::default(),
@@ -127,6 +145,13 @@ impl FileTree {
         // The old workspace's ignore set is meaningless under the new root;
         // the git worker re-queries after its SetRoot and repopulates.
         self.ignored = Arc::default();
+        // Same for the agent review queue (#345), and it matters more: these
+        // are ABSOLUTE paths, and the documented use of Make Root is
+        // re-rooting into a CHILD, where the new tree's paths are the very
+        // ones still in the set. Left behind, every stale dot re-renders on
+        // the new tree, describing a lane the user has walked away from —
+        // the exact staleness this decoration exists to avoid.
+        self.agent_touched = Arc::default();
         self.load_children(0);
     }
 
@@ -232,6 +257,13 @@ impl FileTree {
                 None => return false,
             }
         }
+    }
+
+    /// Whether `path` is a file an agent changed that is still unreviewed.
+    ///
+    /// Exact membership, deliberately: see [`Self::agent_touched`].
+    pub fn is_agent_touched(&self, path: &Path) -> bool {
+        !self.agent_touched.is_empty() && self.agent_touched.contains(path)
     }
 
     /// Map a screen y coordinate to a node index, if any. Screen rows map
@@ -1498,6 +1530,17 @@ impl Widget for &mut FileTree {
                     Style::default().fg(name_fg),
                     self.theme,
                 );
+                // The agent-lane dot (#345), AFTER the name rather than
+                // before it: a leading marker would shift every name in the
+                // tree by a column as writes land, so the eye loses the
+                // alignment it reads the tree by. Trailing, it appears and
+                // clears without moving anything.
+                if self.is_agent_touched(&node.path) {
+                    spans.push(Span::styled(
+                        format!(" {AGENT_DOT}"),
+                        Style::default().fg(self.theme.ui(Color::Yellow)),
+                    ));
+                }
             }
 
             let line = Line::from(spans);
@@ -1893,6 +1936,76 @@ mod tests {
         );
     }
 
+    /// The dot actually reaches the screen, on the right row, and clears
+    /// when the file is reviewed (#345).
+    ///
+    /// Separate from the predicate test above on purpose: a predicate that
+    /// answers correctly while nothing draws it is the same to a user as a
+    /// feature that was never built, and the render is where every wiring
+    /// mistake between the two would live.
+    #[test]
+    fn the_lane_dot_is_painted_on_the_row_and_clears_when_reviewed() {
+        let (_tmp, mut tree) = fixture();
+        let root = tree.root.clone();
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 8,
+        };
+
+        let row_containing = |buf: &Buffer, needle: &str| -> Option<String> {
+            (0..area.height)
+                .map(|y| {
+                    (0..area.width)
+                        .map(|x| buf[(x, y)].symbol().to_string())
+                        .collect::<String>()
+                })
+                .find(|line| line.contains(needle))
+        };
+
+        // Nothing touched: no dot anywhere, which is the control that makes
+        // the positive assertion below mean something.
+        let mut buf = Buffer::empty(area);
+        (&mut tree).render(area, &mut buf);
+        let clean = row_containing(&buf, "main.rs").expect("main.rs is on screen");
+        assert!(
+            !clean.contains(AGENT_DOT),
+            "a dot with nothing unreviewed: {clean:?}"
+        );
+
+        // One unreviewed file: its row takes the dot and its neighbour
+        // does not.
+        tree.agent_touched =
+            std::sync::Arc::new(std::collections::HashSet::from([root.join("main.rs")]));
+        let mut buf = Buffer::empty(area);
+        (&mut tree).render(area, &mut buf);
+        let marked = row_containing(&buf, "main.rs").expect("main.rs is on screen");
+        assert!(
+            marked.contains(AGENT_DOT),
+            "the unreviewed file took no dot: {marked:?}"
+        );
+        let other = row_containing(&buf, "README.md").expect("README.md is on screen");
+        assert!(
+            !other.contains(AGENT_DOT),
+            "an untouched file took a dot: {other:?}"
+        );
+
+        // Reviewed: the dot goes, and the row is otherwise what it was.
+        tree.agent_touched = std::sync::Arc::new(std::collections::HashSet::new());
+        let mut buf = Buffer::empty(area);
+        (&mut tree).render(area, &mut buf);
+        let cleared = row_containing(&buf, "main.rs").expect("main.rs is on screen");
+        assert!(
+            !cleared.contains(AGENT_DOT),
+            "the dot outlived the review: {cleared:?}"
+        );
+        assert_eq!(
+            cleared, clean,
+            "clearing the dot must leave the row exactly as it was"
+        );
+    }
+
     #[test]
     fn collapse_all_closes_nested_folders_but_keeps_the_root_expanded() {
         let tmp = TempDir::new().unwrap();
@@ -2113,6 +2226,36 @@ mod tests {
             tree.nodes.iter().any(|n| n.path.ends_with("dummy2.txt")),
             "Explorer must show disk reality, including gitignored files"
         );
+    }
+
+    /// An unreviewed file carries the agent-lane dot, and only that file
+    /// does (#345).
+    ///
+    /// The dot is a decoration on the FILE the agent wrote, not on the
+    /// directories above it. A directory is not something an agent changed
+    /// and not something a review can clear, so marking the tree all the way
+    /// to the root would put a mark on rows that no gesture can ever remove —
+    /// which is why this is a set membership test rather than a prefix walk
+    /// like `is_ignored`.
+    #[test]
+    fn only_the_unreviewed_files_themselves_take_the_lane_dot() {
+        let (_tmp, mut tree) = fixture();
+        let root = tree.root.clone();
+        tree.agent_touched =
+            std::sync::Arc::new(std::collections::HashSet::from([root.join("src/main.rs")]));
+        assert!(tree.is_agent_touched(&root.join("src/main.rs")));
+        // Not the directories on the way to it: a directory cannot be
+        // reviewed, so a mark there would never clear.
+        assert!(
+            !tree.is_agent_touched(&root.join("src")),
+            "a parent directory must not inherit the dot"
+        );
+        assert!(!tree.is_agent_touched(&root));
+        // Nor a sibling the agent did not touch.
+        assert!(!tree.is_agent_touched(&root.join("src/other.rs")));
+        // An empty set is the common case and must be cheap and quiet.
+        tree.agent_touched = std::sync::Arc::new(std::collections::HashSet::new());
+        assert!(!tree.is_agent_touched(&root.join("src/main.rs")));
     }
 
     #[test]


### PR DESCRIPTION
Part of #345 — the Explorer decoration. The ledger and "mark reviewed" shipped in #421/#429, but the queue was only visible as a status line: you had to ask what was waiting rather than see it where you already look.

## The decoration

**Membership is exact**, unlike the git-ignored set right next to it, which covers a directory's descendants. A directory is not something an agent wrote, and not something "mark reviewed" can clear — so a dot on one would be a mark no gesture ever removes. That asymmetry is why the two decorations cannot share a predicate, and the test asserts a parent directory does *not* inherit it.

**The dot trails the name.** A leading marker shifts every name in the tree by a column as writes land, so the eye loses the alignment it reads the tree by. Trailing, it appears and clears without moving anything.

**Synced from every path that changes the ledger**, rather than on a schedule. A decoration that lags is worse than none here, because "no dot" is exactly what a reviewed file looks like — a stale one tells the user they have already looked at something they have not. A re-root and a folder removal both drop the queue belonging to the workspace being left.

The status chip now counts the Explorer's cached set instead of recomputing off the ledger. It sits in the per-frame render path and the count allocated a fresh set of cloned paths just to take its length; reading the cache also makes the chip and the dots the same number by construction rather than by two code paths agreeing.

## A real bug this uncovered

Review pointed out that my app-level test *substituted* for the fs-watch drain — it called the attribution helper and then hand-invoked the sync — so deleting the drain's own sync left every assertion green. Rewriting it to call `drain_fs_events` for real failed immediately, and not because of the sync:

**No agent write was ever attributed under a symlinked root.** The watcher reports a file's realpath while a root is stored as the user spelled it, so a workspace under `/var` arrives as `/private/var`, matches no root in `owning_root`'s `starts_with`, and is dropped. On macOS that is every `/var` workspace and every tempdir; on Linux any symlinked checkout. The queue stayed empty and nothing failed.

`path_under_roots` compares canonicalised and returns the path **in the root's spelling**, so the ledger's keys match the tree's rows. Two details review caught, both of which matter:

- **`canonicalize` stats the final component**, so it fails on a path that is gone — which is exactly what a deletion event carries. Resolving the whole path would have made the `forget_path` arm unreachable and stranded rows on deleted files with no later write able to clear them: *strictly worse* than the original bug, which dropped writes and deletions alike and so at least stayed self-consistent. `canonicalize_existing_ancestor` resolves the deepest ancestor that still exists and re-attaches the tail.
- **Longest prefix wins**, mirroring `owning_root`. Taking the first match would have made the ledger's key depend on the order the user added folders.

The direct check runs before the walk, and that ordering is load-bearing rather than merely quick: if an intermediate directory is itself a symlink pointing outside the workspace, resolving the whole path would land the result outside the root.

## Gate

Six tests, red-first, each mutation-tested rather than merely passing:

- **Render** — never painting the dot and always painting it *each* fail, so neither a missing decoration nor a blanket one can pass. It asserts the glyph reaches the buffer, because a predicate that answers correctly while nothing draws it looks the same to a user as a feature that was never built.
- **Wiring** — drives the real drain. Removing the drain's sync fails it.
- **Symlinked root** — reverting the resolution fails it; resolving the whole path rather than the ancestor fails the deletion assertion; climbing only one level fails the deleted-parent assertion.
- **Re-root and folder removal** — removing either clear fails its test.

3941 pass. The failures on my machine (`the_pinned_toolchain_has_every_cross_target`, `a_client_arriving_mid_swap_…`) fail identically on unmodified `origin/main` — missing musl cross-targets and a socket-path length limit — and the rest pass unloaded, so they are the suite's known load-sensitive shell-spawning flakes. fmt 0, clippy 0, doc-ownership gate clean.

Version 0.1.838 against main's 0.1.835; .836 and .837 are the peer session's #435 and #443.

**Not included, deliberately:** an unreviewed file inside a *collapsed* folder is invisible, since membership is exact. A rollup glyph on the collapsed ancestor is the answer, but it is derived state with its own design questions and belongs in its own change rather than riding in on this one.
