### PR TITLE
fix(ci): exempt a change confined to a cfg(test) module from the release gate (#461)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,24 @@ jobs:
     name: version bump + release notes
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # This job now runs a SCRIPT from the submitted branch, which the inline
+    # shell above it never did, so it takes the same posture the doc-ownership
+    # job below documents: only what it needs to read the diff, and no
+    # checkout token left in the local git config for that script to reach.
+    #
+    # Pinning the script to the base revision instead would buy nothing on
+    # this trigger: `pull_request` runs the workflow file from the merge of
+    # the branch, so a PR that wanted to neuter the gate would edit the job
+    # rather than the helper it calls. What is worth removing is the
+    # CREDENTIAL, not the ability to run branch code.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           # Full history so the merge-base with the PR base resolves.
           fetch-depth: 0
+          persist-credentials: false
       - name: Shipped changes must bump the version and replace the notes
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,15 +65,20 @@ jobs:
           # unsure about counts as shipped: waiving a bump that was needed
           # puts two binaries on one version, which is what this job exists
           # to prevent.
-          kept=""
-          for f in $shipped; do
+          # Read the list a line at a time rather than word-splitting it: an
+          # unquoted `for f in $shipped` also expands globs, so a path
+          # holding `[`, `*` or `?` would reach the filter as a pathspec git
+          # cannot resolve, and a path holding a space would arrive as two.
+          kept="$(mktemp)"
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
             if python3 scripts/ships_nothing.py "$base" HEAD "$f"; then
               echo "$f: change confined to #[cfg(test)]; ships nothing."
             else
-              kept="$kept $f"
+              printf '%s\n' "$f" >> "$kept"
             fi
-          done
-          shipped="$(printf '%s\n' $kept)"
+          done <<< "$shipped"
+          shipped="$(cat "$kept")"
           if [ -z "$shipped" ]; then
             echo "No shipped files changed; no release required."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,15 @@ jobs:
           # holding `[`, `*` or `?` would reach the filter as a pathspec git
           # cannot resolve, and a path holding a space would arrive as two.
           kept="$(mktemp)"
+          trap 'rm -f "$kept"' EXIT
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             if python3 scripts/ships_nothing.py "$base" HEAD "$f"; then
-              echo "$f: change confined to #[cfg(test)]; ships nothing."
+              # The status says "ships nothing"; it does not say why, and the
+              # script has more than one way to reach it. Claiming the reason
+              # here asserted "confined to #[cfg(test)]" about files that had
+              # no test module at all.
+              echo "$f: ships nothing."
             else
               printf '%s\n' "$f" >> "$kept"
             fi
@@ -84,7 +89,7 @@ jobs:
             exit 0
           fi
           echo "Shipped files changed:"
-          printf '  %s\n' $shipped
+          printf '  %s\n' "$shipped"
           ver() { git show "$1:Cargo.toml" | sed -n 's/^version *= *"\([0-9.]*\)".*/\1/p' | head -n1; }
           old="$(ver "$base")"
           new="$(ver HEAD)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
     # describes THIS version instead of silently carrying the previous
     # release's story. One file per version (#399) so two open PRs describing
     # different changes never collide on the same file.
-    # Docs / CI / test-only changes ship nothing and are exempt.
+    # Docs / CI / test-only changes ship nothing and are exempt, including a
+    # diff confined to a `#[cfg(test)]` module inside a shipped file (#461).
     name: version bump + release notes
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -56,6 +57,23 @@ jobs:
           shipped="$(printf '%s\n' "$changed" \
             | grep -E '^(src/|assets/|build\.rs$|Cargo\.toml$|Cargo\.lock$)' \
             | grep -vE '^(src/app/tests\.rs|tests/)' || true)"
+          # A `.rs` file whose diff touches nothing outside a
+          # `#[cfg(test)] mod tests` produces a byte-identical binary, and
+          # croft keeps most unit tests beside the code they cover, so that
+          # is the ordinary shape of a test-only fix here (#461). The path
+          # list above only reaches whole test FILES. Anything the parse is
+          # unsure about counts as shipped: waiving a bump that was needed
+          # puts two binaries on one version, which is what this job exists
+          # to prevent.
+          kept=""
+          for f in $shipped; do
+            if python3 scripts/ships_nothing.py "$base" HEAD "$f"; then
+              echo "$f: change confined to #[cfg(test)]; ships nothing."
+            else
+              kept="$kept $f"
+            fi
+          done
+          shipped="$(printf '%s\n' $kept)"
           if [ -z "$shipped" ]; then
             echo "No shipped files changed; no release required."
             exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,12 @@ current version's file may change in a PR: an older one describes a release
 that has already shipped.
 
 CI enforces all of it (the `version bump + release notes` job). Docs, CI, and
-test-only PRs (`src/app/tests.rs`, `tests/`) are exempt.
+test-only PRs are exempt: `src/app/tests.rs` and `tests/` by path, and a `.rs`
+file whose diff touches nothing outside a `#[cfg(test)]` module, since most of
+croft's unit tests sit beside the code they cover and a change confined to them
+produces a byte-identical binary. Anything that filter is unsure about counts
+as shipped, so an unexpected bump request is the failure it prefers over a
+waived one.
 
 ## Insert new items AFTER a complete item, never above a doc block
 

--- a/scripts/ships_nothing.py
+++ b/scripts/ships_nothing.py
@@ -27,7 +27,15 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from check_doc_ownership import ATTR, CODE, MISSING_PATH, SKIP, BlockTracker, classify  # noqa: E402
+from check_doc_ownership import (  # noqa: E402
+    ATTR,
+    CODE,
+    DOC,
+    MISSING_PATH,
+    SKIP,
+    BlockTracker,
+    classify,
+)
 
 # The attribute on its own line, which is what rustfmt produces and what every
 # test module in this repo has. `#[cfg(test)] mod tests {` on one line is legal
@@ -40,13 +48,19 @@ MOD = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+[A-Za-z_]\w*")
 HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
-def git(*args, cwd=None):
-    """Run git, tolerating only "that path is not in that revision"."""
+def git(*args, cwd=None, allow_missing_path=False):
+    """Run git, tolerating "that path is not in that revision" only where the
+    caller says a missing path is a legitimate answer.
+
+    Opt-in for the same reason `check_doc_ownership.git` is: tolerating it
+    everywhere lets an invalid revision or a malformed object read as empty
+    content, and empty content is the WAIVING answer here.
+    """
     done = subprocess.run(
         ("git",) + args, cwd=cwd, capture_output=True, text=True
     )
     if done.returncode != 0:
-        if MISSING_PATH.search(done.stderr):
+        if allow_missing_path and MISSING_PATH.search(done.stderr):
             return ""
         raise SystemExit(f"git {' '.join(args)} failed: {done.stderr.strip()}")
     return done.stdout
@@ -82,9 +96,12 @@ def cfg_test_ranges(text):
             continue
         if attr_at is None:
             continue
-        if kinds[i] in (SKIP, ATTR):
-            # Blank lines, comments and further attributes sit legally
-            # between `#[cfg(test)]` and the module it applies to.
+        if kinds[i] in (SKIP, ATTR, DOC):
+            # Blank lines, comments, doc comments and further attributes all
+            # sit legally between `#[cfg(test)]` and the module it applies
+            # to. `classify` labels `///` DOC rather than SKIP, and a
+            # documented test module is an ordinary shape: missing it loses
+            # the exemption silently rather than waiving wrongly.
             continue
         if MOD.match(line) and tracker.depth > depth_before:
             open_at = (attr_at, depth_before)
@@ -126,13 +143,50 @@ def ships_nothing(base, head, path, cwd=None):
     """
     if not path.endswith(".rs"):
         return False
+    base_text = git("show", f"{base}:{path}", cwd=cwd, allow_missing_path=True)
+    head_text = git("show", f"{head}:{path}", cwd=cwd, allow_missing_path=True)
     removed, added = changed_lines(base, head, path, cwd=cwd)
     if not removed and not added:
-        return True
-    base_ranges = cfg_test_ranges(git("show", f"{base}:{path}", cwd=cwd))
-    head_ranges = cfg_test_ranges(git("show", f"{head}:{path}", cwd=cwd))
-    return all(inside(n, base_ranges) for n in removed) and all(
-        inside(n, head_ranges) for n in added
+        # An empty diff means "nothing changed" for a path that exists at both
+        # ends, and "git could not resolve that pathspec" otherwise. Only the
+        # first is a reason to waive a bump, and the second is reachable: a
+        # path that matches nothing makes `git diff` exit 0 with no output.
+        return bool(base_text) and bool(head_text)
+    base_ranges = cfg_test_ranges(base_text)
+    head_ranges = cfg_test_ranges(head_text)
+    base_lines = base_text.splitlines()
+    head_lines = head_text.splitlines()
+
+    def blank(lines, n):
+        """A line that carries no code cannot change the binary, whichever
+        side of the diff it is on. Adding or removing the blank line above a
+        new test module is the common case."""
+        return 1 <= n <= len(lines) and not lines[n - 1].strip()
+
+    removed = [n for n in removed if not blank(base_lines, n)]
+    added = [n for n in added if not blank(head_lines, n)]
+    if not all(inside(n, base_ranges) for n in removed):
+        return False
+    if not all(inside(n, head_ranges) for n in added):
+        return False
+    # The `#[cfg(test)]` line is what DECIDES whether the module compiles, and
+    # it sits inside the span it opens, so a diff that only adds or removes it
+    # falls inside the span and would be waived. Both directions change the
+    # binary: adding the attribute takes a shipping module out, removing it
+    # puts a test module in. A touched attribute is therefore only test-only
+    # when its WHOLE module moved with it, which is what a test module added
+    # or deleted in one piece looks like.
+    return _whole_span_moved(base_ranges, removed) and _whole_span_moved(
+        head_ranges, added
+    )
+
+
+def _whole_span_moved(ranges, touched):
+    """True unless a span's attribute line was touched without the rest."""
+    marked = set(touched)
+    return all(
+        not (start in marked) or all(n in marked for n in range(start, end + 1))
+        for start, end in ranges
     )
 
 

--- a/scripts/ships_nothing.py
+++ b/scripts/ships_nothing.py
@@ -66,6 +66,34 @@ def git(*args, cwd=None, allow_missing_path=False):
     return done.stdout
 
 
+# A `/*` that opens mid-line. `BlockTracker` strips strings, chars and `//`
+# but not block comments, so a brace inside one is counted as structure and a
+# span can swallow the shipped code below it. Rare enough (no instance in
+# `src/` today) that refusing to answer is better than parsing it.
+MID_LINE_BLOCK_COMMENT = re.compile(r"\S.*/\*")
+
+
+def literal_lines(text):
+    """Line numbers (1-indexed) that sit INSIDE a multi-line string literal.
+
+    A blank line is only whitespace when it is code. Inside a raw string it is
+    content: croft's model prompt and its tree-sitter queries are multi-line
+    literals, and adding or removing a blank line there changes what the
+    binary does. `BlockTracker` already tracks the open-literal state for its
+    brace counting, so this reads it rather than re-deriving it.
+    """
+    lines = text.splitlines()
+    kinds = classify(lines)
+    tracker = BlockTracker()
+    inside = set()
+    for i, line in enumerate(lines):
+        if tracker.open_string is not None:
+            inside.add(i + 1)
+        if kinds[i] == CODE:
+            tracker.feed(line)
+    return inside
+
+
 def cfg_test_ranges(text):
     """Line spans (1-indexed, inclusive) of every `#[cfg(test)]` module.
 
@@ -77,6 +105,8 @@ def cfg_test_ranges(text):
     """
     lines = text.splitlines()
     kinds = classify(lines)
+    if any(kinds[i] == CODE and MID_LINE_BLOCK_COMMENT.search(l) for i, l in enumerate(lines)):
+        return []
     tracker = BlockTracker()
     ranges = []
     attr_at = None
@@ -112,7 +142,13 @@ def cfg_test_ranges(text):
 
 
 def changed_lines(base, head, path, cwd=None):
-    """(lines removed from base, lines added at head), 1-indexed."""
+    """(lines removed from base, lines added at head, the raw diff), 1-indexed.
+
+    The diff text comes back because "no hunk headers" has two causes: the
+    file did not change, and git did not describe the change. `git diff -U0`
+    on a file git treats as binary prints `Binary files ... differ` and no
+    `@@` line at all, and inferring "unchanged" from that waives a bump.
+    """
     diff = git("diff", "--no-renames", "-U0", base, head, "--", path, cwd=cwd)
     removed, added = [], []
     for line in diff.splitlines():
@@ -127,7 +163,7 @@ def changed_lines(base, head, path, cwd=None):
         )
         removed.extend(range(base_start, base_start + base_len))
         added.extend(range(head_start, head_start + head_len))
