### PR TITLE
fix(ci): catch a doc capture whose newcomer brings its own doc (#455)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,12 +246,15 @@ with no base version has no merge-base history to lose documentation against.
 Two further passes cover captures that fingerprint does not leave. One reads
 your head on its own and reports a `///` block with nothing under it that a
 doc can attach to, which is what an insertion strands when the newcomer has no
-doc of its own. The other compares what each doc line sat above at the merge
-base with what it sits above now: an item inserted directly above a documented
-enum variant takes its prose while stranding nothing at all, and that shape
-shipped once with the gate green. It reports only when the old item is still
-there and now has no documentation, and when the line the prose landed on is
-new, so moving a doc back onto its rightful item stays green.
+doc of its own. The other compares what each doc line sat above earlier with
+what it sits above now, at the merge base and at every commit on your branch
+that touched the file, so a capture made and left in place mid-branch is seen
+even though the merge base predates both items. An item inserted directly
+above a documented enum variant takes its prose while stranding nothing at
+all, and that shape shipped once with the gate green. It reports only when the
+old item is still there and now has no documentation, and when the line the
+prose landed on is new, so moving a doc back onto its rightful item stays
+green.
 
 If a removal is deliberate, say so in a commit message on the branch:
 
@@ -263,7 +266,10 @@ doc-removal: src/path/to/file.rs::SomeType::method_name
 The key after the path is the one the gate's own error names: a bare name
 for a free item, or the enclosing `impl` header for a method (`Foo::new`,
 `Display for Foo::fmt`), so a declared removal of one `new` cannot excuse
-another.
+another. It covers all three passes. For a victim the gate does not model as
+an item, an enum variant being the common case, the key is the leading name on
+the line itself (`E::A` is declared as `a.rs::A`), and the error prints the
+exact declaration to write.
 
 The file qualifier matters: an exemption keyed on the bare name would excuse
 every function of that name in every changed file, so a deliberate removal of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,10 +266,15 @@ doc-removal: src/path/to/file.rs::SomeType::method_name
 The key after the path is the one the gate's own error names: a bare name
 for a free item, or the enclosing `impl` header for a method (`Foo::new`,
 `Display for Foo::fmt`), so a declared removal of one `new` cannot excuse
-another. It covers all three passes. For a victim the gate does not model as
-an item, an enum variant being the common case, the key is the leading name on
-the line itself (`E::A` is declared as `a.rs::A`), and the error prints the
-exact declaration to write.
+another. It covers the two passes that name an item: the merge-base loss check
+and the doc-changed-owner check. For a victim the gate does not model as an
+item, an enum variant being the common case, the key is the leading name on the
+line itself (`E::A` is declared as `a.rs::A`), and the error prints the exact
+declaration to write.
+
+The head-only pass has no declaration, because what it reports is prose with
+nothing under it and there is no item to name. Give the block an item, or move
+the inserted one above it.
 
 The file qualifier matters: an exemption keyed on the bare name would excuse
 every function of that name in every changed file, so a deliberate removal of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,8 +241,19 @@ job): an item that had a doc comment at the merge base and has none at your
 head is the fingerprint this insertion leaves. It covers `fn`, `const`,
 `static`, `struct`, `enum`, `union`, `trait`, `type` and `macro_rules!`, and
 for a file your branch ADDS it compares your commits pairwise, since a file
-with no base version has no merge-base history to lose documentation against. If a removal is deliberate, say
-so in a commit message on the branch:
+with no base version has no merge-base history to lose documentation against.
+
+Two further passes cover captures that fingerprint does not leave. One reads
+your head on its own and reports a `///` block with nothing under it that a
+doc can attach to, which is what an insertion strands when the newcomer has no
+doc of its own. The other compares what each doc line sat above at the merge
+base with what it sits above now: an item inserted directly above a documented
+enum variant takes its prose while stranding nothing at all, and that shape
+shipped once with the gate green. It reports only when the old item is still
+there and now has no documentation, and when the line the prose landed on is
+new, so moving a doc back onto its rightful item stays green.
+
+If a removal is deliberate, say so in a commit message on the branch:
 
 ```text
 doc-removal: src/path/to/file.rs::some_function_name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,9 +247,13 @@ Two further passes cover captures that fingerprint does not leave. One reads
 your head on its own and reports a `///` block with nothing under it that a
 doc can attach to, which is what an insertion strands when the newcomer has no
 doc of its own. The other compares what each doc line sat above earlier with
-what it sits above now, at the merge base and at every commit on your branch
-that touched the file, so a capture made and left in place mid-branch is seen
-even though the merge base predates both items. An item inserted directly
+what it sits above now, at the merge base and at every non-merge commit on
+your branch that touched the file, so a capture made and left in place
+mid-branch is seen even though the merge base predates both items. Merges are
+skipped because a merge's first parent is your branch tip, so comparing across
+one replays whatever you merged IN as your own work; the cost is that a
+capture made by a merge resolution, where the thief is a line the other side
+already had, is not reported. An item inserted directly
 above a documented enum variant takes its prose while stranding nothing at
 all, and that shape shipped once with the gate green. It reports only when the
 old item is still there and now has no documentation, and when the line the

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -466,6 +466,140 @@ def orphaned_docs(text):
     return orphans
 
 
+def _doc_blocks(lines, kinds):
+    """Every `///` block in the file, with the line it documents.
+
+    Yields `(start, end, subject)`: the block spans `lines[start:end]`, and
+    `subject` is the first line under it that a doc can attach to - blank
+    lines, ordinary comments and attributes sit legally in between - or None
+    when the block reaches the end of the file. The subject is the line's own
+    text rather than a parsed item, because the captures that get through the
+    other two passes are on kinds `ITEM` deliberately does not model: an enum
+    variant is what #455 was filed for.
+    """
+    i = 0
+    while i < len(lines):
+        if kinds[i] != DOC:
+            i += 1
+            continue
+        start = i
+        while i < len(lines) and kinds[i] == DOC:
+            i += 1
+        j = i
+        while j < len(lines) and kinds[j] in (ATTR, SKIP):
+            j += 1
+        yield start, i, (lines[j].strip() if j < len(lines) else None)
+
+
+# A doc line carrying no prose of its own: the `///` separators a long block
+# is full of. They repeat, they move whenever anything near them moves, and
+# they say nothing about which item they describe.
+DOC_PROSE = re.compile(r"^\s*(?:///+|//!|/\*\*+|\*)\s*(\S.*)$")
+
+
+def doc_subjects(text):
+    """Doc lines that occur exactly once in `text`, and what each sits above.
+
+    Uniqueness is the whole guard against reading a coincidence as a move: a
+    `/// The width, in cells.` that appears above three different fields has
+    no single owner to have changed, so it is dropped rather than guessed at.
+    """
+    lines = text.splitlines()
+    kinds = classify(lines)
+    subjects = {}
+    seen = {}
+    for start, end, subject in _doc_blocks(lines, kinds):
+        for k in range(start, end):
+            doc = lines[k].strip()
+            seen[doc] = seen.get(doc, 0) + 1
+            subjects[doc] = (subject, k + 1)
+    return {
+        doc: where
+        for doc, where in subjects.items()
+        if seen[doc] == 1 and DOC_PROSE.match(doc)
+    }
+
+
+def documented_subjects(text):
+    """Every line that some doc block reaches, unique or not."""
+    lines = text.splitlines()
+    return {
+        subject
+        for _start, _end, subject in _doc_blocks(lines, classify(lines))
+        if subject
+    }
+
+
+def line_counts(text):
+    """How often each stripped line occurs, for the "still there, and only
+    once" test the report depends on."""
+    counts = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        counts[stripped] = counts.get(stripped, 0) + 1
+    return counts
+
+
+def reassigned_docs(before, after):
+    """Doc lines that changed the item they sit above, leaving it bare (#455).
+
+    The two passes above see a capture only through prose that is STRANDED -
+    a doc block with nothing a doc can attach to under it. A newcomer that
+    brings its own doc strands nothing: rustfmt leaves the stolen line and
+    the thief's own contiguous, they read as one ordinary two-line block, and
+    at HEAD the file is indistinguishable from one where somebody wrote a
+    two-line doc. That is why #455 could not be closed in the snapshot; the
+    signal only exists in the diff, where the same line used to sit above a
+    different item.
+
+    Three conditions have to hold together, and each one is a false-accusation
+    class removed rather than a nicety:
+
+    * the doc line is unchanged and unique on both sides, so there is exactly
+      one thing it can be talking about;
+    * its old subject is still in the file, exactly once, and now has no doc
+      block of its own - prose that merely moved between two documented items
+      cost nobody their documentation;
+    * the line it landed on is NEW. Moving a doc DOWN onto an item that was
+      already there is how a capture gets repaired, and a gate that fails the
+      fix as well as the bug is one people route around.
+
+    Returns `(line at head, the doc line, the old subject, the new one)`.
+    """
+    before_map = doc_subjects(before)
+    after_map = doc_subjects(after)
+    if not before_map or not after_map:
+        return []
+    before_lines = line_counts(before)
+    after_lines = line_counts(after)
+    documented = documented_subjects(after)
+    found = []
+    for doc, (old, _at) in before_map.items():
+        moved = after_map.get(doc)
+        if not old or not moved:
+            continue
+        new, line_no = moved
+        if not new or new == old:
+            continue
+        if after_lines.get(old, 0) != 1 or old in documented:
+            continue
+        if before_lines.get(new, 0):
+            continue
+        found.append((line_no, doc, old, new))
+    return sorted(found)
+
+
+def item_name(line):
+    """The bare item name a subject line declares, or None.
+
+    Only used to tell the two passes apart: when the diff pass and the loss
+    pass have found the same capture, the loss pass owns the report, and one
+    defect must not print two annotations.
+    """
+    m = ITEM.match(line)
+    return next((g for g in m.groups() if g), None) if m else None
+
+
 def main():
     base, head = sys.argv[1], sys.argv[2]
     declared = git("log", f"{base}..{head}", "--format=%B")
