### PR TITLE
fix(doc-gate): one annotation for a capture both older passes see

### DIFF
--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -377,7 +377,7 @@ def documented(text):
     reported documentation as missing when rustc could see it perfectly well.
     """
     state = {}
-    for name, block in _items(text):
+    for name, block, _line in _items(text):
         state[name] = state.get(name, False) or block is not None
     return state
 
@@ -414,15 +414,44 @@ def _items(text):
             while j >= 0 and kinds[j] == DOC:
                 j -= 1
             block = tuple(l.strip() for l in lines[j + 1 : end])
-        yield name, block
+        yield name, block, i
 
 
 def doc_blocks_of(text, names):
     """The `///` blocks sitting above the items in `names`, as tuples of
-    stripped lines. What a stranded block at HEAD is compared against to
-    tell "the prose this loss already accounts for" from a second defect
-    (#463)."""
-    return {block for name, block in _items(text) if name in names and block}
+    stripped lines, one entry per documented definition. What a stranded
+    block at HEAD is compared against to tell "the prose this loss already
+    accounts for" from a second defect (#463)."""
+    return [block for name, block, _line in _items(text) if name in names and block]
+
+
+def explained_orphans(head_text, candidates, lost, explained):
+    """Line numbers of the stranded blocks in `candidates` that the losses
+    of `lost` already account for (#463).
+
+    An insertion strands the block that sat above its victim, so the
+    explained copy is the nearest matching block ABOVE where the victim now
+    sits at HEAD. Pairing by position rather than by text alone matters when
+    the same prose occurs twice in a file: `/// Creates a new instance.`
+    above two `new`s is ordinary, and a match on text would let one loss
+    silence a stranded copy that never documented it. Each lost definition
+    explains at most one block, and a block with no victim below it is
+    reported as usual.
+    """
+    remaining = list(explained)
+    stood_down = set()
+    victims = sorted(line for name, _block, line in _items(head_text) if name in lost)
+    for victim in victims:
+        above = [
+            o
+            for o in candidates
+            if o[0] - 1 < victim and o[0] not in stood_down and o[3] in remaining
+        ]
+        if above:
+            pick = max(above, key=lambda o: o[0])
+            stood_down.add(pick[0])
+            remaining.remove(pick[3])
+    return stood_down
 
 
 def orphaned_docs(text):
@@ -823,21 +852,25 @@ def main():
         # named it, and the block it left stranded at HEAD is the very block
         # that sat above it at the revision the loss names. Reporting that
         # block again describes the same edit a second time. The match is on
-        # the block's full text, not on the file: a stranded block that
-        # never documented the lost item is a second defect and keeps its
-        # line, and prose the branch also rewrote no longer matches and is
-        # reported, which is the conservative side for a gate.
-        explained = set()
+        # the block's full text AND its position above the victim, not on
+        # the file: a stranded block that never documented the lost item is
+        # a second defect and keeps its line, and prose the branch also
+        # rewrote no longer matches and is reported, which is the
+        # conservative side for a gate.
+        explained = []
         by_rev = {}
         for path, name, at in losses:
             if path == f:
                 by_rev.setdefault(at, set()).add(name)
         for at, names in by_rev.items():
-            explained |= doc_blocks_of(
-                git("show", f"{at}:{f}", allow_missing_path=True), names
+            explained.extend(
+                doc_blocks_of(git("show", f"{at}:{f}", allow_missing_path=True), names)
             )
-        for line_no, first, follower, block in orphaned_docs(head_text):
-            if block in explained:
+        candidates = orphaned_docs(head_text)
+        lost_here = set().union(*by_rev.values()) if by_rev else set()
+        stood_down = explained_orphans(head_text, candidates, lost_here, explained)
+        for line_no, first, follower, _block in candidates:
+            if line_no in stood_down:
                 continue
             orphans.append((f, line_no, first, follower))
         # `--no-merges`, and the omission is not a shortcut. A merge's first

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -430,27 +430,29 @@ def explained_orphans(head_text, candidates, lost, explained):
     of `lost` already account for (#463).
 
     An insertion strands the block that sat above its victim, so the
-    explained copy is the nearest matching block ABOVE where the victim now
-    sits at HEAD. Pairing by position rather than by text alone matters when
+    explained copy is the NEAREST stranded block above where the victim now
+    sits at HEAD, and it stands down only when its text is one a loss
+    explains. Pairing by position rather than by text alone matters when
     the same prose occurs twice in a file: `/// Creates a new instance.`
     above two `new`s is ordinary, and a match on text would let one loss
-    silence a stranded copy that never documented it. Each lost definition
-    explains at most one block, and a block with no victim below it is
-    reported as usual.
+    silence a stranded copy that never documented it. Taking the nearest
+    block regardless of text, rather than the nearest MATCHING one, is what
+    stops a loss whose own prose the branch also rewrote from reaching past
+    that rewritten block to an identical one further up. Each lost
+    definition explains at most one block, and a block with no victim below
+    it is reported as usual.
     """
     remaining = list(explained)
     stood_down = set()
     victims = sorted(line for name, _block, line in _items(head_text) if name in lost)
     for victim in victims:
-        above = [
-            o
-            for o in candidates
-            if o[0] - 1 < victim and o[0] not in stood_down and o[3] in remaining
-        ]
-        if above:
-            pick = max(above, key=lambda o: o[0])
-            stood_down.add(pick[0])
-            remaining.remove(pick[3])
+        above = [o for o in candidates if o[0] - 1 < victim and o[0] not in stood_down]
+        if not above:
+            continue
+        nearest = max(above, key=lambda o: o[0])
+        if nearest[3] in remaining:
+            stood_down.add(nearest[0])
+            remaining.remove(nearest[3])
     return stood_down
 
 

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -376,9 +376,20 @@ def documented(text):
     attributes, blanks and `//` comments alike; stopping at the first blank
     reported documentation as missing when rustc could see it perfectly well.
     """
+    state = {}
+    for name, block in _items(text):
+        state[name] = state.get(name, False) or block is not None
+    return state
+
+
+def _items(text):
+    """Every item `ITEM` models, keyed as `documented` keys it, with the
+    `///` block that reaches it: a tuple of the block's stripped lines, or
+    None when nothing documents it. One scan serves both the "is it
+    documented" question and the "which prose documented it" one, so the
+    two can never disagree about where a block's reach ends."""
     lines = text.splitlines()
     kinds = classify(lines)
-    state = {}
     tracker = BlockTracker()
     for i, line in enumerate(lines):
         # The scope an item belongs to is the one in force BEFORE its own
@@ -397,9 +408,21 @@ def documented(text):
         j = i - 1
         while j >= 0 and kinds[j] in (ATTR, SKIP):
             j -= 1
-        has_doc = j >= 0 and kinds[j] == DOC
-        state[name] = state.get(name, False) or has_doc
-    return state
+        block = None
+        if j >= 0 and kinds[j] == DOC:
+            end = j + 1
+            while j >= 0 and kinds[j] == DOC:
+                j -= 1
+            block = tuple(l.strip() for l in lines[j + 1 : end])
+        yield name, block
+
+
+def doc_blocks_of(text, names):
+    """The `///` blocks sitting above the items in `names`, as tuples of
+    stripped lines. What a stranded block at HEAD is compared against to
+    tell "the prose this loss already accounts for" from a second defect
+    (#463)."""
+    return {block for name, block in _items(text) if name in names and block}
 
 
 def orphaned_docs(text):
@@ -446,19 +469,23 @@ def orphaned_docs(text):
         start = i
         while i < len(lines) and kinds[i] == DOC:
             i += 1
+        # Each entry is `(line, first line, what follows, block)`; the block
+        # is the stripped text of the whole `///` run, which is how the
+        # caller recognises the block a reported loss already explains.
+        block = tuple(l.strip() for l in lines[start:i])
         # Attributes and blank lines sit legally between a doc and its item.
         j = i
         while j < len(lines) and kinds[j] in (ATTR, SKIP):
             j += 1
         if j >= len(lines):
             # A doc block at end of file documents nothing.
-            orphans.append((start + 1, lines[start].strip(), "end of file"))
+            orphans.append((start + 1, lines[start].strip(), "end of file", block))
             continue
         if kinds[j] == DOC:
             # Two doc blocks with no item between them: the first cannot
             # reach an item, because the second one gets there first. This
             # is what an insertion above a documented item leaves behind.
-            orphans.append((start + 1, lines[start].strip(), "another doc block"))
+            orphans.append((start + 1, lines[start].strip(), "another doc block", block))
             continue
         if NEVER_DOCUMENTED.match(lines[j]):
             # A line that syntactically cannot carry a doc comment. `use`
@@ -466,7 +493,7 @@ def orphaned_docs(text):
             # dropped between a doc and its function takes prose that
             # rustdoc then renders against the import, and neither the
             # diff check nor `unused_doc_comments` says a word.
-            orphans.append((start + 1, lines[start].strip(), lines[j].strip()))
+            orphans.append((start + 1, lines[start].strip(), lines[j].strip(), block))
     return orphans
 
 
@@ -791,7 +818,27 @@ def main():
         head_text = git("show", f"{head}:{f}", allow_missing_path=True)
         if not head_text:
             continue
-        for line_no, first, follower in orphaned_docs(head_text):
+        # One insertion, one annotation (#463). When the victim is an item
+        # `ITEM` models and was documented before, the loss pass has already
+        # named it, and the block it left stranded at HEAD is the very block
+        # that sat above it at the revision the loss names. Reporting that
+        # block again describes the same edit a second time. The match is on
+        # the block's full text, not on the file: a stranded block that
+        # never documented the lost item is a second defect and keeps its
+        # line, and prose the branch also rewrote no longer matches and is
+        # reported, which is the conservative side for a gate.
+        explained = set()
+        by_rev = {}
+        for path, name, at in losses:
+            if path == f:
+                by_rev.setdefault(at, set()).add(name)
+        for at, names in by_rev.items():
+            explained |= doc_blocks_of(
+                git("show", f"{at}:{f}", allow_missing_path=True), names
+            )
+        for line_no, first, follower, block in orphaned_docs(head_text):
+            if block in explained:
+                continue
             orphans.append((f, line_no, first, follower))
         # `--no-merges`, and the omission is not a shortcut. A merge's first
         # parent is the branch tip, so the pair `(M^, M)` is everything the

--- a/scripts/check_doc_ownership.py
+++ b/scripts/check_doc_ownership.py
@@ -438,9 +438,10 @@ def explained_orphans(head_text, candidates, lost, explained):
     silence a stranded copy that never documented it. Taking the nearest
     block regardless of text, rather than the nearest MATCHING one, is what
     stops a loss whose own prose the branch also rewrote from reaching past
-    that rewritten block to an identical one further up. Each lost
-    definition explains at most one block, and a block with no victim below
-    it is reported as usual.
+    that rewritten block to an identical one further up, and when two blocks
+    above the victim carry that text the pairing is ambiguous and stands
+    nothing down. Each lost definition explains at most one block, and a
+    block with no victim below it is reported as usual.
     """
     remaining = list(explained)
     stood_down = set()
@@ -450,9 +451,17 @@ def explained_orphans(head_text, candidates, lost, explained):
         if not above:
             continue
         nearest = max(above, key=lambda o: o[0])
-        if nearest[3] in remaining:
-            stood_down.add(nearest[0])
-            remaining.remove(nearest[3])
+        if nearest[3] not in remaining:
+            continue
+        # Two blocks with the victim's prose above it: nothing says which one
+        # it lost, and the nearer may be an independent capture that reads
+        # the same. Standing it down would hide that defect and leave the
+        # report pointing at the other block, so an ambiguous pairing stands
+        # nothing down and every block prints.
+        if sum(1 for o in above if o[3] == nearest[3]) > 1:
+            continue
+        stood_down.add(nearest[0])
+        remaining.remove(nearest[3])
     return stood_down
 
 

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -686,6 +686,41 @@ class HeadOnlyOrphanTests(unittest.TestCase):
             self.assertNotIn("'/// Documents beta.'", text, f"the block the loss explains stands down: {text}")
             self.assertEqual(text.count("::error"), 2, f"two defects, two annotations: {text}")
 
+    def test_duplicated_prose_does_not_silence_a_second_stranded_block(self):
+        """The stand-down pairs a loss with the stranded block ABOVE its
+        victim, not with every block that reads the same. `/// Creates a new
+        instance.` above two `new`s is ordinary Rust; here one copy is the
+        #463 capture of `A::new`, and the other is a #427-shaped capture in
+        a new impl, whose victim has no base doc to lose and so is seen by
+        the head-only pass alone. Matching on text would silence it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "impl A {\n    /// Creates a new instance.\n    pub fn new() {}\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "impl A {\n    /// Creates a new instance.\n\n    /// Helper.\n"
+                "    pub fn helper() {}\n\n    pub fn new() {}\n}\n"
+                "impl C {\n    /// Creates a new instance.\n\n    /// Other.\n"
+                "    pub fn other() {}\n\n    pub fn new() {}\n}\n",
+            )
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            text = out.getvalue()
+            self.assertIn("`A::new` had a doc comment", text)
+            self.assertIn("line=10::", text, f"the copy in impl C is its own defect: {text}")
+            self.assertNotIn("line=2::", text, f"the copy above A::new is the loss's: {text}")
+            self.assertEqual(text.count("::error"), 2, f"two captures, two annotations: {text}")
+
     def test_ordinary_docs_are_not_reported(self):
         """The control. A gate that cries wolf stops being read, so the
         shapes a real file is full of must stay silent: attributes and

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -782,6 +782,39 @@ class HeadOnlyOrphanTests(unittest.TestCase):
             self.assertIn("line=2::", text, f"the block at end of file is reported: {text}")
             self.assertEqual(text.count("::error"), 2, f"loss and stranded block both print: {text}")
 
+    def test_two_identical_blocks_above_one_victim_are_both_reported(self):
+        """When two stranded blocks with the victim's prose both sit above it,
+        nothing says which one it lost: the nearer may be an independent
+        capture that happens to read the same. Standing the nearer one down
+        hides that defect and leaves the report pointing at the other block,
+        so an ambiguous pairing stands nothing down and all three print."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "impl A {\n    /// Creates a new instance.\n    pub fn new() {}\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "impl A {\n    /// Creates a new instance.\n\n    /// Helper.\n"
+                "    pub fn helper() {}\n\n    /// Creates a new instance.\n\n    /// Other.\n"
+                "    pub fn other() {}\n\n    pub fn new() {}\n}\n",
+            )
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            text = out.getvalue()
+            self.assertIn("`A::new` had a doc comment", text)
+            self.assertIn("line=2::", text, f"the farther copy is reported: {text}")
+            self.assertIn("line=7::", text, f"and so is the nearer one: {text}")
+            self.assertEqual(text.count("::error"), 3, f"an ambiguous pairing stands nothing down: {text}")
+
     def test_ordinary_docs_are_not_reported(self):
         """The control. A gate that cries wolf stops being read, so the
         shapes a real file is full of must stay silent: attributes and

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -721,6 +721,67 @@ class HeadOnlyOrphanTests(unittest.TestCase):
             self.assertNotIn("line=2::", text, f"the copy above A::new is the loss's: {text}")
             self.assertEqual(text.count("::error"), 2, f"two captures, two annotations: {text}")
 
+    def test_a_rewritten_victim_block_does_not_lend_its_loss_to_a_farther_block(self):
+        """The pairing takes the nearest stranded block ABOVE the victim and
+        stands it down only when its text is one a loss explains. When the
+        branch both rewrote `A::new`'s prose and captured it, the block
+        directly above `A::new` no longer matches the base, and the loss
+        must not reach past it to silence an identically-worded stranded
+        block in another impl. Three defects, three annotations."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "impl A {\n    /// Creates a new instance.\n    pub fn new() {}\n}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "impl C {\n    /// Creates a new instance.\n\n    /// Other.\n"
+                "    pub fn other() {}\n\n    pub fn new() {}\n}\n"
+                "impl A {\n    /// Creates a new instance, better.\n\n    /// Helper.\n"
+                "    pub fn helper() {}\n\n    pub fn new() {}\n}\n",
+            )
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            text = out.getvalue()
+            self.assertIn("`A::new` had a doc comment", text)
+            self.assertIn("line=2::", text, f"impl C's stranded copy is its own defect: {text}")
+            self.assertIn("line=10::", text, f"the rewritten block is stranded too: {text}")
+            self.assertEqual(text.count("::error"), 3, f"three defects, three annotations: {text}")
+
+    def test_a_victim_moved_above_its_old_block_leaves_the_block_reported(self):
+        """The stand-down needs a victim BELOW the block. Moving `beta` above
+        its own doc strands the block at end of file with no victim under
+        it, so the loss explains nothing here and both annotations print;
+        matching on text alone used to fold them into one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "/// Documents beta.\nfn beta() {}\n")
+            repo.branch("feat")
+            repo.commit("a.rs", "fn beta() {}\n/// Documents beta.\n")
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            text = out.getvalue()
+            self.assertIn("`beta` had a doc comment", text)
+            self.assertIn("line=2::", text, f"the block at end of file is reported: {text}")
+            self.assertEqual(text.count("::error"), 2, f"loss and stranded block both print: {text}")
+
     def test_ordinary_docs_are_not_reported(self):
         """The control. A gate that cries wolf stops being read, so the
         shapes a real file is full of must stay silent: attributes and

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -815,6 +815,43 @@ class HeadOnlyOrphanTests(unittest.TestCase):
             self.assertIn("line=7::", text, f"and so is the nearer one: {text}")
             self.assertEqual(text.count("::error"), 3, f"an ambiguous pairing stands nothing down: {text}")
 
+    def test_cfg_twins_each_captured_stand_both_blocks_down(self):
+        """Two `#[cfg]` definitions under one key, each with its own copy of
+        the doc, each captured by an insertion. The first victim pairs with
+        the first block; the second must still pair with the second, which
+        needs the ambiguity count to skip blocks already stood down. One
+        loss, no stranded-block annotations."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit(
+                "a.rs",
+                "/// Creates a new instance.\n#[cfg(unix)]\nfn new() {}\n\n"
+                "/// Creates a new instance.\n#[cfg(windows)]\nfn new() {}\n",
+            )
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "/// Creates a new instance.\n\n/// Helper.\nfn helper_a() {}\n\n"
+                "#[cfg(unix)]\nfn new() {}\n\n"
+                "/// Creates a new instance.\n\n/// Helper.\nfn helper_b() {}\n\n"
+                "#[cfg(windows)]\nfn new() {}\n",
+            )
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            text = out.getvalue()
+            self.assertIn("`new` had a doc comment", text)
+            self.assertNotIn("line=", text, f"both stranded copies are explained: {text}")
+            self.assertEqual(text.count("::error"), 1, f"one loss, one annotation: {text}")
+
     def test_ordinary_docs_are_not_reported(self):
         """The control. A gate that cries wolf stops being read, so the
         shapes a real file is full of must stay silent: attributes and

--- a/scripts/tests/test_doc_ownership.py
+++ b/scripts/tests/test_doc_ownership.py
@@ -617,6 +617,75 @@ class HeadOnlyOrphanTests(unittest.TestCase):
             )
             self.assertEqual(repo.exit_code(), 1)
 
+    def test_a_capture_both_older_passes_see_is_reported_once(self):
+        """#463: when the victim is an item `ITEM` models and was documented
+        at the base, the loss pass names it AND the head-only pass names the
+        block it left stranded. Both are true and both point at one
+        insertion; a reader counting annotations counts two defects. The
+        loss message is the older and more precise of the two, so it keeps
+        the report and the stranded-block one stands down."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "/// Documents beta.\nfn beta() {}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "/// Documents beta.\n\n/// Documents gamma.\nfn gamma() {}\n\nfn beta() {}\n",
+            )
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            self.assertIn(
+                "`beta` had a doc comment",
+                out.getvalue(),
+                f"the loss pass keeps the report: {out.getvalue()}",
+            )
+            self.assertEqual(
+                out.getvalue().count("::error"),
+                1,
+                f"one insertion, one annotation: {out.getvalue()}",
+            )
+
+    def test_a_stranded_block_unrelated_to_a_loss_is_still_reported(self):
+        """The stand-down is keyed on the BLOCK, not on the file: a loss in a
+        file must not silence every stranded block in it. Here the branch
+        makes the #463 capture and, elsewhere in the same file, strands a
+        block that never documented the lost item. That one is a second
+        defect and keeps its annotation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Repo(Path(tmp))
+            repo.commit("a.rs", "/// Documents beta.\nfn beta() {}\n")
+            repo.branch("feat")
+            repo.commit(
+                "a.rs",
+                "/// Documents beta.\n\n/// Documents gamma.\nfn gamma() {}\n\nfn beta() {}\n"
+                "\n/// Lonely.\n\n/// Documents delta.\nfn delta() {}\n",
+            )
+            out = io.StringIO()
+            cwd, argv = os.getcwd(), sys.argv
+            os.chdir(repo.path)
+            sys.argv = ["check_doc_ownership.py", "main", "HEAD"]
+            try:
+                with contextlib.redirect_stdout(out):
+                    code = gate.main()
+            finally:
+                sys.argv = argv
+                os.chdir(cwd)
+            self.assertEqual(code, 1)
+            text = out.getvalue()
+            self.assertIn("`beta` had a doc comment", text)
+            self.assertIn("'/// Lonely.'", text, f"the unrelated block is still stranded: {text}")
+            self.assertNotIn("'/// Documents beta.'", text, f"the block the loss explains stands down: {text}")
+            self.assertEqual(text.count("::error"), 2, f"two defects, two annotations: {text}")
+
     def test_ordinary_docs_are_not_reported(self):
         """The control. A gate that cries wolf stops being read, so the
         shapes a real file is full of must stay silent: attributes and


### PR DESCRIPTION
## Summary

Part of #463 (the doc-ownership gate prints two annotations for one capture).

When the victim is an item the gate models and it was documented at the base, an insertion above it is seen by two passes: the loss pass names the item that lost its prose, and the head-only pass names the block the insertion left stranded. Both are true and both point at the same edit, so a reader counting annotations counted two defects.

The stranded block at HEAD is the very block that sat above the lost item at the revision the loss names. The head-only pass now stands down for a block whose full text matches one that a loss on the same file explains. The match is on the block, not the file: a stranded block that never documented the lost item is a second defect and keeps its annotation, and prose the branch also rewrote no longer matches and is still reported, which is the conservative side for a gate.

`documented` and the new `doc_blocks_of` share one item scan, so the two cannot disagree about where a block's reach ends.

## Evidence

- `test_a_capture_both_older_passes_see_is_reported_once`: the issue's reduced case. Red before (`2 != 1`), green after, and the surviving annotation is the loss.
- `test_a_stranded_block_unrelated_to_a_loss_is_still_reported`: the same capture plus an unrelated stranded block in the same file. Red before (three annotations, the explained block still present), green after with exactly two.
- Whole gate suite: 120 tests OK.

## Release

No Rust source changed, so no version bump or release note: `scripts/` is not compiled into the binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved documentation tracking and diagnostics for head-only reporting.
  - Reduced duplicate orphan documentation reports when the issue is already explained by a documented-item loss.
  - Preserved reporting for unrelated, moved, rewritten, duplicated, ambiguous, and configuration-specific documentation blocks.
  - Orphan reports now include the complete documentation block and more accurate location details.

- **Tests**
  - Added regression coverage for documentation capture, deduplication, annotation counts, and location pairing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->