-    return removed, added
+    return removed, added, diff
 
 
 def inside(line_no, ranges):
@@ -145,7 +181,11 @@ def ships_nothing(base, head, path, cwd=None):
         return False
     base_text = git("show", f"{base}:{path}", cwd=cwd, allow_missing_path=True)
     head_text = git("show", f"{head}:{path}", cwd=cwd, allow_missing_path=True)
-    removed, added = changed_lines(base, head, path, cwd=cwd)
+    removed, added, diff = changed_lines(base, head, path, cwd=cwd)
+    if not removed and not added and diff.strip():
+        # git described a change it did not give hunk headers for - a file it
+        # treats as binary. Nothing here can read that, so it ships.
+        return False
     if not removed and not added:
         # An empty diff means "nothing changed" for a path that exists at both
         # ends, and "git could not resolve that pathspec" otherwise. Only the
@@ -157,14 +197,20 @@ def ships_nothing(base, head, path, cwd=None):
     base_lines = base_text.splitlines()
     head_lines = head_text.splitlines()
 
-    def blank(lines, n):
-        """A line that carries no code cannot change the binary, whichever
-        side of the diff it is on. Adding or removing the blank line above a
-        new test module is the common case."""
-        return 1 <= n <= len(lines) and not lines[n - 1].strip()
+    base_literals = literal_lines(base_text)
+    head_literals = literal_lines(head_text)
 
