### PR TITLE
fix(terminal): let a strip on the side-bar seam unfold its pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.861"
+version = "0.1.865"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.861"
+version = "0.1.865"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -35990,7 +35990,21 @@ impl App {
                         && rect_contains(self.outline.last_scrollbar, m.column, m.row);
                     let graph_bar = self.sidebar_view == SidebarView::SourceControl
                         && rect_contains(self.commit_graph.last_scrollbar, m.column, m.row);
+                    // A collapsed terminal pane's one-column strip shares this
+                    // zone too (#468): the leftmost pane starts on the seam
+                    // itself, and with the side bar on the right the last
+                    // pane ends one column short of it. The strip's only
+                    // gesture is the click that unfolds it, so the seam must
+                    // not take that click as a resize, or a folded pane on
+                    // that edge can never be brought back. The rects are
+                    // cleared whenever the panel is not painted, so a stale
+                    // strip cannot deaden the seam later.
+                    let on_strip = self
+                        .terminal_strip_rects
+                        .iter()
+                        .any(|r| rect_contains(*r, m.column, m.row));
                     if (m.column == x || m.column == x.saturating_sub(1))
+                        && !on_strip
                         && !outline_bar
                         && !graph_bar
                         && self.decoration_dot_at(m.column, m.row).is_none()

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -38371,6 +38371,55 @@ fn clicking_a_collapsed_strip_gives_the_pane_its_width_back() {
 }
 
 #[test]
+fn a_strip_on_the_sidebar_seam_still_unfolds_its_pane() {
+    // #468: the default terminal is the LEFTMOST pane, and its strip sits on
+    // the editor column's left edge, which is exactly the column the sidebar
+    // seam claims for a resize drag. That hit-test runs before the strip's,
+    // so a click on the left pane's strip started a drag and the pane could
+    // never be brought back; a pane opened to the right sat clear of the seam
+    // and unfolded fine. Both sidebar positions are covered because the seam
+    // moves with the side bar: on the right it is the column past the editor,
+    // and its two-column grab zone reaches the LAST pane's strip instead.
+    for &pos in &[SideBarPosition::Left, SideBarPosition::Right] {
+        let (_tmp, mut app, mut term) = app_with_terminal_panes(2);
+        app.side_bar_position = pos;
+        let idx = match pos {
+            SideBarPosition::Left => 0,
+            SideBarPosition::Right => 1,
+        };
+        app.toggle_terminal_collapse(idx);
+        term.draw(|f| app.render(f)).unwrap();
+
+        let strip = app.terminal_strip_rects[idx];
+        assert_eq!(strip.width, 1, "{pos:?}: pane {idx} is folded to a strip");
+        let seam = app
+            .sidebar_splitter_x
+            .expect("the side bar is shown, so its seam exists");
+        // The whole point: the strip must lie inside the seam's grab zone
+        // (the seam column and the one left of it), or this proves nothing.
+        assert!(
+            strip.x == seam || strip.x + 1 == seam,
+            "{pos:?}: precondition - strip x={} must meet the seam at x={seam}",
+            strip.x
+        );
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            strip.x,
+            strip.y + strip.height / 2,
+        ));
+        assert!(
+            !app.terminals[idx].collapsed,
+            "{pos:?}: the strip on the seam is still the way back out"
+        );
+        assert_eq!(
+            app.splitter_drag, None,
+            "{pos:?}: a click on a strip is not a sidebar resize"
+        );
+    }
+}
+
+#[test]
 fn a_collapsed_pane_is_never_reflowed_into_its_strip() {
     // `resize` clamps to two columns, so rendering a collapsed pane would not
     // crash - it would quietly rewrap the running shell to a two-column grid

--- a/src/release_notes/0.1.865.md
+++ b/src/release_notes/0.1.865.md
@@ -1,0 +1,1 @@
+fix: A terminal pane folded on the side-bar edge can be unfolded again. Its one-column strip sits where the side-bar resize grab begins, and that grab used to swallow the click; the default left-hand pane was the one that could never come back.


### PR DESCRIPTION
## Summary

Part of #468 (a terminal pane collapsed on the left cannot be brought back).

The sidebar seam's grab zone is the editor column's first cell and the cell before it, and its hit-test runs before the terminal strip's. The default terminal is the leftmost pane, so its collapsed one-column strip sat exactly on the seam: a click started a sidebar resize drag instead of unfolding the pane. The strip is a folded pane's only gesture, so that pane could never come back. A pane opened to the right sat clear of the seam and unfolded fine, which is the asymmetry the issue reports. With the side bar on the right the seam is the column past the editor and its zone reaches the last pane's strip, so that side had the same hole.

The seam grab now exempts a collapsed pane's strip, the way it already exempts the outline scrollbar, the commit-graph scrollbar and decoration dots. The strip rects are cleared whenever the panel is not painted, so a stale strip cannot deaden the seam.

## Evidence

- New test `a_strip_on_the_sidebar_seam_still_unfolds_its_pane` renders a real frame with two panes, folds the pane that meets the seam for each side-bar position, asserts the strip really lies in the seam's grab zone, clicks it, and requires the pane back with no drag started. Red before the fix on the left case (`Left: the strip on the seam is still the way back out`); green after for both positions. The right-side case was not observed red separately because the loop fails on the left case first.
- Every test matching collapse, strip, splitter, seam and terminal_pane: 128 passed. Clippy with `-D warnings` on all targets: clean.

## Release

Version 0.1.865 with `src/release_notes/0.1.865.md`. 0.1.862 through 0.1.864 are taken by other open PRs.