@@ -538,6 +672,52 @@ def main():
             continue
         for line_no, first, follower in orphaned_docs(text):
             orphans.append((f, line_no, first, follower))
+    # The diff pass (#455): a doc line that changed the item it sits above.
+    # Runs per file over the revisions that actually touched it - the merge
+    # base, then each commit on the branch - so a capture made in one commit
+    # of a branch is seen even though the merge base predates both items.
+    # Every candidate is then re-tested against HEAD, because a capture that
+    # a later commit repaired is not a defect in the branch being merged.
+    reassigned = []
+    for f in changed:
+        head_text = git("show", f"{head}:{f}", allow_missing_path=True)
+        if not head_text:
+            continue
+        touched = git(
+            "log", f"{base}..{head}", "--format=%H", "--reverse", "--", f
+        ).split()
+        texts = [git("show", f"{rev}:{f}", allow_missing_path=True) for rev in [base] + touched]
+        texts.append(head_text)
+        candidates = {}
+        for older, newer in zip(texts, texts[1:]):
+            if not older or older == newer:
+                continue
+            for _line, doc, old, new in reassigned_docs(older, newer):
+                candidates[doc] = (old, new)
+        if not candidates:
+            continue
+        at_head = doc_subjects(head_text)
+        counts = line_counts(head_text)
+        has_doc = documented_subjects(head_text)
+        for doc, (old, new) in candidates.items():
+            here = at_head.get(doc)
+            if not here or not here[0] or here[0] == old:
+                continue
+            if counts.get(old, 0) != 1 or old in has_doc:
+                continue
+            # The same capture, when its victim is an item `ITEM` models and
+            # was documented at the base, is already reported as a loss. One
+            # defect, one annotation: the loss message is the older and more
+            # precise of the two, so it keeps the report. The declared-removal
+            # exemption travels with it for the same reason.
+            victim = item_name(old)
+            if victim and any(
+                path == f and (name == victim or name.endswith(f"::{victim}"))
+                for path, name in [(l[0], l[1]) for l in losses] + sorted(exempt)
+            ):
+                continue
+            reassigned.append((f, here[1], doc, old, here[0]))
+
     for f, name, at in losses:
         print(
             f"::error file={f}::`{name}` had a doc comment at {at[:12]} and has none now. "
@@ -554,11 +734,22 @@ def main():
             "check nor rustc reports it. Move the inserted item above the block, "
             f"or give the block an item. First line: {first!r}"
         )
-    if losses or orphans:
+    for f, line_no, doc, old, new in reassigned:
+        print(
+            f"::error file={f},line={line_no}::this doc comment described {old!r} "
+            f"before this branch and describes {new!r} now, leaving {old!r} with no "
+            "documentation at all (#455). An item inserted directly above a documented "
+            "one takes its prose: nothing is stranded, so the head-only pass cannot see "
+            "it, and the rendered docs are confidently wrong rather than absent. Move "
+            f"the new item above the doc block, or give it a doc of its own. Line: {doc!r}"
+        )
+    if losses or orphans or reassigned:
         if losses:
             print(f"\n{len(losses)} item(s) lost documentation.", file=sys.stderr)
         if orphans:
             print(f"{len(orphans)} doc block(s) document nothing.", file=sys.stderr)
