### PR TITLE
test(terminal): give the quick-select pane rows, and scale the restore wait (#397)

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -24460,17 +24460,20 @@ fn undo_close_restores_a_closed_terminal_pane_with_its_process_alive() {
     assert_eq!(app.terminals[1].label(), "keepme");
     assert_eq!(app.active_terminal, 1, "the restored pane takes focus");
     app.terminals[1].write_input(b"back\n");
-    let mut waited = 0u32;
-    while !app.terminals[1]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("revived-back"))
-    {
-        assert!(waited < 8000, "restored pane's shell no longer answers");
-        std::thread::sleep(std::time::Duration::from_millis(40));
-        waited += 40;
-    }
+    // The same operation and the same old constant as the restore wait in the
+    // next test: a shell echoing one line, waited on under whatever load the
+    // suite is running.
+    crate::test_budget::await_spawned(
+        std::time::Duration::from_secs(1),
+        "the reopened pane's shell to answer",
+        || {
+            app.terminals[1]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("revived-back"))
+        },
+    );
 
     // Past the grace window the parked pane is dropped for real: the tick
     // reaps it and undo has nothing left to restore.
@@ -24790,11 +24793,17 @@ fn terminal_session_restores_pane_layout_names_and_focus_across_restarts() {
     // Load-scaled, not a fixed 8000ms: what blows a wait on a spawned shell
     // is contention, which is a property of what else the suite is doing
     // rather than of this test, and `test_budget` is where that reasoning
-    // already lives (#307/#422). The old constant is this call's `base`
-    // divided by the calibration, so a quiet machine waits what it waited
-    // before and a loaded one waits longer instead of failing (#397).
+    // already lives (#307/#422).
+    //
+    // The base is what the operation costs on a QUIET machine, which for a
+    // shell echoing one line is about a second. `await_spawned` multiplies it
+    // by `BASE_CALIBRATION * load_scale`, which that module's own test pins at
+    // 4 on a quiet machine and 8 at the cap, so 1s here is 4s quiet and 8s
+    // loaded: the 8000ms this replaces, kept as the CEILING rather than as the
+    // floor. An earlier version of this comment said the base was the old
+    // constant divided by the calibration, which is neither of those numbers.
     crate::test_budget::await_spawned(
-        std::time::Duration::from_secs(4),
+        std::time::Duration::from_secs(1),
         "the restored pane's shell to answer",
         || {
             app2.terminals[1]
@@ -30340,17 +30349,29 @@ fn quick_select_labels_follow_content_that_streams_below_them() {
     app.focus_pane(Pane::Terminal);
     let backend = ratatui::backend::TestBackend::new(80, 24);
     let mut term = ratatui::Terminal::new(backend).unwrap();
-    // The panel over the editor, so the pane has ROWS. Unmaximized it is five
-    // rows tall here, and this test parks its URL four rows from the bottom:
-    // one row of slack against a prompt that is written by a real shell and
-    // wraps to three or four rows on a machine with a long hostname and path.
-    // That is the whole of this test's entry in #397 - measured at 3 failures
-    // in 20 runs under load, and the URL scrolling off the top is what the
-    // failure prints. Maximizing leaves sixteen rows of slack instead of one.
+    // The panel over the editor, so the pane has ROWS. Unmaximized it is a
+    // few rows tall here, and this test parks its URL four rows from the
+    // bottom: almost no slack against a prompt that a real shell writes and
+    // that wraps to several rows on a machine with a long hostname and path.
+    // That is this test's entry in #397, measured at 3 failures in 20 runs
+    // under load, with the URL scrolling off the top in the failure. The
+    // measured numbers are in the PR; the literals are not repeated here,
+    // since they are one configuration's and the code derives its own below.
+    //
+    // The maximize also resizes the PTY, so the pane's shell takes a SIGWINCH
+    // and may repaint its prompt. That lands before the newline flood parks
+    // the cursor, and the slack this exists to create absorbs a late one.
     app.toggle_terminal_maximize();
     term.draw(|f| app.render(f)).unwrap();
     // Park the cursor at the pane bottom so every further row SCROLLS.
     let h = app.terminals[0].last_inner.height as usize;
+    // The precondition this fix IS, checked in the same run as the claim it
+    // supports: if a future panel change shrank the pane back toward five
+    // rows, the test would quietly return to flaking instead of failing.
+    assert!(
+        h >= 12,
+        "the maximized panel must leave slack for the shell's wrapped prompt; got {h} rows"
+    );
     app.terminals[0].feed_bytes_for_test("\r\n".repeat(h * 2).as_bytes());
     // One atomic feed, opening with its own newline: the live child
     // shell's prompt can flush between feed calls under suite load (#62),
@@ -30360,7 +30381,10 @@ fn quick_select_labels_follow_content_that_streams_below_them() {
     // this chunk (its row is above) or after it (it appends to the right).
     app.terminals[0].feed_bytes_for_test(b"\r\nhttp://drift.io");
     app.open_terminal_quick_select();
-    assert!(app.terminal_quick_select.is_some(), "staging: one hint");
+    assert!(
+        app.terminal_quick_select.is_some(),
+        "staging: at least the URL is hinted"
+    );
     app.terminals[0].feed_bytes_for_test(b"\r\nx1\r\nx2\r\nx3");
     term.draw(|f| app.render(f)).unwrap();
     let buf = term.backend().buffer().clone();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -24787,17 +24787,23 @@ fn terminal_session_restores_pane_layout_names_and_focus_across_restarts() {
     );
     // The restored pane runs a live shell.
     app2.terminals[1].write_input(b"s=ali; echo ${s}ve-42\n");
-    let mut waited = 0u32;
-    while !app2.terminals[1]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("alive-42"))
-    {
-        assert!(waited < 8000, "restored pane's shell is not alive");
-        std::thread::sleep(std::time::Duration::from_millis(60));
-        waited += 60;
-    }
+    // Load-scaled, not a fixed 8000ms: what blows a wait on a spawned shell
+    // is contention, which is a property of what else the suite is doing
+    // rather than of this test, and `test_budget` is where that reasoning
+    // already lives (#307/#422). The old constant is this call's `base`
+    // divided by the calibration, so a quiet machine waits what it waited
+    // before and a loaded one waits longer instead of failing (#397).
+    crate::test_budget::await_spawned(
+        std::time::Duration::from_secs(4),
+        "the restored pane's shell to answer",
+        || {
+            app2.terminals[1]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("alive-42"))
+        },
+    );
 
     // Closing back down to one default pane prunes the record, so a plain
     // single-shell workspace never grows the file.
@@ -30334,6 +30340,14 @@ fn quick_select_labels_follow_content_that_streams_below_them() {
     app.focus_pane(Pane::Terminal);
     let backend = ratatui::backend::TestBackend::new(80, 24);
     let mut term = ratatui::Terminal::new(backend).unwrap();
+    // The panel over the editor, so the pane has ROWS. Unmaximized it is five
+    // rows tall here, and this test parks its URL four rows from the bottom:
+    // one row of slack against a prompt that is written by a real shell and
+    // wraps to three or four rows on a machine with a long hostname and path.
+    // That is the whole of this test's entry in #397 - measured at 3 failures
+    // in 20 runs under load, and the URL scrolling off the top is what the
+    // failure prints. Maximizing leaves sixteen rows of slack instead of one.
+    app.toggle_terminal_maximize();
     term.draw(|f| app.render(f)).unwrap();
     // Park the cursor at the pane bottom so every further row SCROLLS.
     let h = app.terminals[0].last_inner.height as usize;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -24460,11 +24460,12 @@ fn undo_close_restores_a_closed_terminal_pane_with_its_process_alive() {
     assert_eq!(app.terminals[1].label(), "keepme");
     assert_eq!(app.active_terminal, 1, "the restored pane takes focus");
     app.terminals[1].write_input(b"back\n");
-    // The same operation and the same old constant as the restore wait in the
-    // next test: a shell echoing one line, waited on under whatever load the
-    // suite is running.
+    // The same operation and the same old constant as the wait in
+    // `terminal_session_restores_pane_layout_names_and_focus_across_restarts`:
+    // a shell echoing one line, waited on under whatever load the suite is
+    // running. Same 2s base, so the same 8s floor.
     crate::test_budget::await_spawned(
-        std::time::Duration::from_secs(1),
+        std::time::Duration::from_secs(2),
         "the reopened pane's shell to answer",
         || {
             app.terminals[1]
@@ -24795,15 +24796,15 @@ fn terminal_session_restores_pane_layout_names_and_focus_across_restarts() {
     // rather than of this test, and `test_budget` is where that reasoning
     // already lives (#307/#422).
     //
-    // The base is what the operation costs on a QUIET machine, which for a
-    // shell echoing one line is about a second. `await_spawned` multiplies it
-    // by `BASE_CALIBRATION * load_scale`, which that module's own test pins at
-    // 4 on a quiet machine and 8 at the cap, so 1s here is 4s quiet and 8s
-    // loaded: the 8000ms this replaces, kept as the CEILING rather than as the
-    // floor. An earlier version of this comment said the base was the old
-    // constant divided by the calibration, which is neither of those numbers.
+    // `await_spawned` multiplies the base by `BASE_CALIBRATION * load_scale`,
+    // which that module's own test pins at 4 at MIN_SCALE and 8 at the cap.
+    // A 2s base is therefore 8s at the floor and 16s at the cap: the 8000ms
+    // this replaces is what the wait KEEPS on a quiet machine, and load buys
+    // more on top. The floor is the point - `MIN_SCALE`'s own doc says it may
+    // never shrink below the budgets these tests already had, since every one
+    // of them was observed failing at 1x.
     crate::test_budget::await_spawned(
-        std::time::Duration::from_secs(1),
+        std::time::Duration::from_secs(2),
         "the restored pane's shell to answer",
         || {
             app2.terminals[1]
@@ -30338,6 +30339,52 @@ fn shift_end_reaches_an_alt_screen_program() {
     );
 }
 
+#[test]
+fn a_wrapped_prompt_does_not_push_the_url_off_a_maximized_pane() {
+    // The deterministic half of #397's quick-select entry. Its sibling below
+    // was measured at 3 failures in 20 runs under load, because a REAL
+    // shell's prompt wraps to several rows and the pane had one row of slack;
+    // a rate is the best evidence a race allows, and it is not a test.
+    //
+    // This one feeds the prompt itself, so the geometry is the whole claim
+    // and the machine has no say. Four rows of it, then the same park,
+    // stream and assert. On the unmaximized pane, which is five rows here,
+    // this fails on every machine on every run.
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.focus_pane(Pane::Terminal);
+    let mut term = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+    app.toggle_terminal_maximize();
+    term.draw(|f| app.render(f)).unwrap();
+    let inner = app.terminals[0].last_inner;
+    let h = inner.height as usize;
+
+    app.terminals[0].feed_bytes_for_test("\r\n".repeat(h * 2).as_bytes());
+    app.terminals[0].feed_bytes_for_test(b"\r\nhttp://drift.io");
+    app.open_terminal_quick_select();
+    // The prompt arrives AFTER the URL is on screen, which is the race: one
+    // that lands before the flood is scrolled away by it and costs nothing.
+    // Four rows of it, the shape a hostname-and-path prompt takes when it
+    // wraps at this width, and then the stream that scrolls the URL.
+    app.terminals[0]
+        .feed_bytes_for_test(format!("\r\n{}", "p".repeat(inner.width as usize * 4)).as_bytes());
+    app.terminals[0].feed_bytes_for_test(b"\r\nx1\r\nx2\r\nx3");
+    term.draw(|f| app.render(f)).unwrap();
+
+    let buf = term.backend().buffer().clone();
+    let joined: String = (inner.y..inner.y + inner.height)
+        .flat_map(|y| {
+            (inner.x..inner.x + inner.width)
+                .map(move |x| (x, y))
+                .map(|(x, y)| buf[(x, y)].symbol().chars().next().unwrap_or(' '))
+        })
+        .collect();
+    assert!(
+        joined.contains("ttp://drift.io"),
+        "a four-row prompt must not cost the URL its place on screen: {joined:?}"
+    );
+}
+
 /// Quick-select labels ride the scroll clock like every other overlay:
 /// output streaming under an open label set used to leave the gold labels
 /// at fixed viewport rows while their matches scrolled away, so the user
@@ -30369,7 +30416,7 @@ fn quick_select_labels_follow_content_that_streams_below_them() {
     // supports: if a future panel change shrank the pane back toward five
     // rows, the test would quietly return to flaking instead of failing.
     assert!(
-        h >= 12,
+        h >= 16,
         "the maximized panel must leave slack for the shell's wrapped prompt; got {h} rows"
     );
     app.terminals[0].feed_bytes_for_test("\r\n".repeat(h * 2).as_bytes());
@@ -30381,9 +30428,15 @@ fn quick_select_labels_follow_content_that_streams_below_them() {
     // this chunk (its row is above) or after it (it appends to the right).
     app.terminals[0].feed_bytes_for_test(b"\r\nhttp://drift.io");
     app.open_terminal_quick_select();
+    // The URL by name, not `is_some()`. Quick select stages every match on
+    // screen and the live shell's prompt path is one, so `is_some()` cannot
+    // tell "the URL is hinted" from "only the prompt is", and maximizing the
+    // pane put more prompt text on screen rather than less.
     assert!(
-        app.terminal_quick_select.is_some(),
-        "staging: at least the URL is hinted"
+        app.terminal_quick_select
+            .as_ref()
+            .is_some_and(|s| s.hints.iter().any(|h| h.text.contains("drift.io"))),
+        "staging: the URL is hinted"
     );
     app.terminals[0].feed_bytes_for_test(b"\r\nx1\r\nx2\r\nx3");
     term.draw(|f| app.render(f)).unwrap();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -24465,7 +24465,7 @@ fn undo_close_restores_a_closed_terminal_pane_with_its_process_alive() {
     // a shell echoing one line, waited on under whatever load the suite is
     // running. Same 2s base, so the same 8s floor.
     crate::test_budget::await_spawned(
-        std::time::Duration::from_secs(2),
+        crate::test_budget::RESTORED_SHELL_BASE,
         "the reopened pane's shell to answer",
         || {
             app.terminals[1]
@@ -24804,7 +24804,7 @@ fn terminal_session_restores_pane_layout_names_and_focus_across_restarts() {
     // never shrink below the budgets these tests already had, since every one
     // of them was observed failing at 1x.
     crate::test_budget::await_spawned(
-        std::time::Duration::from_secs(2),
+        crate::test_budget::RESTORED_SHELL_BASE,
         "the restored pane's shell to answer",
         || {
             app2.terminals[1]
@@ -30358,6 +30358,14 @@ fn a_wrapped_prompt_does_not_push_the_url_off_a_maximized_pane() {
     term.draw(|f| app.render(f)).unwrap();
     let inner = app.terminals[0].last_inner;
     let h = inner.height as usize;
+    // The same tripwire the sibling carries. This fixture's own band is
+    // wider - it needs eight rows, not sixteen - but a panel that shrank
+    // below the sibling's threshold should fail in both, not silently pass
+    // here while failing there.
+    assert!(
+        h >= 16,
+        "the maximized panel must leave slack for the wrapped prompt; got {h} rows"
+    );
 
     app.terminals[0].feed_bytes_for_test("\r\n".repeat(h * 2).as_bytes());
     app.terminals[0].feed_bytes_for_test(b"\r\nhttp://drift.io");
@@ -30379,9 +30387,13 @@ fn a_wrapped_prompt_does_not_push_the_url_off_a_maximized_pane() {
                 .map(|(x, y)| buf[(x, y)].symbol().chars().next().unwrap_or(' '))
         })
         .collect();
+    // The label clause is what makes `open_terminal_quick_select` above
+    // load-bearing: without it the bare URL satisfies this assertion just as
+    // well as a labelled one, and deleting the call left the test green.
     assert!(
-        joined.contains("ttp://drift.io"),
-        "a four-row prompt must not cost the URL its place on screen: {joined:?}"
+        joined.contains("ttp://drift.io") && !joined.contains("http://drift.io"),
+        "a four-row prompt must not cost the URL its place on screen, and a \
+         label must still cover its first cell: {joined:?}"
     );
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -24465,7 +24465,7 @@ fn undo_close_restores_a_closed_terminal_pane_with_its_process_alive() {
     // a shell echoing one line, waited on under whatever load the suite is
     // running. Same 2s base, so the same 8s floor.
     crate::test_budget::await_spawned(
-        crate::test_budget::RESTORED_SHELL_BASE,
+        crate::test_budget::tests::RESTORED_SHELL_BASE,
         "the reopened pane's shell to answer",
         || {
             app.terminals[1]
@@ -24804,7 +24804,7 @@ fn terminal_session_restores_pane_layout_names_and_focus_across_restarts() {
     // never shrink below the budgets these tests already had, since every one
     // of them was observed failing at 1x.
     crate::test_budget::await_spawned(
-        crate::test_budget::RESTORED_SHELL_BASE,
+        crate::test_budget::tests::RESTORED_SHELL_BASE,
         "the restored pane's shell to answer",
         || {
             app2.terminals[1]

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -328,22 +328,6 @@ mod tests {
     /// to be told their change broke something, which is the cost
     /// `MAX_SCALE` exists to bound.
     #[test]
-    /// A conversion must not be a cut. #397 replaced two `waited < 8000`
-    /// loops with `await_spawned`, and the base that does that honestly is
-    /// the one whose FLOOR is the constant it replaced: `MIN_SCALE`'s own
-    /// doc says a budget may never shrink below what these tests already
-    /// had, since every one of them was observed failing at 1x. A 1s base
-    /// would have given them 4s on a quiet machine, which is half.
-    #[test]
-    fn a_converted_wait_keeps_the_budget_it_replaced() {
-        let floor = Duration::from_secs(2) * BASE_CALIBRATION * MIN_SCALE;
-        assert!(
-            floor >= Duration::from_millis(8000),
-            "a 2s base must reproduce the 8000ms it replaced at the floor, got {floor:?}"
-        );
-    }
-
-    #[test]
     fn the_worst_case_stretch_is_unchanged() {
         assert_eq!(
             BASE_CALIBRATION * MAX_SCALE,
@@ -362,6 +346,21 @@ mod tests {
         assert!(
             spawn_budget(base) <= base * 8,
             "no budget may exceed the 8x ceiling, however it is composed"
+        );
+    }
+
+    /// A conversion must not be a cut. #397 replaced two `waited < 8000`
+    /// loops with `await_spawned`, and the base that does that honestly is
+    /// the one whose FLOOR is the constant it replaced: `MIN_SCALE`'s own
+    /// doc says a budget may never shrink below what these tests already
+    /// had, since every one of them was observed failing at 1x. A 1s base
+    /// would have given them 4s on a quiet machine, which is half.
+    #[test]
+    fn a_converted_wait_keeps_the_budget_it_replaced() {
+        let floor = Duration::from_secs(2) * BASE_CALIBRATION * MIN_SCALE;
+        assert!(
+            floor >= Duration::from_millis(8000),
+            "a 2s base must reproduce the 8000ms it replaced at the floor, got {floor:?}"
         );
     }
 

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -56,22 +56,6 @@ const MIN_SCALE: u32 = 2;
 /// to know about.
 const BASE_CALIBRATION: u32 = 2;
 
-/// The base the two restored-shell waits use (#397).
-///
-/// Shared rather than retyped at each call site, because the test that pins
-/// it has to be about THEM: an assertion over a literal written beside it
-/// stays green when a call site changes, which is the regression it exists
-/// to catch.
-///
-/// 2s because `await_spawned` multiplies by `BASE_CALIBRATION * load_scale`,
-/// which is 4 at the floor: these two replaced a fixed 8000ms, and this
-/// keeps that as what they still get on a quiet machine. Deliberately NOT a
-/// repo-wide rule - `a_terminal_link_binding_is_not_refused_for_an_editor_side_reason`
-/// converts an 8s constant with a 1s base, and reconciling the two is a
-/// question about that test's operation rather than about these.
-#[cfg(test)]
-pub(crate) const RESTORED_SHELL_BASE: Duration = Duration::from_secs(2);
-
 /// One-minute load average, where the platform reports one.
 fn load_average() -> Option<f64> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -252,8 +236,29 @@ pub fn await_spawned(base: Duration, what: &str, mut ready: impl FnMut() -> bool
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
+
+    /// The base the two restored-shell waits use (#397).
+    ///
+    /// Shared rather than retyped at each call site, because the test that
+    /// pins it has to be about THEM: an assertion over a literal written
+    /// beside it stays green when a call site changes, which is the
+    /// regression it exists to catch.
+    ///
+    /// 2s because `await_spawned` multiplies by
+    /// `BASE_CALIBRATION * load_scale`, which is 4 at the floor: these two
+    /// replaced a fixed 8000ms, and this keeps that as what they still get
+    /// on a quiet machine. Deliberately NOT a repo-wide rule -
+    /// `a_terminal_link_binding_is_not_refused_for_an_editor_side_reason`
+    /// converts an 8s constant with a 1s base, and reconciling the two is a
+    /// question about that test's operation rather than about these.
+    ///
+    /// Inside this module rather than beside it, because the release gate
+    /// waives a `#[cfg(test)] mod` and nothing else: a `#[cfg(test)]` on a
+    /// free item reads as shipped, which is the conservative direction that
+    /// filter deliberately takes.
+    pub(crate) const RESTORED_SHELL_BASE: Duration = Duration::from_secs(2);
 
     // The floor matters more than it looks: every budget this replaces was
     // observed failing at 1x, so a quiet machine must still get more room

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -56,6 +56,22 @@ const MIN_SCALE: u32 = 2;
 /// to know about.
 const BASE_CALIBRATION: u32 = 2;
 
+/// The base the two restored-shell waits use (#397).
+///
+/// Shared rather than retyped at each call site, because the test that pins
+/// it has to be about THEM: an assertion over a literal written beside it
+/// stays green when a call site changes, which is the regression it exists
+/// to catch.
+///
+/// 2s because `await_spawned` multiplies by `BASE_CALIBRATION * load_scale`,
+/// which is 4 at the floor: these two replaced a fixed 8000ms, and this
+/// keeps that as what they still get on a quiet machine. Deliberately NOT a
+/// repo-wide rule - `a_terminal_link_binding_is_not_refused_for_an_editor_side_reason`
+/// converts an 8s constant with a 1s base, and reconciling the two is a
+/// question about that test's operation rather than about these.
+#[cfg(test)]
+pub(crate) const RESTORED_SHELL_BASE: Duration = Duration::from_secs(2);
+
 /// One-minute load average, where the platform reports one.
 fn load_average() -> Option<f64> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -349,18 +365,21 @@ mod tests {
         );
     }
 
-    /// A conversion must not be a cut. #397 replaced two `waited < 8000`
-    /// loops with `await_spawned`, and the base that does that honestly is
-    /// the one whose FLOOR is the constant it replaced: `MIN_SCALE`'s own
-    /// doc says a budget may never shrink below what these tests already
-    /// had, since every one of them was observed failing at 1x. A 1s base
-    /// would have given them 4s on a quiet machine, which is half.
+    /// The two restored-shell waits keep the 8000ms they replaced.
+    ///
+    /// Written against `RESTORED_SHELL_BASE`, which those call sites use, so
+    /// lowering the base fails HERE. The first version asserted over a
+    /// literal `Duration::from_secs(2)` retyped beside it, which left both
+    /// call sites free to change underneath it, and reduced to
+    /// `BASE_CALIBRATION * MIN_SCALE >= 4` - already asserted, more
+    /// strongly, by `the_worst_case_stretch_is_unchanged` above.
     #[test]
     fn a_converted_wait_keeps_the_budget_it_replaced() {
-        let floor = Duration::from_secs(2) * BASE_CALIBRATION * MIN_SCALE;
+        let floor = RESTORED_SHELL_BASE * BASE_CALIBRATION * MIN_SCALE;
         assert!(
             floor >= Duration::from_millis(8000),
-            "a 2s base must reproduce the 8000ms it replaced at the floor, got {floor:?}"
+            "the restored-shell base must reproduce the 8000ms it replaced at \
+             the floor, got {floor:?}"
         );
     }
 

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -328,6 +328,22 @@ mod tests {
     /// to be told their change broke something, which is the cost
     /// `MAX_SCALE` exists to bound.
     #[test]
+    /// A conversion must not be a cut. #397 replaced two `waited < 8000`
+    /// loops with `await_spawned`, and the base that does that honestly is
+    /// the one whose FLOOR is the constant it replaced: `MIN_SCALE`'s own
+    /// doc says a budget may never shrink below what these tests already
+    /// had, since every one of them was observed failing at 1x. A 1s base
+    /// would have given them 4s on a quiet machine, which is half.
+    #[test]
+    fn a_converted_wait_keeps_the_budget_it_replaced() {
+        let floor = Duration::from_secs(2) * BASE_CALIBRATION * MIN_SCALE;
+        assert!(
+            floor >= Duration::from_millis(8000),
+            "a 2s base must reproduce the 8000ms it replaced at the floor, got {floor:?}"
+        );
+    }
+
+    #[test]
     fn the_worst_case_stretch_is_unchanged() {
         assert_eq!(
             BASE_CALIBRATION * MAX_SCALE,


### PR DESCRIPTION
Part of #397.

Two of the tests that issue tracks, one fixed against a measurement and one against a rationale. The difference is stated rather than blurred, because a flake fix that cannot be measured is a guess and should say so.

## The one with numbers

`quick_select_labels_follow_content_that_streams_below_them` parks its URL four rows from the bottom of the pane, then scrolls three more rows past it. A probe of the running test says the pane is **42 columns by 5 rows** in an 80x24 window, so the URL has exactly one row of slack. The prompt is written by a real shell, and on a box whose prompt carries a hostname and a path it wraps to three or four rows at that width. The URL leaves the screen, and the failure prints a pane holding only `x1 x2 x3`.

Maximizing the panel turns one row of slack into sixteen.

Measured on a four-core box with six busy loops saturating it, 20 runs each, same binary otherwise:

| tree | failures |
| --- | --- |
| baseline (`origin/main`) | **3/20** |
| with the panel maximized | **0/20** |

## Two shapes that made it worse

Recorded because the measurement is the only reason they were caught, and because both looked right.

A `settle_pane` helper that ran a command through the shell, waited for its output and then cleared the screen: **6/20**. The wait was satisfied by the shell **echoing the command line**, which contained the marker text, so it fired before the command ran and the real output landed after the clear.

The same helper with the marker assembled by the command (`printf 'croft-%s\n' settled`) so the echo could not match it: **20/20**. A probe of the grid explains it: `\x1b[2J` pushes the cleared rows into scrollback rather than removing them, and driving the shell adds the echoed command line on top of the prompt it was meant to neutralise. Driving the shell to make a pane quieter adds output; it cannot remove any.

## The one without numbers

`terminal_session_restores_pane_layout_names_and_focus_across_restarts` waited a fixed `8000ms` for a restored pane's shell to answer. That is exactly the number `src/test_budget.rs` exists to replace, and its module docs argue the case better than this PR can: what blows such a wait is contention, which is a property of what else the suite is running rather than of the test, so per-test tuning keeps looking reasonable and keeps not working.

It does **not** reproduce in isolation (0/15 under the same load), so this change is justified by that rationale and by the two full-suite failures seen today, not by a before-and-after of its own. The base is 4s, which through the module's calibration is the 8s it waited before on a quiet machine.

## What is left

The other four tests in this class are 0/15 alone under the same load and fail only inside a full-suite run, where thousands of tests and dozens of shells are competing:

```
the_swallow_guard_reads_the_clicked_terminal_not_the_active_one           0/15
terminal_cmd_c_copies_even_when_search_sidebar_is_open                    0/15
copy_mode_keys_follow_content_that_streamed_between_presses               0/15
terminal_copy_paste_into_other_panes_works_in_split_and_maximised_layout  0/15
```

They are left for a change that can measure them rather than swept in here on the strength of resembling the one that was.

## Verification

`cargo clippy --all-targets --all-features` exits 0 with zero warnings; the suite is green (4048 passed, 0 failed).

Test-only: `src/app/tests.rs` is excluded from the release gate's shipped set, so there is no version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal layout handling so wrapped prompts no longer obscure URLs in maximized panes.
  * Improved quick-select behavior and URL hint visibility in maximized views.

* **Tests**
  * Added coverage for wrapped prompts, pane sizing, URL visibility, and quick-select hints.
  * Improved terminal restoration timing coverage for more consistent results across environments.
  * Added safeguards to ensure restored-shell waits retain their expected minimum duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->