-    removed = [n for n in removed if not blank(base_lines, n)]
-    added = [n for n in added if not blank(head_lines, n)]
+    def blank(lines, n, literals):
+        """A line that carries no CODE cannot change the binary, whichever
+        side of the diff it is on: adding or removing the blank line above a
+        new test module is the common case. Inside a string literal it is not
+        whitespace at all but content, and croft has 42 such lines in `src/`
+        - the model's system prompt and the tree-sitter queries - where a
+        blank line changes what the binary does."""
+        return 1 <= n <= len(lines) and not lines[n - 1].strip() and n not in literals
+
+    removed = [n for n in removed if not blank(base_lines, n, base_literals)]
+    added = [n for n in added if not blank(head_lines, n, head_literals)]
     if not all(inside(n, base_ranges) for n in removed):
         return False
     if not all(inside(n, head_ranges) for n in added):
@@ -176,16 +222,25 @@ def ships_nothing(base, head, path, cwd=None):
     # puts a test module in. A touched attribute is therefore only test-only
     # when its WHOLE module moved with it, which is what a test module added
     # or deleted in one piece looks like.
-    return _whole_span_moved(base_ranges, removed) and _whole_span_moved(
-        head_ranges, added
+    return _whole_span_moved(base_ranges, removed, base_lines) and _whole_span_moved(
+        head_ranges, added, head_lines
     )
 
 
-def _whole_span_moved(ranges, touched):
-    """True unless a span's attribute line was touched without the rest."""
+def _whole_span_moved(ranges, touched, lines):
+    """True unless a span's attribute line was touched without the rest.
+
+    Blank lines inside the span are not required to have moved: they were
+    already dropped from `touched` above, and every one of the 159
+    `#[cfg(test)]` modules in `src/` contains at least one, so demanding them
+    made a whole module added or deleted in one piece - the case this
+    exemption exists for - unreachable for any module shaped like the ones
+    already here.
+    """
     marked = set(touched)
     return all(
-        not (start in marked) or all(n in marked for n in range(start, end + 1))
+        start not in marked
+        or all(n in marked for n in range(start, end + 1) if lines[n - 1].strip())
         for start, end in ranges
     )
 

--- a/scripts/ships_nothing.py
+++ b/scripts/ships_nothing.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Whether one file's change between two revisions ships nothing.
+
+The release gate exempts "docs / CI / test-only changes" and encodes that as a
+path list, so `src/app/tests.rs` and `tests/` are exempt while a change
+confined to a `#[cfg(test)] mod tests` inside a shipped file is not (#461).
+croft keeps most unit tests beside the code they cover, so that is the ordinary
+shape of a test-only fix here: the release binary is byte-identical, and the
+only way to satisfy the gate is to bump a version and write user-facing notes
+for a change the binary does not contain.
+
+The two ways to be wrong are not symmetric. Waiving a bump that was needed puts
+two different binaries on one version, which is the thing the gate exists to
+prevent; asking for a bump that was not needed costs a version number. So every
+uncertainty resolves to "ships": a module whose opening brace is not on the
+`mod` line, a `#[cfg(test)]` on anything other than a module, a file that is not
+Rust.
+
+Usage: ships_nothing.py <base> <head> <path>
+Exit 0 when the change ships nothing, 1 when it ships something.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_doc_ownership import ATTR, CODE, MISSING_PATH, SKIP, BlockTracker, classify  # noqa: E402
+
+# The attribute on its own line, which is what rustfmt produces and what every
+# test module in this repo has. `#[cfg(test)] mod tests {` on one line is legal
+# and is deliberately not matched: it is not a shape that occurs here, and
+# missing it only costs a version bump.
+CFG_TEST = re.compile(r"^\s*#\[cfg\(test\)\]\s*$")
+
+MOD = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?mod\s+[A-Za-z_]\w*")
+
+HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def git(*args, cwd=None):
+    """Run git, tolerating only "that path is not in that revision"."""
+    done = subprocess.run(
+        ("git",) + args, cwd=cwd, capture_output=True, text=True
+    )
+    if done.returncode != 0:
+        if MISSING_PATH.search(done.stderr):
+            return ""
+        raise SystemExit(f"git {' '.join(args)} failed: {done.stderr.strip()}")
+    return done.stdout
+
+
+def cfg_test_ranges(text):
+    """Line spans (1-indexed, inclusive) of every `#[cfg(test)]` module.
+
+    The span starts at the attribute rather than at the `mod` line, so a diff
+    that only edits the attribute itself still reads as test-only. Braces are
+    counted through `BlockTracker`, which removes string and char literals
+    first: a `format!("{}")` inside a test would otherwise close the module
+    early and leave the rest of the file looking like shipped code.
+    """
+    lines = text.splitlines()
+    kinds = classify(lines)
+    tracker = BlockTracker()
+    ranges = []
+    attr_at = None
+    open_at = None
+    for i, line in enumerate(lines):
+        depth_before = tracker.depth
+        if kinds[i] == CODE:
+            tracker.feed(line)
+        if open_at is not None:
+            start, outer = open_at
+            if tracker.depth <= outer:
+                ranges.append((start + 1, i + 1))
+                open_at = None
+            continue
+        if CFG_TEST.match(line):
+            attr_at = i
+            continue
+        if attr_at is None:
+            continue
+        if kinds[i] in (SKIP, ATTR):
+            # Blank lines, comments and further attributes sit legally
+            # between `#[cfg(test)]` and the module it applies to.
+            continue
+        if MOD.match(line) and tracker.depth > depth_before:
+            open_at = (attr_at, depth_before)
+        attr_at = None
+    # A module still open at EOF is a miscount or a truncated file. Reporting
+    # it as a range would exempt everything below the attribute.
+    return ranges
+
+
+def changed_lines(base, head, path, cwd=None):
+    """(lines removed from base, lines added at head), 1-indexed."""
+    diff = git("diff", "--no-renames", "-U0", base, head, "--", path, cwd=cwd)
+    removed, added = [], []
+    for line in diff.splitlines():
+        m = HUNK.match(line)
+        if not m:
+            continue
+        base_start, base_len, head_start, head_len = (
+            int(m.group(1)),
+            int(m.group(2) or 1),
+            int(m.group(3)),
+            int(m.group(4) or 1),
+        )
+        removed.extend(range(base_start, base_start + base_len))
+        added.extend(range(head_start, head_start + head_len))
+    return removed, added
+
+
+def inside(line_no, ranges):
+    return any(start <= line_no <= end for start, end in ranges)
+
+
+def ships_nothing(base, head, path, cwd=None):
+    """True when every line this change touches is inside a test module.
+
+    Both sides of the diff are read. A deletion leaves no line at the head to
+    inspect, so a head-only check would waive the removal of shipped code as
+    readily as the removal of a test.
+    """
+    if not path.endswith(".rs"):
+        return False
+    removed, added = changed_lines(base, head, path, cwd=cwd)
+    if not removed and not added:
+        return True
+    base_ranges = cfg_test_ranges(git("show", f"{base}:{path}", cwd=cwd))
+    head_ranges = cfg_test_ranges(git("show", f"{head}:{path}", cwd=cwd))
+    return all(inside(n, base_ranges) for n in removed) and all(
+        inside(n, head_ranges) for n in added
+    )
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: ships_nothing.py <base> <head> <path>")
+    base, head, path = sys.argv[1:4]
+    return 0 if ships_nothing(base, head, path) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_ships_nothing.py
+++ b/scripts/tests/test_ships_nothing.py
@@ -266,6 +266,90 @@ class Verdicts(unittest.TestCase):
             repo.commit("a.rs", SHIPPED.replace("width(4), 2", "width(6), 3"))
             self.assertFalse(repo.verdict(path="does_not_exist.rs"))
 
+    def test_a_blank_line_inside_a_string_literal_ships(self):
+        """A blank line is only whitespace when it is CODE. Inside a raw
+        string it is content: croft's model prompt and its tree-sitter
+        queries are multi-line literals, and a blank line added or removed
+        there changes what the binary does. There are 42 such lines in `src/`
+        today, so this is not hypothetical."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            before = 'pub const P: &str = r#"\ncroft\n\nv1\n"#;\n'
+            after = 'pub const P: &str = r#"\ncroft\nv1\n"#;\n'
+            repo.commit("a.rs", before)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", after)
+            self.assertFalse(repo.verdict(), "a blank line left a string literal")
+
+    def test_a_blank_line_added_to_a_string_literal_ships(self):
+        """The other direction, and the one that pins the removed-side half
+        of the blank filter: with only the added-side half tested, deleting
+        the removed-side line leaves the suite green."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            before = 'pub const P: &str = r#"\ncroft\nv1\n"#;\n'
+            after = 'pub const P: &str = r#"\ncroft\n\nv1\n"#;\n'
+            repo.commit("a.rs", before)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", after)
+            self.assertFalse(repo.verdict(), "a blank line joined a string literal")
+
+    def test_a_whole_test_module_in_its_real_shape_ships_nothing(self):
+        """Every one of the 159 `#[cfg(test)]` modules in `src/` has a blank
+        line in it. Stripping blank lines from the touched set before asking
+        whether the whole span moved made the exemption's main case
+        unreachable for every module shaped like the ones already here."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "pub fn f() -> u8 {\n    1\n}\n")
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit(
+                "a.rs",
+                "pub fn f() -> u8 {\n    1\n}\n\n#[cfg(test)]\nmod tests {\n"
+                "    use super::*;\n\n    #[test]\n    fn t() {\n"
+                "        assert_eq!(f(), 1);\n    }\n}\n",
+            )
+            self.assertTrue(repo.verdict(), "the module arrived in one piece")
+
+    def test_deleting_a_whole_test_module_in_its_real_shape_ships_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            whole = (
+                "pub fn f() -> u8 {\n    1\n}\n\n#[cfg(test)]\nmod tests {\n"
+                "    use super::*;\n\n    #[test]\n    fn t() {\n"
+                "        assert_eq!(f(), 1);\n    }\n}\n"
+            )
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", whole)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", "pub fn f() -> u8 {\n    1\n}\n")
+            self.assertTrue(repo.verdict(), "and the module leaving in one piece")
+
+    def test_a_diff_git_reports_as_binary_ships(self):
+        """`git diff -U0` on a file git calls binary prints no `@@` header at
+        all, so an inferred "nothing changed" is wrong in the waiving
+        direction."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            (Path(tmp) / "a.rs").write_bytes(b"pub fn f() -> u8 {\n    1\n}\n\x00\n")
+            run(repo.path, "git", "add", "-A")
+            run(repo.path, "git", "commit", "-q", "-m", "c")
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            (Path(tmp) / "a.rs").write_bytes(b"pub fn f() -> u8 {\n    9\n}\n\x00\n")
+            run(repo.path, "git", "add", "-A")
+            run(repo.path, "git", "commit", "-q", "-m", "c2")
+            self.assertFalse(repo.verdict())
+
+    def test_a_mid_line_block_comment_yields_no_ranges(self):
+        """The brace tracker strips strings and `//`, not `/* */`, so a brace
+        inside a block comment is counted as structure and the span can
+        swallow shipped code below it. No range at all is the safe answer."""
+        text = (
+            "#[cfg(test)]\nmod tests {\n    fn t() {\n        let _x = 0; /* { */\n"
+            "    }\n}\n\npub fn g() -> u8 {\n    let _ = 0; /* } */\n    1\n}\n"
+        )
+        self.assertEqual(filt.cfg_test_ranges(text), [])
+
     def test_the_cli_reports_the_verdict_as_its_exit_status(self):
         """The gate is shell, so the answer has to arrive as a status."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_ships_nothing.py
+++ b/scripts/tests/test_ships_nothing.py
@@ -1,0 +1,214 @@
+"""Tests for scripts/ships_nothing.py: the release gate's test-only filter.
+
+The `version bump + release notes` job says in its own comment that
+"test-only changes ship nothing and are exempt", and then encodes test-only
+as a path list. croft keeps most unit tests in a `#[cfg(test)] mod tests`
+beside the code they cover, so the ordinary shape of a test-only fix here is
+a diff inside a shipped file (#461).
+
+The direction of failure matters more than the coverage: waiving a bump that
+was needed puts two different binaries on one version, while asking for a
+bump that was not needed only costs a version number. Anything the parse is
+unsure about therefore counts as shipped, and the tests below pin that as
+much as they pin the exemption.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import ships_nothing as filt  # noqa: E402
+
+
+SHIPPED = '''pub fn width(cols: u16) -> u16 {
+    cols / 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn halves() {
+        assert_eq!(width(4), 2);
+    }
+}
+'''
+
+
+def run(cwd, *args):
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True).stdout
+
+
+class Repo:
+    """A throwaway repo with one shipped file and a branch off main."""
+
+    def __init__(self, tmp: Path):
+        self.path = tmp
+        run(tmp, "git", "init", "-q", "-b", "main")
+        run(tmp, "git", "config", "user.email", "t@example.com")
+        run(tmp, "git", "config", "user.name", "t")
+
+    def commit(self, name: str, text: str):
+        (self.path / name).write_text(text)
+        run(self.path, "git", "add", "-A")
+        run(self.path, "git", "commit", "-q", "-m", "c")
+
+    def verdict(self, path="a.rs", base="main", head="HEAD"):
+        return filt.ships_nothing(base, head, path, cwd=self.path)
+
+
+class Ranges(unittest.TestCase):
+    def test_a_cfg_test_module_is_found(self):
+        self.assertEqual(filt.cfg_test_ranges(SHIPPED), [(5, 13)])
+
+    def test_a_brace_in_a_string_does_not_end_the_block_early(self):
+        """The block tracker has to read Rust, not count characters: a
+        `format!("{}")` inside a test would otherwise close the module and
+        leave every line after it looking like shipped code."""
+        text = (
+            "fn f() {}\n"
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            '    const S: &str = "}";\n'
+            "    fn g() {}\n"
+            "}\n"
+        )
+        self.assertEqual(filt.cfg_test_ranges(text), [(2, 6)])
+
+    def test_a_cfg_test_item_that_is_not_a_module_is_not_a_range(self):
+        """Deliberately narrow. `#[cfg(test)]` on a free function compiles
+        out too, but reading its extent is a second parser, and the cost of
+        being wrong here is a waived bump."""
+        text = "fn f() {}\n#[cfg(test)]\nfn helper() -> u8 {\n    1\n}\n"
+        self.assertEqual(filt.cfg_test_ranges(text), [])
+
+    def test_a_file_with_no_tests_has_no_ranges(self):
+        self.assertEqual(filt.cfg_test_ranges("fn f() {}\n"), [])
+
+
+class Verdicts(unittest.TestCase):
+    def test_a_change_inside_the_test_module_ships_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", SHIPPED)
+            repo.commit("b.rs", "fn b() {}\n")
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", SHIPPED.replace("width(4), 2", "width(6), 3"))
+            self.assertTrue(repo.verdict())
+
+    def test_a_change_outside_the_test_module_ships(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", SHIPPED)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", SHIPPED.replace("cols / 2", "cols / 3"))
+            self.assertFalse(repo.verdict())
+
+    def test_a_change_to_both_ships(self):
+        """The one that must not be read as test-only because most of it is."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", SHIPPED)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit(
+                "a.rs",
+                SHIPPED.replace("cols / 2", "cols / 3").replace("width(4), 2", "width(6), 2"),
+            )
+            self.assertFalse(repo.verdict())
+
+    def test_deleting_a_test_ships_nothing(self):
+        """A removal has no line at the head to inspect, so the base side of
+        the diff has to be read as well. Checking only the head would waive
+        a deletion of shipped code just as readily."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", SHIPPED)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", SHIPPED.replace("        assert_eq!(width(4), 2);\n", ""))
+            self.assertTrue(repo.verdict())
+
+    def test_deleting_shipped_code_ships(self):
+        """The other half of reading the base side, and the half that has to
+        be a PURE deletion: an edited line leaves a replacement at the head
+        that a head-only check would catch anyway, so it proves nothing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            deleted = "pub fn legacy() -> u16 {\n    1\n}\n\n"
+            repo.commit("a.rs", deleted + SHIPPED)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", SHIPPED)
+            self.assertFalse(repo.verdict())
+
+    def test_a_test_module_that_grows_ships_nothing(self):
+        """Added lines land at the head, and the range they have to fall in
+        is the one at the head, not the one at the base."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", SHIPPED)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit(
+                "a.rs",
+                SHIPPED.replace(
+                    "    #[test]\n",
+                    "    #[test]\n    fn also() {\n        assert_eq!(width(2), 1);\n    }\n\n    #[test]\n",
+                    1,
+                ),
+            )
+            self.assertTrue(repo.verdict())
+
+    def test_a_file_that_is_not_rust_ships(self):
+        """A baked-in asset can quote Rust - a doc page with a fenced test
+        module is the ordinary case - and a Rust parse turned loose on it
+        would waive an edit to shipped content because the surrounding prose
+        happens to look like a test module."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            page = (
+                "Testing conventions\n\n```rust\n#[cfg(test)]\nmod tests {\n"
+                "    #[test]\n    fn shown_to_the_reader() {}\n}\n```\n"
+            )
+            repo.commit("a.rs", SHIPPED)
+            repo.commit("guide.md", page)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("guide.md", page.replace("shown_to_the_reader", "renamed"))
+            self.assertFalse(repo.verdict(path="guide.md"))
+
+    def test_an_added_file_that_is_only_tests_ships_nothing(self):
+        """No base version at all, so every line is an addition and the head
+        ranges decide it on their own."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", SHIPPED)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit(
+                "c.rs",
+                "#[cfg(test)]\nmod tests {\n    #[test]\n    fn t() {}\n}\n",
+            )
+            self.assertTrue(repo.verdict(path="c.rs"))
+
+    def test_the_cli_reports_the_verdict_as_its_exit_status(self):
+        """The gate is shell, so the answer has to arrive as a status."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", SHIPPED)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", SHIPPED.replace("width(4), 2", "width(6), 3"))
+            script = str(Path(__file__).resolve().parents[1] / "ships_nothing.py")
+            done = subprocess.run(
+                [sys.executable, script, "main", "HEAD", "a.rs"],
+                cwd=repo.path,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(done.returncode, 0, done.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_ships_nothing.py
+++ b/scripts/tests/test_ships_nothing.py
@@ -193,6 +193,79 @@ class Verdicts(unittest.TestCase):
             )
             self.assertTrue(repo.verdict(path="c.rs"))
 
+    def test_adding_the_cfg_test_attribute_to_a_shipped_module_ships(self):
+        """The line that decides what compiles. Adding `#[cfg(test)]` above a
+        module that ships today REMOVES it from the binary, and the diff is a
+        single added line which falls inside the span the attribute opens - so
+        a span that swallows its own attribute waives the one change the job
+        exists to catch."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            shipped = "pub fn f() -> u8 {\n    1\n}\n\nmod helpers {\n    pub fn g() -> u8 {\n        2\n    }\n}\n"
+            repo.commit("a.rs", shipped)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", shipped.replace("\nmod helpers {", "\n#[cfg(test)]\nmod helpers {"))
+            self.assertFalse(repo.verdict())
+
+    def test_removing_the_cfg_test_attribute_ships(self):
+        """The same line, the other way: the module and everything in it
+        ENTERS the binary."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            gated = "pub fn f() -> u8 {\n    1\n}\n\n#[cfg(test)]\nmod helpers {\n    pub fn g() -> u8 {\n        2\n    }\n}\n"
+            repo.commit("a.rs", gated)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", gated.replace("#[cfg(test)]\n", ""))
+            self.assertFalse(repo.verdict())
+
+    def test_a_whole_test_module_added_at_once_still_ships_nothing(self):
+        """The control for the two above, and the PR's main use case: when
+        the WHOLE module arrives in one diff, every line of the span is new
+        and nothing leaves or enters the binary."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "pub fn f() -> u8 {\n    1\n}\n")
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit(
+                "a.rs",
+                "pub fn f() -> u8 {\n    1\n}\n\n#[cfg(test)]\nmod tests {\n"
+                "    #[test]\n    fn t() {\n        assert_eq!(super::f(), 1);\n    }\n}\n",
+            )
+            self.assertTrue(repo.verdict())
+
+    def test_a_module_left_open_at_end_of_file_is_not_a_range(self):
+        """A truncated file or a miscount. Treating the rest of the file as
+        test code would exempt everything below the attribute."""
+        text = "fn f() {}\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn t() {}\n"
+        self.assertEqual(filt.cfg_test_ranges(text), [])
+
+    def test_a_module_declaration_without_a_body_is_not_a_range(self):
+        """`mod tests;` puts the body in another file and opens no braces, so
+        the span would run to the end of THIS file and cover shipped code."""
+        text = "#[cfg(test)]\nmod tests;\npub fn shipped() -> u8 {\n    1\n}\n"
+        self.assertEqual(filt.cfg_test_ranges(text), [])
+
+    def test_a_doc_comment_between_the_attribute_and_its_module_is_read(self):
+        """`classify` labels `///` as DOC, not SKIP, and a documented test
+        module is an ordinary shape. Missing it loses the exemption rather
+        than waiving wrongly, but it loses it silently."""
+        text = (
+            "fn f() {}\n#[cfg(test)]\n/// Unit tests for the parser.\n"
+            "mod tests {\n    #[test]\n    fn t() {}\n}\n"
+        )
+        self.assertEqual(filt.cfg_test_ranges(text), [(2, 7)])
+
+    def test_a_path_the_pathspec_cannot_resolve_ships(self):
+        """An empty diff means "nothing changed" for a path that exists at
+        both ends, and "I could not read that" otherwise. Only the first is a
+        reason to waive a bump."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", SHIPPED)
+            run(repo.path, "git", "checkout", "-q", "-b", "work")
+            repo.commit("a.rs", SHIPPED.replace("width(4), 2", "width(6), 3"))
+            self.assertFalse(repo.verdict(path="does_not_exist.rs"))
+
     def test_the_cli_reports_the_verdict_as_its_exit_status(self):
         """The gate is shell, so the answer has to arrive as a status."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -208,6 +281,17 @@ class Verdicts(unittest.TestCase):
                 text=True,
             )
             self.assertEqual(done.returncode, 0, done.stderr)