+        if reassigned:
+            print(f"{len(reassigned)} doc comment(s) changed owner.", file=sys.stderr)
         return 1
     print(
         f"No documentation lost or stranded across {len(changed)} changed Rust file(s)."

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -606,7 +606,10 @@ def reassigned_docs(before, after):
     return sorted(per_subject.values())
 
 
-SUBJECT_KEY = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:#\[[^\]]*\]\s*)*([A-Za-z_]\w*)")
+# The leading name on a subject line. `r#` is part of the name, not a
+# prefix to skip: `r#type` and `r#match` are different items, and
+# capturing `r` for both would let one declared removal excuse the other.
+SUBJECT_KEY = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:#\[[^\]]*\]\s*)*((?:r#)?[A-Za-z_]\w*)")
 
 
 def subject_key(line):
@@ -642,7 +645,11 @@ def main():
     exempt = {
         (path, name)
         for path, name in re.findall(
-            r"doc-removal:\s*([\w./-]+\.rs)::((?:(?:trait )?[A-Za-z_][\w:]*(?: for [A-Za-z_][\w:]*)?::)?[A-Za-z_]\w*)",
+            # `r#` belongs to the name it prefixes: `r#type` and `r#match` are
+            # different items, and a pattern stopping at `r` would read both
+            # declarations as the same one.
+            r"doc-removal:\s*([\w./-]+\.rs)::"
+            r"((?:(?:trait )?[A-Za-z_][\w:]*(?: for [A-Za-z_][\w:]*)?::)?(?:r#)?[A-Za-z_]\w*)",
             declared,
         )
     }
@@ -715,13 +722,24 @@ def main():
         touched = git(
             "log", f"{base}..{head}", "--format=%H", "--reverse", "--", f
         ).split()
-        texts = [git("show", f"{rev}:{f}", allow_missing_path=True) for rev in [base] + touched]
-        # The last commit that touched the file usually IS the head, so the
-        # pair loop below skips the duplicate rather than re-reading it.
-        texts.append(head_text)
+        # Each commit against its OWN first parent, not against the previous
+        # entry in the log. Path limiting simplifies history before `--reverse`
+        # orders it, so two adjacent entries need not be parent and child, and
+        # comparing them reads a doc as having moved between states that were
+        # never one edit apart. The base-to-head pair is kept as well: it is
+        # what sees a capture whose commits are all outside this file's own
+        # history, and it is the pair the real #454 instance was caught by.
+        pairs = [(git("show", f"{base}:{f}", allow_missing_path=True), head_text)]
+        for rev in touched:
+            pairs.append(
+                (
+                    git("show", f"{rev}^:{f}", allow_missing_path=True),
+                    git("show", f"{rev}:{f}", allow_missing_path=True),
+                )
+            )
         candidates = {}
-        for older, newer in zip(texts, texts[1:]):
-            if not older or older == newer:
+        for older, newer in pairs:
+            if not older or not newer or older == newer:
                 continue
             for _line, doc, old, new in reassigned_docs(older, newer):
                 # FIRST owner wins. A doc captured twice on one branch
@@ -732,7 +750,7 @@ def main():
                 candidates.setdefault(doc, (old, new))
         if not candidates:
             continue
-        losses_keys = [(l[0], l[1]) for l in losses]
+        losses_keys = [(loss[0], loss[1]) for loss in losses]
         at_head = doc_subjects(head_text)
         counts = line_counts(head_text)
         has_doc = documented_subjects(head_text)

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -629,7 +629,8 @@ ITEM_KEYWORDS = frozenset(
         "const",
         "static",
         "fn",
-        "macro_rules!",
+        # Without the bang: `SUBJECT_KEY` captures `\w*`, which stops before it.
+        "macro_rules",
         "pub",
         "unsafe",
         "async",
@@ -648,18 +649,38 @@ def subject_key(line):
     have a merge-blocking check and no way to declare a removal against it,
     which is the one thing that turns a gate into an obstacle.
     """
-    m = SUBJECT_KEY.match(line)
-    if not m:
-        return None
-    name = m.group(1)
-    if name in ITEM_KEYWORDS:
-        # A keyword-led line: the NAME is the word after it. `mod theme;` is
-        # exactly the unmodelled-item case this fallback exists for, and
-        # keying it as `mod` made one `doc-removal: f.rs::mod` excuse every
-        # captured `mod` in that file.
-        rest = SUBJECT_KEY.match(line[m.end():].lstrip())
-        return rest.group(1) if rest else None
-    return name
+    # An impl or trait header keys the way the loss pass already keys its
+    # methods, so one declaration cannot cover two impls of one type: `impl
+    # fmt::Display for Foo {` is `Display for Foo`, not `fmt`. Taking the
+    # first word gave `fmt` to both a Display and a Debug impl, and one
+    # `doc-removal: a.rs::fmt` excused either.
+    header = BLOCK_HEADER.match(line)
+    if header:
+        kind = "trait" if "trait" in header.group(0)[: header.start("rest")] else "impl"
+        return block_key(kind, header.group("rest")) or None
+
+    # EVERY leading keyword, not one. `pub async unsafe extern "C" fn bar(`
+    # walks four before the name, and stopping after the first keyed it as
+    # `unsafe`. The bound is a guard against a pathological line rather than
+    # a real limit: Rust has no item with eight qualifiers.
+    rest = line
+    for _ in range(8):
+        m = SUBJECT_KEY.match(rest)
+        if not m:
+            return None
+        name = m.group(1)
+        if name not in ITEM_KEYWORDS:
+            return name
+        rest = rest[m.end():]
+        if name == "extern":
+            # `extern "C" fn bar(`: the ABI is a string literal, which the
+            # name pattern cannot step over.
+            rest = re.sub(r'^\s*"[^"]*"', "", rest)
+        elif name == "macro_rules":
+            # The bang belongs to the keyword, and `\w` stops before it.
+            rest = rest.lstrip().removeprefix("!")
+        rest = rest.lstrip()
+    return None
 
 
 def git_ok(*args):
@@ -695,8 +716,14 @@ def main():
             # `r#` belongs to the name it prefixes: `r#type` and `r#match` are
             # different items, and a pattern stopping at `r` would read both
             # declarations as the same one.
+            # Three shapes, because the gate prints three. A bare name
+            # (`bar`); a method under its block (`Foo::new`, `Display for
+            # Foo::fmt`); and, since the diff pass may report an impl HEADER
+            # as the victim, that header on its own (`fmt::Display for Foo`).
+            # A declaration the error tells you to write has to parse back.
             r"doc-removal:\s*([\w./-]+\.rs)::"
-            r"((?:(?:trait )?[A-Za-z_][\w:]*(?: for [A-Za-z_][\w:]*)?::)?(?:r#)?[A-Za-z_]\w*)",
+            r"((?:trait )?(?:r#)?[A-Za-z_][\w:]*(?: for (?:r#)?[A-Za-z_][\w:]*)?"
+            r"(?:::(?:r#)?[A-Za-z_]\w*)?)",
             declared,
         )
     }
@@ -773,8 +800,16 @@ def main():
         # needs it, so that is the common shape rather than an exotic one. The
         # declaration that excused such a change on main is invisible here
         # too, because the commit-message scan starts above the merge base, so
-        # the report would name an escape hatch the reader cannot use. What a
-        # merge itself resolves is covered by the base-to-head pair below.
+        # the report would name an escape hatch the reader cannot use.
+        #
+        # What it COSTS, stated rather than waved at: a capture made by the
+        # resolution itself, when the thief is a line the other side already
+        # had. The base-to-head pair does not cover that one, because "the
+        # line the prose landed on is new" is false for a line main brought
+        # in. A resolution that invents a new thief line IS still caught.
+        # `test_a_capture_inside_a_merge_resolution_is_a_known_gap` pins that
+        # boundary, and an earlier version of this comment claimed the pair
+        # covered it, which was wrong.
         touched = git(
             "log", f"{base}..{head}", "--no-merges", "--format=%H", "--reverse", "--", f
         ).split()
@@ -832,10 +867,6 @@ def main():
             # defect, one annotation: the loss message is the older and more
             # precise of the two, so it keeps the report. The declared-removal
             # exemption travels with it for the same reason.
-            # The same capture, when its victim is an item `ITEM` models and
-            # was documented at the base, is already reported as a loss. One
-            # defect, one annotation: the loss message is the older and more
-            # precise of the two, so it keeps the report.
             modelled = item_name(old)
             if modelled and any(
                 path == f and (name == modelled or name.endswith(f"::{modelled}"))

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -488,13 +488,21 @@ def _doc_blocks(lines, kinds):
         j = i
         while j < len(lines) and kinds[j] in (ATTR, SKIP):
             j += 1
-        yield start, i, (lines[j].strip() if j < len(lines) else None)
+        # A block followed by ANOTHER doc block documents nothing, and the
+        # head-only pass above reports exactly that. Handing the second
+        # block's text back as a "subject" made one defect print two
+        # annotations, the second of them saying the prose now describes a
+        # `///` line, which is not an item and not something a reader can act
+        # on. The two passes cannot now report the same block: this one needs
+        # a real subject, and the other one fires only when there is none.
+        subject = lines[j].strip() if j < len(lines) and kinds[j] == CODE else None
+        yield start, i, subject
 
 
 # A doc line carrying no prose of its own: the `///` separators a long block
 # is full of. They repeat, they move whenever anything near them moves, and
 # they say nothing about which item they describe.
-DOC_PROSE = re.compile(r"^\s*(?:///+|//!|/\*\*+|\*)\s*(\S.*)$")
+DOC_PROSE = re.compile(r"^\s*(?:///|/\*\*+|\*)\s*(\S.*)$")
 
 
 def doc_subjects(text):
@@ -589,6 +597,22 @@ def reassigned_docs(before, after):
     return sorted(found)
 
 
+SUBJECT_KEY = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:#\[[^\]]*\]\s*)*([A-Za-z_]\w*)")
+
+
+def subject_key(line):
+    """The name to declare a deliberate removal against, for a subject line
+    `ITEM` does not model.
+
+    #455 was filed for an enum variant, and a variant is not an item this
+    file parses. Without a key derived from the line itself, the branch would
+    have a merge-blocking check and no way to declare a removal against it,
+    which is the one thing that turns a gate into an obstacle.
+    """
+    m = SUBJECT_KEY.match(line)
+    return m.group(1) if m else None
+
+
 def item_name(line):
     """The bare item name a subject line declares, or None.
 
@@ -665,37 +689,41 @@ def main():
     # its victim is new on the branch, or because the capturing item is of a
     # kind `ITEM` does not model. Runs on the same changed files, needs no
     # base, and reports separately so the two failure shapes stay legible.
-    orphans = []
-    for f in changed:
-        text = git("show", f"{head}:{f}", allow_missing_path=True)
-        if not text:
-            continue
-        for line_no, first, follower in orphaned_docs(text):
-            orphans.append((f, line_no, first, follower))
     # The diff pass (#455): a doc line that changed the item it sits above.
     # Runs per file over the revisions that actually touched it - the merge
     # base, then each commit on the branch - so a capture made in one commit
     # of a branch is seen even though the merge base predates both items.
     # Every candidate is then re-tested against HEAD, because a capture that
     # a later commit repaired is not a defect in the branch being merged.
+    orphans = []
     reassigned = []
     for f in changed:
         head_text = git("show", f"{head}:{f}", allow_missing_path=True)
         if not head_text:
             continue
+        for line_no, first, follower in orphaned_docs(head_text):
+            orphans.append((f, line_no, first, follower))
         touched = git(
             "log", f"{base}..{head}", "--format=%H", "--reverse", "--", f
         ).split()
         texts = [git("show", f"{rev}:{f}", allow_missing_path=True) for rev in [base] + touched]
+        # The last commit that touched the file usually IS the head, so the
+        # pair loop below skips the duplicate rather than re-reading it.
         texts.append(head_text)
         candidates = {}
         for older, newer in zip(texts, texts[1:]):
             if not older or older == newer:
                 continue
             for _line, doc, old, new in reassigned_docs(older, newer):
-                candidates[doc] = (old, new)
+                # FIRST owner wins. A doc captured twice on one branch
+                # (A -> B -> C) would otherwise be reported as having left B,
+                # which is the thief from the first move; the item that
+                # actually lost its documentation is A, and a reader who
+                # repairs the item the message names leaves A bare.
+                candidates.setdefault(doc, (old, new))
         if not candidates:
             continue
+        losses_keys = [(l[0], l[1]) for l in losses]
         at_head = doc_subjects(head_text)
         counts = line_counts(head_text)
         has_doc = documented_subjects(head_text)
@@ -710,13 +738,27 @@ def main():
             # defect, one annotation: the loss message is the older and more
             # precise of the two, so it keeps the report. The declared-removal
             # exemption travels with it for the same reason.
-            victim = item_name(old)
-            if victim and any(
-                path == f and (name == victim or name.endswith(f"::{victim}"))
-                for path, name in [(l[0], l[1]) for l in losses] + sorted(exempt)
+            # The same capture, when its victim is an item `ITEM` models and
+            # was documented at the base, is already reported as a loss. One
+            # defect, one annotation: the loss message is the older and more
+            # precise of the two, so it keeps the report.
+            modelled = item_name(old)
+            if modelled and any(
+                path == f and (name == modelled or name.endswith(f"::{modelled}"))
+                for path, name in losses_keys
             ):
                 continue
-            reassigned.append((f, here[1], doc, old, here[0]))
+            # The declared-removal hatch reaches this pass too. Keyed on the
+            # modelled name where there is one, and otherwise on the leading
+            # name of the subject line - an enum variant has no other key, and
+            # a variant is what #455 was filed for.
+            key = modelled or subject_key(old)
+            if key and any(
+                path == f and (name == key or name.endswith(f"::{key}"))
+                for path, name in exempt
+            ):
+                continue
+            reassigned.append((f, here[1], doc, old, here[0], key))
 
     for f, name, at in losses:
         print(
@@ -734,7 +776,12 @@ def main():
             "check nor rustc reports it. Move the inserted item above the block, "
             f"or give the block an item. First line: {first!r}"
         )
-    for f, line_no, doc, old, new in reassigned:
+    for f, line_no, doc, old, new, key in reassigned:
+        declare = (
+            f" Or declare the removal with `doc-removal: {f}::{key}` in a commit message."
+            if key
+            else ""
+        )
         print(
             f"::error file={f},line={line_no}::this doc comment described {old!r} "
             f"before this branch and describes {new!r} now, leaving {old!r} with no "
@@ -742,6 +789,7 @@ def main():
             "one takes its prose: nothing is stranded, so the head-only pass cannot see "
             "it, and the rendered docs are confidently wrong rather than absent. Move "
             f"the new item above the doc block, or give it a doc of its own. Line: {doc!r}"
+            f"{declare}"
         )
     if losses or orphans or reassigned:
         if losses:

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -500,9 +500,11 @@ def _doc_blocks(lines, kinds):
 
 
 # A doc line carrying no prose of its own: the `///` separators a long block
-# is full of. They repeat, they move whenever anything near them moves, and
-# they say nothing about which item they describe.
-DOC_PROSE = re.compile(r"^\s*(?:///|/\*\*+|\*)\s*(\S.*)$")
+# is full of, and the `*/` that closes a `/** */` one. They repeat, they move
+# whenever anything near them moves, and they say nothing about which item
+# they describe. The lookahead is what keeps `*/` out: the continuation-line
+# branch matches its `*`, leaving `/` to read as prose.
+DOC_PROSE = re.compile(r"^\s*(?:///|/\*\*+|\*)\s*(?!\*?/\s*$)(\S.*)$")
 
 
 def doc_subjects(text):
@@ -594,7 +596,14 @@ def reassigned_docs(before, after):
         if before_lines.get(new, 0):
             continue
         found.append((line_no, doc, old, new))
-    return sorted(found)
+    # One insertion is one defect. Every line of a block sits above the same
+    # item, so a three-line doc reported per line names the same victim and
+    # the same thief three times; the block's FIRST line is the one a reader
+    # recognises, and it is the lowest line number.
+    per_subject = {}
+    for line_no, doc, old, new in sorted(found):
+        per_subject.setdefault(old, (line_no, doc, old, new))
+    return sorted(per_subject.values())
 
 
 SUBJECT_KEY = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:#\[[^\]]*\]\s*)*([A-Za-z_]\w*)")

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -44,16 +44,20 @@ ITEM = re.compile(
     # merely undocumented. The `const A: u8` declaration is a branch below,
     # reached when this optional one is not taken.
     r"(?:default\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?"
+    # `r#` belongs to the name it prefixes. Without it here, `r#type` and
+    # `r#match` in one impl both key as `r`, and the "any documented" reading
+    # then hides a capture on either behind the other's surviving prose -
+    # the #405 collision the impl qualifier exists to prevent, one level down.
     r"(?:extern\s+\"[^\"]*\"\s+)?(?:"
-    r"fn\s+([A-Za-z_]\w*)"
-    r"|const\s+([A-Za-z_]\w*)\s*:"
-    r"|static\s+(?:mut\s+)?([A-Za-z_]\w*)\s*:"
-    r"|struct\s+([A-Za-z_]\w*)"
-    r"|enum\s+([A-Za-z_]\w*)"
-    r"|union\s+([A-Za-z_]\w*)"
-    r"|trait\s+([A-Za-z_]\w*)"
-    r"|type\s+([A-Za-z_]\w*)"
-    r"|macro_rules!\s+([A-Za-z_]\w*)"
+    r"fn\s+((?:r#)?[A-Za-z_]\w*)"
+    r"|const\s+((?:r#)?[A-Za-z_]\w*)\s*:"
+    r"|static\s+(?:mut\s+)?((?:r#)?[A-Za-z_]\w*)\s*:"
+    r"|struct\s+((?:r#)?[A-Za-z_]\w*)"
+    r"|enum\s+((?:r#)?[A-Za-z_]\w*)"
+    r"|union\s+((?:r#)?[A-Za-z_]\w*)"
+    r"|trait\s+((?:r#)?[A-Za-z_]\w*)"
+    r"|type\s+((?:r#)?[A-Za-z_]\w*)"
+    r"|macro_rules!\s+((?:r#)?[A-Za-z_]\w*)"
     r")"
 )
 
@@ -612,6 +616,29 @@ def reassigned_docs(before, after):
 SUBJECT_KEY = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:#\[[^\]]*\]\s*)*((?:r#)?[A-Za-z_]\w*)")
 
 
+# Words that lead an item rather than name one.
+ITEM_KEYWORDS = frozenset(
+    {
+        "mod",
+        "impl",
+        "trait",
+        "enum",
+        "struct",
+        "union",
+        "type",
+        "const",
+        "static",
+        "fn",
+        "macro_rules!",
+        "pub",
+        "unsafe",
+        "async",
+        "default",
+        "extern",
+    }
+)
+
+
 def subject_key(line):
     """The name to declare a deliberate removal against, for a subject line
     `ITEM` does not model.
@@ -622,7 +649,27 @@ def subject_key(line):
     which is the one thing that turns a gate into an obstacle.
     """
     m = SUBJECT_KEY.match(line)
-    return m.group(1) if m else None
+    if not m:
+        return None
+    name = m.group(1)
+    if name in ITEM_KEYWORDS:
+        # A keyword-led line: the NAME is the word after it. `mod theme;` is
+        # exactly the unmodelled-item case this fallback exists for, and
+        # keying it as `mod` made one `doc-removal: f.rs::mod` excuse every
+        # captured `mod` in that file.
+        rest = SUBJECT_KEY.match(line[m.end():].lstrip())
+        return rest.group(1) if rest else None
+    return name
+
+
+def git_ok(*args):
+    """Whether a git command succeeds, for a question rather than an answer."""
+    return (
+        subprocess.run(
+            ("git",) + args, capture_output=True, text=True, check=False
+        ).returncode
+        == 0
+    )
 
 
 def item_name(line):
@@ -683,7 +730,7 @@ def main():
                         and not after[name]
                         and (f, name) not in exempt
                         and not head_state[f].get(name, False)
-                        and not any(l[0] == f and l[1] == name for l in losses)
+                        and not any(loss[0] == f and loss[1] == name for loss in losses)
                     ):
                         # Name the commit the doc was last seen at. Saying
                         # "at {base}" would be wrong for a file the branch
@@ -719,18 +766,38 @@ def main():
             continue
         for line_no, first, follower in orphaned_docs(head_text):
             orphans.append((f, line_no, first, follower))
+        # `--no-merges`, and the omission is not a shortcut. A merge's first
+        # parent is the branch tip, so the pair `(M^, M)` is everything the
+        # OTHER side brought in, replayed as though this branch had written
+        # it - and this repo's convention is to merge main into a branch that
+        # needs it, so that is the common shape rather than an exotic one. The
+        # declaration that excused such a change on main is invisible here
+        # too, because the commit-message scan starts above the merge base, so
+        # the report would name an escape hatch the reader cannot use. What a
+        # merge itself resolves is covered by the base-to-head pair below.
         touched = git(
-            "log", f"{base}..{head}", "--format=%H", "--reverse", "--", f
+            "log", f"{base}..{head}", "--no-merges", "--format=%H", "--reverse", "--", f
         ).split()
         # Each commit against its OWN first parent, not against the previous
         # entry in the log. Path limiting simplifies history before `--reverse`
         # orders it, so two adjacent entries need not be parent and child, and
         # comparing them reads a doc as having moved between states that were
-        # never one edit apart. The base-to-head pair is kept as well: it is
-        # what sees a capture whose commits are all outside this file's own
-        # history, and it is the pair the real #454 instance was caught by.
+        # never one edit apart.
+        #
+        # The base-to-head pair is kept as well, and it is not redundant: the
+        # per-commit walk asks whether the line the prose landed on is new IN
+        # THAT PAIR, so a capture split across two commits - the thief added
+        # above the block in one, moved under it in the next - is invisible to
+        # every pair but this one. It is also the pair that caught the real
+        # #454 instance.
         pairs = [(git("show", f"{base}:{f}", allow_missing_path=True), head_text)]
         for rev in touched:
+            # A root commit has no `rev^`, which is a git failure rather than
+            # a missing path, so it would abort instead of being skipped.
+            # Unreachable under CI's full-depth checkout, reachable in a
+            # shallow clone running the documented local invocation.
+            if not git_ok("rev-parse", "--verify", f"{rev}^"):
+                continue
             pairs.append(
                 (
                     git("show", f"{rev}^:{f}", allow_missing_path=True),

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -23,9 +23,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import check_doc_ownership as gate  # noqa: E402
 
 
-def run(cwd, *args):
+def run(cwd, *args, check=True):
     subprocess.run(
-        args, cwd=cwd, check=True, capture_output=True, text=True
+        args, cwd=cwd, check=check, capture_output=True, text=True
     )
 
 
@@ -1044,11 +1044,31 @@ class ReassignedDocTests(unittest.TestCase):
     def test_a_keyword_led_subject_keys_on_the_name(self):
         """`mod theme;` is the unmodelled-item case the fallback exists for.
         Keying it as `mod` made one declaration excuse every captured `mod`
-        in the file."""
-        self.assertEqual(gate.subject_key("mod theme;"), "theme")
-        self.assertEqual(gate.subject_key("pub mod pane;"), "pane")
-        self.assertEqual(gate.subject_key("impl Foo {"), "Foo")
-        self.assertEqual(gate.subject_key("    A,"), "A")
+        in the file, and one leading keyword is not enough: an item can carry
+        four before its name, and an impl header names a type rather than the
+        first path segment of a trait."""
+        for line, key in [
+            ("mod theme;", "theme"),
+            ("pub mod pane;", "pane"),
+            ("impl Foo {", "Foo"),
+            ("    A,", "A"),
+            ("    r#type,", "r#type"),
+            ("pub(crate) fn foo(", "foo"),
+            # Four qualifiers, and an ABI string the name pattern cannot step
+            # over on its own.
+            ('pub async unsafe extern "C" fn bar(', "bar"),
+            # The bang belongs to the keyword.
+            ("macro_rules! m {", "m"),
+            # Impl headers key like the loss pass keys their methods, so one
+            # declaration cannot cover two impls of the same type: taking the
+            # first word gave `fmt` to both of these.
+            ("impl fmt::Display for Foo {", "fmt::Display for Foo"),
+            ("impl fmt::Debug for Foo {", "fmt::Debug for Foo"),
+            ("unsafe impl Send for X {}", "Send for X"),
+            # Generics are stripped, so a reformat does not move the key.
+            ("impl<T> Foo<T> {", "Foo"),
+        ]:
+            self.assertEqual(gate.subject_key(line), key, line)
 
     def test_two_raw_methods_in_one_impl_are_two_keys(self):
         """`ITEM` stopping at `r` collapsed them, and the "any documented"
@@ -1060,6 +1080,114 @@ class ReassignedDocTests(unittest.TestCase):
         keys = gate.documented(text)
         self.assertIn("Foo::r#type", keys)
         self.assertIn("Foo::r#match", keys)
+
+    def test_two_impls_of_one_type_are_two_declarations(self):
+        """The collision the impl key exists to prevent, end to end: with both
+        headers keyed on `fmt`, one `doc-removal: a.rs::fmt` silenced both."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            before = (
+                "struct Foo;\n\n/// Doc for the Display impl.\n"
+                "impl fmt::Display for Foo {}\n\n/// Doc for the Debug impl.\n"
+                "impl fmt::Debug for Foo {}\n"
+            )
+            repo.commit("a.rs", before)
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "struct Foo;\n\n/// Doc for the Display impl.\n"
+                "/// Doc for the inserted impl.\n"
+                "impl fmt::LowerHex for Foo {}\n"
+                "impl fmt::Display for Foo {}\n\n/// Doc for the Debug impl.\n"
+                "impl fmt::Debug for Foo {}\n",
+                message="feat: hex\n\ndoc-removal: a.rs::fmt::Debug for Foo",
+            )
+            self.assertEqual(
+                repo.exit_code(),
+                1,
+                "a declaration naming the DEBUG impl must not excuse the Display one",
+            )
+
+    def test_a_declaration_naming_the_captured_impl_does_excuse_it(self):
+        """The other half, and the one that makes the pair discriminate: with
+        both headers keyed on `fmt`, the wrong declaration would work, so a
+        test that only checks the refusal passes either way."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit(
+                "a.rs",
+                "struct Foo;\n\n/// Doc for the Display impl.\n"
+                "impl fmt::Display for Foo {}\n\n/// Doc for the Debug impl.\n"
+                "impl fmt::Debug for Foo {}\n",
+            )
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "struct Foo;\n\n/// Doc for the Display impl.\n"
+                "/// Doc for the inserted impl.\n"
+                "impl fmt::LowerHex for Foo {}\n"
+                "impl fmt::Display for Foo {}\n\n/// Doc for the Debug impl.\n"
+                "impl fmt::Debug for Foo {}\n",
+                message="feat: hex\n\ndoc-removal: a.rs::fmt::Display for Foo",
+            )
+            self.assertEqual(repo.exit_code(), 0)
+
+    def test_a_capture_inside_a_merge_resolution_is_a_known_gap(self):
+        """Pinned as scope rather than left to be discovered.
+
+        The walk skips merges, because a merge's first parent is the branch
+        tip and `(M^, M)` otherwise replays the other side's work as this
+        branch's. What that costs is a capture the RESOLUTION itself makes,
+        when the thief is a line that already existed on the side being
+        merged: the base-to-head pair cannot see it either, since "the line
+        the prose landed on is new" is false for a line main already had.
+
+        A resolution that invents a NEW thief line is still caught, so the
+        gap is exactly this shape. If it is ever closed, this test inverts.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n    Z,\n}\n")
+            repo.branch("feat")
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n    Zed,\n}\n")
+            repo.checkout("main")
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n    Z,\n    B,\n}\n")
+            repo.checkout("feat")
+            run(repo.path, "git", "merge", "--no-commit", "main", check=False)
+            # The resolution puts a line main already had under the doc block.
+            (repo.path / "a.rs").write_text(
+                "enum E {\n    /// Doc for A.\n    B,\n    A,\n    Zed,\n}\n"
+            )
+            run(repo.path, "git", "add", "-A")
+            run(repo.path, "git", "commit", "-q", "--no-edit")
+            self.assertEqual(
+                repo.exit_code(base="main"),
+                0,
+                "known gap: a resolution that moves an existing line under a doc block",
+            )
+
+    def test_a_commit_with_no_parent_does_not_abort_the_gate(self):
+        """The `rev^` probe, which nothing pinned.
+
+        A commit in `base..head` can have no parent - an orphan branch is the
+        reachable case, a shallow boundary the other - and `git show
+        <root>^:<file>` fails as a BAD REVISION rather than as a missing path,
+        which `git()` deliberately does not tolerate. Without the probe the
+        gate raises `SystemExit` and reports nothing at all: not a pass, not a
+        failure, just an abort with a git error in the log.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("seed.rs", "fn seed() {}\n")
+            # An orphan branch: its first commit has no parent at all.
+            run(repo.path, "git", "checkout", "-q", "--orphan", "detached")
+            run(repo.path, "git", "rm", "-rq", "--cached", ".")
+            repo.commit("a.rs", "/// Doc for a.\nfn a() {}\n")
+            self.assertEqual(
+                repo.exit_code(base="main"),
+                0,
+                "a parentless commit is skipped, not fatal",
+            )
 
     def test_a_block_doc_closer_is_not_prose(self):
         """`*/` closes a `/** */` block and says nothing about any item, but

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -780,3 +780,155 @@ class ReassignedDocTests(unittest.TestCase):
             "    /// Doc A, still here.\n    A,\n    /// Doc B.\n    B,\n}\n"
         )
         self.assertEqual(gate.reassigned_docs(before, after), [])
+
+    def test_a_doc_line_that_repeats_in_the_file_is_not_a_capture(self):
+        """Uniqueness is what keeps a coincidence from reading as a move. The
+        same `/// The width, in cells.` above three fields has no single owner
+        to have changed, so a rename in one struct plus a deletion in another
+        must not add up to a capture."""
+        before = (
+            "struct A {\n    /// The width, in cells.\n    w: u16,\n}\n"
+            "struct B {\n    /// The width, in cells.\n    x: u16,\n}\n"
+        )
+        after = (
+            "struct A {\n    /// The width, in cells.\n    width: u16,\n}\n"
+            "struct B {\n    x: u16,\n}\n"
+        )
+        self.assertEqual(gate.reassigned_docs(before, after), [])
+
+    def test_a_bare_separator_line_is_not_a_doc_that_moved(self):
+        """A `///` with no prose says nothing about which item it describes,
+        and a long block is full of them. Reporting one names a line the
+        reader cannot act on."""
+        before = "/// Alpha.\n///\nfn a() {}\n"
+        after = "/// Alpha.\n///\nfn zz() {}\n\nfn a() {}\n"
+        moved = [f for f in gate.reassigned_docs(before, after) if f[1] == "///"]
+        self.assertEqual(moved, [], "a separator is not evidence of anything")
+
+    def test_a_two_hop_capture_names_the_item_that_lost_its_doc(self):
+        """The message is the product here. When a doc is captured twice on
+        one branch, the victim is the item it described BEFORE the branch, not
+        the intermediate thief - repairing the one the gate names would leave
+        the real victim bare."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for A.\n    /// Doc for B.\n    B,\n    A,\n}\n",
+            )
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for A.\n    /// Doc for B.\n"
+                "    /// Doc for C.\n    C,\n    B,\n    A,\n}\n",
+            )
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            self.assertIn(
+                "described 'A,'",
+                out.getvalue(),
+                f"the victim is the item that had the doc at the base: {out.getvalue()}",
+            )
+
+    def test_a_capture_made_between_two_branch_commits_is_caught(self):
+        """Both items are absent at the merge base, so only the walk over the
+        branch's own commits can see this one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "fn existing() {}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "fn existing() {}\n\nenum E {\n    /// Doc for A.\n    A,\n}\n",
+            )
+            repo.commit(
+                "a.rs",
+                "fn existing() {}\n\nenum E {\n    /// Doc for A.\n"
+                "    /// Doc for B.\n    B,\n    A,\n}\n",
+            )
+            self.assertEqual(repo.exit_code(), 1)
+
+    def test_a_capture_a_later_commit_repaired_passes(self):
+        """What matters is the state at HEAD. Reporting every state a branch
+        passed through blocks a PR whose head is correct, which is the false
+        accusation that stops a gate being read."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for A.\n    /// Doc for B.\n    B,\n    A,\n}\n",
+            )
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for B.\n    B,\n    /// Doc for A.\n    A,\n}\n",
+            )
+            self.assertEqual(repo.exit_code(), 0)
+
+    def test_a_declared_removal_exempts_a_variant_too(self):
+        """The declaration is keyed on the name the gate's own error prints.
+        For a victim `ITEM` does not model - an enum variant is the kind #455
+        was filed for - that key comes from the subject line, and without it
+        the branch has a merge-blocking check and no way to declare."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for A.\n    /// Doc for B.\n    B,\n    A,\n}\n",
+                message="feat: b\n\ndoc-removal: a.rs::A",
+            )
+            self.assertEqual(repo.exit_code(), 0)
+
+    def test_the_diff_pass_stays_out_of_a_capture_the_others_report(self):
+        """A doc block separated from the newcomer's by a blank line is
+        stranded, and both older passes see it: the loss pass names the item
+        that lost its prose, the head-only pass names the stranded block. The
+        diff pass must not add a THIRD annotation, and in particular must not
+        report that the prose now describes another `///` line, which is not
+        an item and not something a reader can act on.
+
+        The victim is an enum variant, which `ITEM` does not model, so the
+        loss pass cannot fire here: what keeps the diff pass quiet has to be
+        the diff pass itself rather than the dedupe against a loss."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for A.\n\n    /// Doc for B.\n    B,\n    A,\n}\n",
+            )
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            self.assertNotIn(
+                "#455",
+                out.getvalue(),
+                f"the diff pass has nothing to say about a stranded block: {out.getvalue()}",
+            )
+            self.assertEqual(
+                out.getvalue().count("::error"),
+                1,
+                f"the head-only pass alone: {out.getvalue()}",
+            )

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -932,3 +932,27 @@ class ReassignedDocTests(unittest.TestCase):
                 1,
                 f"the head-only pass alone: {out.getvalue()}",
             )
