### PR TITLE
test(app): find the link's row instead of assuming it

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2643,12 +2643,18 @@ fn the_swallow_guard_reads_the_clicked_terminal_not_the_active_one() {
     app.active_terminal = 1;
     term.draw(|f| app.render(f)).unwrap();
 
+    // FIND the link's cell rather than assuming which row it landed on
+    // (#397). Pane 0 has a real shell, and its prompt arrives from the
+    // reader thread whenever the OS gets round to it - before the injected
+    // bytes on a loaded machine, after them on a quiet one. Either way the
+    // link is in the pane; only its row moves, and hard-coding
+    // `area.y + 1` made the test a race against shell startup rather than a
+    // check of the swallow guard it is named for.
     let area = app.terminals[0].last_area;
-    let (col, row) = (area.x + 2, area.y + 1);
-    assert!(
-        app.terminals[0].hyperlink_at_screen(col, row).is_some(),
-        "pane 0 must carry the link, or the built-in has nothing to act on"
-    );
+    let (col, row) = (area.y..area.y + area.height)
+        .flat_map(|r| (area.x..area.x + area.width).map(move |c| (c, r)))
+        .find(|&(c, r)| app.terminals[0].hyperlink_at_screen(c, r).is_some())
+        .expect("pane 0 must carry the link somewhere, or the built-in has nothing to act on");
     assert_eq!(
         app.active_terminal, 1,
         "pane 1 must be ACTIVE while the click lands in pane 0, or the \

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2650,6 +2650,13 @@ fn the_swallow_guard_reads_the_clicked_terminal_not_the_active_one() {
     // link is in the pane; only its row moves, and hard-coding
     // `area.y + 1` made the test a race against shell startup rather than a
     // check of the swallow guard it is named for.
+    //
+    // Searching trades a false negative for a weaker claim, which is the
+    // right trade HERE and not everywhere: this assertion only proves the
+    // built-in has something to act on, and the click coordinates are
+    // computed separately below. If it ever grows into a position-sensitive
+    // check, the search has to narrow with it - "the link is somewhere in
+    // the pane" would then pass for a row no click could reach.
     let area = app.terminals[0].last_area;
     let (col, row) = (area.y..area.y + area.height)
         .flat_map(|r| (area.x..area.x + area.width).map(move |c| (c, r)))


### PR DESCRIPTION
The test #397 names failed on CI an hour ago, on a `main` where #397 is closed. I closed it, and my fix did not address this.

## What #423 fixed and what it did not

#423 made `load_scale` see a thread count spelled `--test-threads` rather than only `RUST_TEST_THREADS`. That is real and it stands.

**This assertion has no budget at all.** It is a bare `assert!` immediately after a synchronous inject, so no amount of budget work reaches it:

```rust
let area = app.terminals[0].last_area;
let (col, row) = (area.x + 2, area.y + 1);
assert!(app.terminals[0].hyperlink_at_screen(col, row).is_some(), ...);
```

## The mechanism

Pane 0 runs a **real shell**, and its prompt arrives from the reader thread whenever the OS gets round to it. The link is fed in synchronously. So the two race for the pane's first row:

- prompt second → link on row 0 → the hard-coded `area.y + 1` finds it → **pass**
- prompt first → link on row 1 → that cell is the prompt → **fail**, with `pane 0 must carry the link`

The link is in the pane under both orderings. Only its row moves. So the test was a race against shell startup wearing the name of the swallow guard.

## Reproduced deterministically, not waited for

Running the test alone under six spinning CPU hogs passed **10 out of 10** — the race needs the full suite's contention to lose, which is why this reads as unreproducible.

So I forced the ordering instead. One line of output before the link:

```rust
app.terminals[0].feed_bytes_for_test(b"prompt-arrived-first\r\n");
```

| form | result |
|---|---|
| new (searches for the link) | **passes** |
| old (`area.y + 1`) | **fails**, `pane 0 must carry the link` — the exact CI message |

That is the mechanism demonstrated, not inferred from it.

## The fix

Find the link's cell by scanning the pane rather than naming a row. Correct under either ordering, and it still fails loudly if the link is genuinely absent — which is the property the assertion was there for.

## Deliberately does not close #397

#397 is a class — waits and reads against a real shell that assume timing. This is the instance it happened to name, and I would rather leave the issue open with this recorded than close it twice. I have already closed it once on a fix that left this untouched.

## Gate

- `cargo test --bin croft`: `3948 passed; 0 failed; 10 ignored`.
- `cargo clippy --all-targets --all-features`: zero warnings.
- `cargo fmt --check`: clean.
- Test-only (`src/app/tests.rs`), so no version bump or release note — the release-hygiene job excludes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved hyperlink detection tests to find links regardless of their position within the pane.
  * Tests now provide clearer failure feedback when no hyperlink is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->