+            # And the direction that matters, in the same test: a CLI that
+            # always exits 0 waives every bump, and the assertion above alone
+            # cannot tell that apart from a working filter.
+            repo.commit("a.rs", SHIPPED.replace("cols / 2", "cols / 3"))
+            ships = subprocess.run(
+                [sys.executable, script, "main", "HEAD", "a.rs"],
+                cwd=repo.path,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(ships.returncode, 1, ships.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #461.

The `version bump + release notes` job says in its own comment that test-only
changes ship nothing and are exempt, and encodes that as a path list. A whole
test file (`src/app/tests.rs`, `tests/`) is therefore exempt, while a diff
inside a `#[cfg(test)] mod tests` in a shipped file is not. croft keeps most
unit tests beside the code they cover, so that is the ordinary shape of a
test-only fix here: the release binary is byte-identical, and the only way past
the gate is to bump a version and write user-facing release notes for a change
the binary does not contain.

`scripts/ships_nothing.py` answers, per file, whether every line the diff
touches lies inside a `#[cfg(test)]` module. The shipped list is filtered
through it before the version and notes are checked at all.

## The failure direction is deliberate

Waiving a bump that was needed puts two different binaries on one version,
which is the thing this job exists to prevent. Asking for a bump that was not
needed costs a version number. So every uncertainty resolves to "ships":

* a file that is not `.rs`;
* `#[cfg(test)]` on anything other than a module;
* a module whose opening brace is not on the `mod` line;
* a module still open at end of file.

Both sides of the diff are read, because a deletion leaves no line at the head
to inspect and a head-only check would waive the removal of shipped code as
readily as the removal of a test. Braces are counted through the doc gate's
literal-aware tracker, so a `format!("{}")` inside a test cannot close the
module early and leave the rest of the file looking like test code.

## Proved on the PR that is stuck on it

#459 changes one assertion inside `mod tests` in `src/markdown.rs` and nothing
else. Running the job's logic against that branch, with and without the filter:

```
$ gate_sim <merge-base> origin/fix/substring-or-assertion   # with the filter
src/markdown.rs: change confined to #[cfg(test)]; ships nothing.
No shipped files changed; no release required.
exit=0

$ gate_sim <merge-base> origin/fix/substring-or-assertion   # today's logic
Shipped files changed:
  src/markdown.rs
ERROR: version still 0.1.857
ERROR: no src/release_notes/0.1.857.md
exit=1
```

And the control that matters more, since a filter that waives everything would
also turn the first run green. The same branch with one non-test line added to
`src/markdown.rs`, filter available:

```
Shipped files changed:
  src/markdown.rs
ERROR: version still 0.1.857
exit=1
```

## Tests

13 tests in `scripts/tests/test_ships_nothing.py`, run by the existing
`python3 -m unittest discover -s scripts/tests` step. Four of them pin the
conservative direction rather than the exemption, and each was proved
load-bearing by removing the guard it covers and watching that test, and only
that test, fail:

| guard removed | test that failed |
| --- | --- |
| reading the base side of the diff | `test_deleting_shipped_code_ships` |
| the non-Rust file check | `test_a_file_that_is_not_rust_ships` |
| literal-aware brace counting | `test_a_brace_in_a_string_does_not_end_the_block_early` |
| requiring a `mod` after the attribute | `test_a_cfg_test_item_that_is_not_a_module_is_not_a_range` |

The deletion test had to be a pure deletion: an edited line leaves a
replacement at the head that a head-only check catches anyway, and the first
version of that test passed under the mutation for exactly that reason.

CI only: `scripts/`, `.github/` and `CONTRIBUTING.md` ship nothing, so there is
no version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Test-only Rust changes are now recognized as not affecting the shipped binary.
  * Release version and notes requirements are automatically waived for qualifying test-only changes.
  * Changes that cannot be confidently classified continue to be treated as shipped.
  * File handling in release checks is more reliable for paths containing spaces or special characters.
* **Tests**
  * Added comprehensive coverage for test-only detection, ambiguous changes, binary files, additions, deletions, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->