+
+    def test_a_block_doc_closer_is_not_prose(self):
+        """`*/` closes a `/** */` block and says nothing about any item, but
+        it matches the continuation-line shape, so it read as a doc line with
+        the prose `/`. Reported, it names a line the reader cannot act on."""
+        before = "/**\n */\nfn a() {}\n"
+        after = "/**\n */\nfn zz() {}\n\nfn a() {}\n"
+        self.assertEqual(
+            gate.reassigned_docs(before, after),
+            [],
+            "the delimiter is not the documentation",
+        )
+
+    def test_a_captured_block_doc_is_reported_once(self):
+        """One insertion is one defect. Keying the report on each doc LINE
+        turned a three-line block into three annotations that name the same
+        item, the same thief and the same file."""
+        before = "/** Doc for A.\n * More.\n */\nfn a() {}\n"
+        after = "/** Doc for A.\n * More.\n */\nfn zz() {}\n\nfn a() {}\n"
+        found = gate.reassigned_docs(before, after)
+        self.assertEqual(
+            len(found), 1, f"one block above one item is one report: {found}"
+        )
+        self.assertEqual(found[0][1], "/** Doc for A.", "and it names the block's first line")

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -648,13 +648,13 @@ class HeadOnlyOrphanTests(unittest.TestCase):
             repo.commit("a.rs", "fn existing() {}\n\n/// Documents nothing at all.\n")
             self.assertEqual(repo.exit_code(), 1)
 
-    def test_a_capture_by_a_documented_newcomer_is_a_known_miss(self):
-        """The residue #427 keeps. When the inserted item carries its OWN
-        doc, nothing is stranded — the original prose has silently moved and
-        both items look documented — so this pass cannot see it. Pinned as a
-        deliberate limitation rather than left for someone to discover: if a
-        future change makes this exit 1, that is an improvement and this test
-        should be inverted, not deleted."""
+    def test_a_capture_by_a_documented_newcomer_is_caught(self):
+        """Was the residue #427 kept, and is now caught by the diff pass
+        (#455). When the inserted item carries its OWN doc nothing is
+        stranded, so the head-only pass still cannot see it; what gives it
+        away is that `/// Documents alpha.` sat above `fn alpha()` earlier on
+        the branch and sits above a newly inserted item now, leaving `alpha`
+        bare. Inverted rather than deleted, as the earlier version asked."""
         with tempfile.TemporaryDirectory() as tmp:
             repo = Repo(Path(tmp))
             repo.commit("a.rs", "fn existing() {}\n")
@@ -666,7 +666,7 @@ class HeadOnlyOrphanTests(unittest.TestCase):
                 "/// ...but now sits above the newcomer.\n"
                 "struct Inserted;\n\nfn alpha() {}\n",
             )
-            self.assertEqual(repo.exit_code(), 0)
+            self.assertEqual(repo.exit_code(), 1)
 
     def test_a_documented_re_export_is_not_reported(self):
         """`pub use` CAN legitimately carry a doc — rustdoc renders it — so
@@ -698,3 +698,85 @@ class HeadOnlyOrphanTests(unittest.TestCase):
             repo.commit("b.rs", "fn b() {}\n\nfn c() {}\n")
             self.assertEqual(repo.exit_code(), 0)
 
+
+
+class ReassignedDocTests(unittest.TestCase):
+    """The third pass (#455): a doc line that changed the item it sits above.
+
+    The head-only pass sees a capture only through the prose it STRANDS, and
+    a capture whose newcomer brings its own doc strands nothing: rustfmt
+    leaves the two `///` lines contiguous, they read as one ordinary block,
+    and the item below them is the thief. What separates that from a genuine
+    two-line doc block is not in the snapshot at all - it is in the diff,
+    where the same line used to sit above a different item.
+    """
+
+    def test_a_contiguous_capture_of_a_variants_doc_is_caught(self):
+        """#455, reduced from the instance that shipped in #454: the victim
+        is an enum variant, which `ITEM` does not model, and the stolen doc
+        is contiguous with the thief's, which the head-only pass reads as
+        one block. Both existing passes are blind to it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit(
+                "a.rs",
+                "enum E {\n"
+                "    /// Doc for A, an existing item.\n"
+                "    A,\n"
+                "}\n",
+            )
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "enum E {\n"
+                "    /// Doc for A, an existing item.\n"
+                "    /// Doc for B, inserted above it.\n"
+                "    B,\n"
+                "    A,\n"
+                "}\n",
+            )
+            self.assertEqual(repo.exit_code(), 1)
+
+    def test_the_error_names_the_line_and_both_items(self):
+        """A gate that says only "something moved" sends the reader hunting.
+        The message has to carry the prose, what it used to describe, and
+        what it describes now."""
+        before = "enum E {\n    /// Doc for A.\n    A,\n}\n"
+        after = "enum E {\n    /// Doc for A.\n    /// Doc for B.\n    B,\n    A,\n}\n"
+        found = gate.reassigned_docs(before, after)
+        self.assertEqual(len(found), 1, found)
+        _line, doc, old, new = found[0]
+        self.assertEqual(doc, "/// Doc for A.")
+        self.assertEqual(old, "A,")
+        self.assertEqual(new, "B,")
+
+    def test_moving_a_doc_back_onto_its_own_item_is_not_a_capture(self):
+        """The corrective PR. Repairing a misattribution moves the prose the
+        other way, and the item it lands on is one that already existed -
+        which is exactly what an INSERTED thief is not."""
+        before = "enum E {\n    /// Doc for A.\n    B,\n    A,\n}\n"
+        after = "enum E {\n    B,\n    /// Doc for A.\n    A,\n}\n"
+        self.assertEqual(gate.reassigned_docs(before, after), [])
+
+    def test_reordering_documented_items_is_not_a_capture(self):
+        """Each doc travels with its own item, so no line changes owner."""
+        before = "enum E {\n    /// Doc A.\n    A,\n    /// Doc B.\n    B,\n}\n"
+        after = "enum E {\n    /// Doc B.\n    B,\n    /// Doc A.\n    A,\n}\n"
+        self.assertEqual(gate.reassigned_docs(before, after), [])
+
+    def test_a_renamed_item_is_not_a_capture(self):
+        """The old subject line is gone at head, so nothing was stranded."""
+        before = "/// Doc for alpha.\nfn alpha() {}\n"
+        after = "/// Doc for alpha.\nfn renamed() {}\n"
+        self.assertEqual(gate.reassigned_docs(before, after), [])
+
+    def test_a_victim_that_keeps_a_doc_of_its_own_is_not_reported(self):
+        """The swap that fixes a capture leaves both items documented. Only
+        prose that leaves an item BARE is a loss worth failing a PR over."""
+        # `Inserted` is new, and A keeps a doc line, so nothing is bare.
+        before = "enum E {\n    /// Doc A.\n    A,\n    /// Doc B.\n    B,\n}\n"
+        after = (
+            "enum E {\n    /// Doc A.\n    Inserted,\n"
+            "    /// Doc A, still here.\n    A,\n    /// Doc B.\n    B,\n}\n"
+        )
+        self.assertEqual(gate.reassigned_docs(before, after), [])

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -46,6 +46,14 @@ class Repo:
     def branch(self, name: str):
         run(self.path, "git", "checkout", "-q", "-b", name)
 
+    def checkout(self, name: str):
+        run(self.path, "git", "checkout", "-q", name)
+
+    def merge(self, name: str):
+        """Merge `name` into the current branch, as this repo's convention
+        says to do when a branch needs main."""
+        run(self.path, "git", "merge", "-q", "--no-edit", name)
+
     def exit_code(self, base="main", head="HEAD"):
         """The gate's exit status: 1 when it found a capture, 0 when clean."""
         import os
@@ -967,6 +975,91 @@ class ReassignedDocTests(unittest.TestCase):
                 message="feat: match\n\ndoc-removal: a.rs::r#match",
             )
             self.assertEqual(repo.exit_code(), 1)
+
+    def test_merging_main_does_not_report_what_main_did(self):
+        """A merge's first parent is the branch tip, so the pair `(M^, M)` is
+        everything the OTHER side brought in. Replaying that as the branch's
+        own work reports a capture main already declared - and the
+        declaration is invisible here, since the commit-message scan starts
+        above the merge base, so the message names a hatch the reader cannot
+        use. This repo merges main into a branch that needs it, so the shape
+        is the convention rather than an exotic case."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for Toggle.\n    Toggle,\n}\n")
+            repo.branch("feat")
+            # The branch touches the same file, far from the doc block.
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for Toggle.\n    Toggle,\n}\n\npub fn helper() {}\n",
+            )
+            repo.checkout("main")
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for Toggle.\n    /// Doc for Load.\n"
+                "    Load,\n    Toggle,\n}\n",
+                message="feat: load\n\ndoc-removal: a.rs::Toggle",
+            )
+            repo.checkout("feat")
+            repo.merge("main")
+            self.assertEqual(
+                repo.exit_code(base="main"),
+                0,
+                "main's own change, declared on main, is not this branch's capture",
+            )
+
+    def test_a_capture_after_a_merge_is_still_caught(self):
+        """The control for the one above: skipping merges must not skip the
+        branch's own commits that follow one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n}\n")
+            repo.branch("feat")
+            repo.commit("b.rs", "fn b() {}\n")
+            repo.checkout("main")
+            repo.commit("c.rs", "fn c() {}\n")
+            repo.checkout("feat")
+            repo.merge("main")
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for A.\n    /// Doc for B.\n    B,\n    A,\n}\n",
+            )
+            self.assertEqual(repo.exit_code(base="main"), 1)
+
+    def test_a_capture_split_across_two_commits_is_caught(self):
+        """What the base-to-head pair is FOR, and what nothing pinned. Each
+        per-commit pair asks whether the line the prose landed on is new IN
+        THAT PAIR, so a thief added above the block in one commit and moved
+        under it in the next is invisible to every pair but this one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    A,\n}\n")
+            repo.branch("feat")
+            # B arrives ABOVE the block: no capture yet.
+            repo.commit("a.rs", "enum E {\n    B,\n    /// Doc for A.\n    A,\n}\n")
+            # and then moves UNDER it, which is the capture.
+            repo.commit("a.rs", "enum E {\n    /// Doc for A.\n    B,\n    A,\n}\n")
+            self.assertEqual(repo.exit_code(), 1)
+
+    def test_a_keyword_led_subject_keys_on_the_name(self):
+        """`mod theme;` is the unmodelled-item case the fallback exists for.
+        Keying it as `mod` made one declaration excuse every captured `mod`
+        in the file."""
+        self.assertEqual(gate.subject_key("mod theme;"), "theme")
+        self.assertEqual(gate.subject_key("pub mod pane;"), "pane")
+        self.assertEqual(gate.subject_key("impl Foo {"), "Foo")
+        self.assertEqual(gate.subject_key("    A,"), "A")
+
+    def test_two_raw_methods_in_one_impl_are_two_keys(self):
+        """`ITEM` stopping at `r` collapsed them, and the "any documented"
+        reading then hid a capture on either behind the other's prose."""
+        text = (
+            "impl Foo {\n    /// Doc for type.\n    pub fn r#type(&self) {}\n\n"
+            "    /// Doc for match.\n    pub fn r#match(&self) {}\n}\n"
+        )
+        keys = gate.documented(text)
+        self.assertIn("Foo::r#type", keys)
+        self.assertIn("Foo::r#match", keys)
 
     def test_a_block_doc_closer_is_not_prose(self):
         """`*/` closes a `/** */` block and says nothing about any item, but

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -933,6 +933,41 @@ class ReassignedDocTests(unittest.TestCase):
                 f"the head-only pass alone: {out.getvalue()}",
             )
 
+    def test_a_raw_identifier_is_one_name(self):
+        """`r#type` and `r#match` are different items. A key that stopped at
+        `r` would make one declared removal excuse the other, which is the
+        error the file qualifier exists to prevent one level up."""
+        self.assertEqual(gate.subject_key("    r#type,"), "r#type")
+        self.assertEqual(gate.subject_key("    r#match,"), "r#match")
+        self.assertEqual(gate.subject_key("    pub r#fn: u8,"), "r#fn")
+
+    def test_a_declared_removal_of_a_raw_identifier_is_exempt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for the type arm.\n    r#type,\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for the type arm.\n    /// Doc for the match arm.\n"
+                "    r#match,\n    r#type,\n}\n",
+                message="feat: match\n\ndoc-removal: a.rs::r#type",
+            )
+            self.assertEqual(repo.exit_code(), 0)
+
+    def test_a_declaration_naming_a_different_raw_identifier_does_not_excuse_it(self):
+        """The control for the one above: `r#match` is not `r#type`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "enum E {\n    /// Doc for the type arm.\n    r#type,\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "enum E {\n    /// Doc for the type arm.\n    /// Doc for the match arm.\n"
+                "    r#match,\n    r#type,\n}\n",
+                message="feat: match\n\ndoc-removal: a.rs::r#match",
+            )
+            self.assertEqual(repo.exit_code(), 1)
+
     def test_a_block_doc_closer_is_not_prose(self):
         """`*/` closes a `/** */` block and says nothing about any item, but
         it matches the continuation-line shape, so it read as a doc line with


### PR DESCRIPTION
Closes #455.

The gate had two passes and neither can see the shape that shipped in #454: a
doc line inserted directly above a documented enum variant.

* The diff pass keys on the items `ITEM` models, and an enum variant is not
  one of them.
* The head-only pass sees a capture only through the prose it **strands**, and
  a newcomer that brings its own doc strands nothing. rustfmt leaves the stolen
  line and the thief's own contiguous, so at HEAD they read as one ordinary
  two-line doc block. That is the contiguous case the issue reproduces.

## What the third pass keys on

The signal is not in the snapshot, it is in the diff: the same doc line used to
sit above a different item. For every changed file the pass compares what each
unique doc line sat above at the merge base, and at each branch commit that
touched that file, with what it sits above at HEAD.

Three conditions must hold together, and each one removes a class of false
accusation rather than being a nicety:

| condition | the false accusation it removes |
| --- | --- |
| the doc line is unchanged and unique on both sides | a `/// The width, in cells.` repeated above three fields has no single owner to have changed |
| its old subject is still present, exactly once, and now carries no doc | prose that moved between two documented items cost nobody their documentation; a renamed item is not a capture |
| the line the prose landed on is **new** | moving a doc back down onto an item that already existed is how a capture is repaired, and a gate that fails the fix as well as the bug gets routed around |

A capture whose victim is an item the diff pass already models is reported by
that pass alone: one defect, one annotation, and a `doc-removal:` declaration
still covers both.

## Proved against the instance that shipped

`fbe9de3` is the #454 commit that carried the capture, `95ba876` is the commit
that fixed it, and both were green on this gate before this change:

```
$ python3 scripts/check_doc_ownership.py $(git merge-base 89ae516^1 fbe9de3) fbe9de3
::error file=src/widgets/command_palette.rs,line=196::this doc comment described
'ToggleSessionRecording,' before this branch and describes 'LoadReviewThreads,' now,
leaving 'ToggleSessionRecording,' with no documentation at all (#455). ...
exit=1

$ python3 scripts/check_doc_ownership.py $(git merge-base 89ae516^1 fbe9de3) 95ba876
No documentation lost or stranded across 5 changed Rust file(s).
exit=0
```

## False positives

Swept the last 30 merges on `main`, running the gate over each branch's own
merge base to its head: zero reports from the new pass. The one `exit=1` in
that range is an older pass on a pre-existing branch and predates this change.

Each of the three conditions above is pinned by a control test, and each was
proved load-bearing by removing that condition and watching its own control
fail (and only that one).

The known-miss test #427 left behind is inverted rather than deleted, which is
what its docstring asked for.

CI only: `scripts/` and `CONTRIBUTING.md` ship nothing, so there is no version
bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Documentation ownership checks now detect comments unintentionally reassigned between items across changes.
  - Reports identify affected documentation and both related items, including enum variants.
  - Deliberate removals can be declared to prevent false positives.

- **Documentation**
  - Expanded contributor guidance explains ownership checks, detection limitations, and removal exemptions.

- **Tests**
  - Added coverage for reassigned documentation, exemptions, multi-step changes, repairs, merge scenarios, and duplicate detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->