### PR TITLE
test(app): budget the probe and task-pane waits, silence the quick-select pane (part of #397)

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -22,29 +22,37 @@ fn probe_command(probe: &str) -> String {
     format!("printf '%s%s\\n' '{head}' '{tail}'\r")
 }
 
-/// How long the terminal end-to-end tests wait for their probe to come back
-/// through the PTY. Generous on purpose: a real shell has to start, run the
-/// command, and have the reader thread drain the bytes into the grid, and on
-/// a box running the whole suite in parallel that took longer than the three
-/// seconds this used to allow (issue #226).
-const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-
 /// Run the probe command in the app's embedded terminal and wait until the
 /// probe is on screen. Panics with the actual screen contents if it never
 /// arrives, so a failure says what the terminal was showing instead of
 /// unwrapping `None` several lines later.
+///
+/// The wait is load-scaled (#397): a real shell has to start, run the
+/// command, and have the reader thread drain the bytes into the grid, and
+/// what stretches that is contention from the rest of the suite, not this
+/// test. The fixed 15s this replaced (#226 had raised it from 3s) is what a
+/// quiet machine still gets at the floor; the captured failure had the probe
+/// command echoed on screen and unanswered at 15s, a starved shell rather
+/// than a broken one. `spawn_budget` rather than `await_spawned` so the
+/// panic can keep showing the screen.
 fn await_terminal_probe(app: &mut App, probe: &str) {
     app.terminal_mut()
         .write_input(probe_command(probe).as_bytes());
+    let base = crate::test_budget::tests::TERMINAL_PROBE_BASE;
+    let budget = crate::test_budget::spawn_budget(base);
     let started = std::time::Instant::now();
-    while started.elapsed() < PROBE_TIMEOUT {
+    while started.elapsed() < budget {
         if app.terminal().visible_text().contains(probe) {
             return;
         }
         std::thread::sleep(std::time::Duration::from_millis(20));
     }
     panic!(
-        "the shell never printed the probe {probe:?} within {PROBE_TIMEOUT:?}; terminal showed:\n{}",
+        "the shell never printed the probe {probe:?} within {budget:?} ({base:?} base x{} total \
+         for calibration and load); if this is a real failure it would also fail at 1x, so \
+         re-run the full suite on the unmodified merge base under the same load before \
+         suspecting your diff. Terminal showed:\n{}",
+        budget.as_millis() / base.as_millis().max(1),
         app.terminal().visible_text()
     );
 }
@@ -6227,13 +6235,14 @@ fn rerunning_a_task_reuses_its_pane_instead_of_stacking_new_ones() {
     app.handle_key(chord).unwrap();
     // Wait for the pane's shell to come back to its prompt so the rerun
     // path sees an idle pane (a busy pane legitimately gets a new one).
-    let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(5000) {
-        if app.terminals[app.active_terminal].foreground_is_shell() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+    // Load-scaled and LOUD (#397): the fixed 5000ms loop broke out silently
+    // on timeout, so under suite load the next step met a pane still busy
+    // and the assertion after it misreported the timeout as its own failure.
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::TASK_PANE_PROMPT_BASE,
+        "the task pane's shell to return to its prompt",
+        || app.terminals[app.active_terminal].foreground_is_shell(),
+    );
     let after_first = app.terminals.len();
     app.handle_key(chord).unwrap();
     assert_eq!(
@@ -6264,13 +6273,14 @@ fn a_reused_task_pane_clears_a_half_typed_prompt_line_first() {
         KeyModifiers::SUPER | KeyModifiers::SHIFT,
     );
     app.handle_key(chord).unwrap();
-    let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(5000) {
-        if app.terminals[app.active_terminal].foreground_is_shell() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+    // Load-scaled and LOUD (#397): the fixed 5000ms loop broke out silently
+    // on timeout, so under suite load the next step met a pane still busy
+    // and the assertion after it misreported the timeout as its own failure.
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::TASK_PANE_PROMPT_BASE,
+        "the task pane's shell to return to its prompt",
+        || app.terminals[app.active_terminal].foreground_is_shell(),
+    );
     app.handle_key(chord).unwrap();
     let bytes = app.terminals[app.active_terminal].written_bytes_for_test();
     let needle = b"\x05\x15make build\r";
@@ -6294,13 +6304,16 @@ fn a_task_pane_from_the_old_workspace_is_not_reused_after_a_re_root() {
         KeyModifiers::SUPER | KeyModifiers::SHIFT,
     );
     app.handle_key(chord).unwrap();
-    let started = std::time::Instant::now();
-    while started.elapsed() < std::time::Duration::from_millis(5000) {
-        if app.terminals[app.active_terminal].foreground_is_shell() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(20));
-    }
+    // Load-scaled and LOUD (#397). The fixed 5000ms loop broke out silently
+    // on timeout, and here a still-busy pane passes the assertion below for
+    // the wrong reason: a busy pane always gets a sibling, so `after + 1`
+    // held without the cwd guard ever being exercised. Failing loudly makes
+    // the guard the thing under test.
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::TASK_PANE_PROMPT_BASE,
+        "the task pane's shell to return to its prompt",
+        || app.terminals[app.active_terminal].foreground_is_shell(),
+    );
     // Focus another pane so the re-root's active-pane `cd` cannot move the
     // task pane along (the reviewer's scenario: it is NOT cd'd).
     app.active_terminal = 0;
@@ -30405,21 +30418,32 @@ fn a_wrapped_prompt_does_not_push_the_url_off_a_maximized_pane() {
 fn quick_select_labels_follow_content_that_streams_below_them() {
     let tmp = tempfile::tempdir().unwrap();
     let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    // A SILENT pane (#397). The row slack below was this test's first fix,
+    // and it held until a full-suite run captured the pane holding ONLY the
+    // shell's wrapped prompt and the trailing x1 x2 x3, the URL gone: the
+    // shell's prompt repaint after the maximize's SIGWINCH landed between
+    // the feeds and rewrote the rows the URL sat on. Slack absorbs a prompt
+    // that appends; it cannot absorb one that repaints. A child that prints
+    // nothing removes the writer entirely, and the subject here -- croft's
+    // label overlay following content the pane streams -- needs a grid, not
+    // a shell. The slack assertion stays: the scroll this test drives still
+    // needs the rows.
+    app.terminals[0] = crate::widgets::terminal::PtyTerminal::new_running(
+        "/bin/sh",
+        &[String::from("-c"), String::from("sleep 30")],
+        tmp.path(),
+    )
+    .unwrap();
     app.focus_pane(Pane::Terminal);
     let backend = ratatui::backend::TestBackend::new(80, 24);
     let mut term = ratatui::Terminal::new(backend).unwrap();
     // The panel over the editor, so the pane has ROWS. Unmaximized it is a
     // few rows tall here, and this test parks its URL four rows from the
-    // bottom: almost no slack against a prompt that a real shell writes and
-    // that wraps to several rows on a machine with a long hostname and path.
-    // That is this test's entry in #397, measured at 3 failures in 20 runs
-    // under load, with the URL scrolling off the top in the failure. The
-    // measured numbers are in the PR; the literals are not repeated here,
-    // since they are one configuration's and the code derives its own below.
-    //
-    // The maximize also resizes the PTY, so the pane's shell takes a SIGWINCH
-    // and may repaint its prompt. That lands before the newline flood parks
-    // the cursor, and the slack this exists to create absorbs a late one.
+    // bottom. When the pane still ran the workspace shell that was almost
+    // no slack against a wrapped prompt (this test's first entry in #397,
+    // 3 failures in 20 runs under load); with a silent child the rows are
+    // simply what the scroll below needs, and the maximize is how it gets
+    // them.
     app.toggle_terminal_maximize();
     term.draw(|f| app.render(f)).unwrap();
     // Park the cursor at the pane bottom so every further row SCROLLS.
@@ -30429,21 +30453,19 @@ fn quick_select_labels_follow_content_that_streams_below_them() {
     // rows, the test would quietly return to flaking instead of failing.
     assert!(
         h >= 16,
-        "the maximized panel must leave slack for the shell's wrapped prompt; got {h} rows"
+        "the maximized panel must leave rows for the scroll this test drives; got {h} rows"
     );
     app.terminals[0].feed_bytes_for_test("\r\n".repeat(h * 2).as_bytes());
-    // One atomic feed, opening with its own newline: the live child
-    // shell's prompt can flush between feed calls under suite load (#62),
-    // and a prompt landing just before the URL used to push it across the
-    // pane edge, wrapping the match. Advancing "\r\n" + URL under one grid
-    // lock keeps the URL at column 0 whether the prompt arrives before
-    // this chunk (its row is above) or after it (it appends to the right).
+    // One atomic feed, opening with its own newline, so "\r\n" + URL lands
+    // under one grid lock with the URL at column 0. #62 saw the match wrap
+    // the pane edge when another writer got between two feeds; the pane is
+    // silent now, and the shape is kept because it is the one that cannot
+    // wrap whatever else is on screen.
     app.terminals[0].feed_bytes_for_test(b"\r\nhttp://drift.io");
     app.open_terminal_quick_select();
-    // The URL by name, not `is_some()`. Quick select stages every match on
-    // screen and the live shell's prompt path is one, so `is_some()` cannot
-    // tell "the URL is hinted" from "only the prompt is", and maximizing the
-    // pane put more prompt text on screen rather than less.
+    // The URL by name, not `is_some()`: quick select stages every match on
+    // screen, and naming the one this test planted keeps the assertion
+    // about it rather than about whatever else happens to match.
     assert!(
         app.terminal_quick_select
             .as_ref()
@@ -30455,10 +30477,9 @@ fn quick_select_labels_follow_content_that_streams_below_them() {
     let buf = term.backend().buffer().clone();
     // Join the pane's inner rows into one stream before searching, so pane
     // geometry can't split the needle across a row boundary (#62), and
-    // don't pin WHICH gold label the URL drew: when the live shell's
-    // prompt lands above the URL its path is a match too, and label
-    // assignment is bottom-priority, so the URL's letter depends on that
-    // race. The invariant is that SOME label still covers the URL's first
+    // don't pin WHICH gold label the URL drew: label assignment is
+    // bottom-priority over every match on screen, and the letter is not the
+    // claim. The invariant is that SOME label still covers the URL's first
     // cell after the scroll — the 'h' is overlaid, the rest is intact.
     let inner = app.terminals[0].last_inner;
     let joined: String = (inner.y..inner.y + inner.height)

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -260,6 +260,24 @@ pub(crate) mod tests {
     /// filter deliberately takes.
     pub(crate) const RESTORED_SHELL_BASE: Duration = Duration::from_secs(2);
 
+    /// The base behind the app tests' `await_terminal_probe` (#397), which
+    /// six end-to-end tests go through. It replaced a fixed 15s (#226 had
+    /// raised that from 3s for the same reason). 3750ms because
+    /// `BASE_CALIBRATION * MIN_SCALE` is 4 at the floor: a quiet machine
+    /// keeps the 15s it had, and a loaded one gets up to twice that. The
+    /// captured failure was a probe that had been ECHOED but not answered
+    /// within the 15s during a full parallel suite, so the shell was alive
+    /// and merely starved -- the case a load-scaled budget exists for.
+    pub(crate) const TERMINAL_PROBE_BASE: Duration = Duration::from_millis(3750);
+
+    /// The base the three task-pane tests wait for the pane's shell to come
+    /// back to its prompt (#397). They had a fixed 5000ms loop that `break`s
+    /// on timeout, so under load the rerun met a pane still busy, opened a
+    /// second one, and the count assertion reported "3 panes, expected 2"
+    /// as if reuse were broken. 1250ms keeps the 5s at the floor, and the
+    /// wait now fails loudly, naming what it waited for.
+    pub(crate) const TASK_PANE_PROMPT_BASE: Duration = Duration::from_millis(1250);
+
     // The floor matters more than it looks: every budget this replaces was
     // observed failing at 1x, so a quiet machine must still get more room
     // than the constant it replaced, not less.
@@ -385,6 +403,25 @@ pub(crate) mod tests {
             floor >= Duration::from_millis(8000),
             "the restored-shell base must reproduce the 8000ms it replaced at \
              the floor, got {floor:?}"
+        );
+    }
+
+    /// Same rule for the two #397 bases added later: each must give back,
+    /// at the floor, the constant it replaced. Against the constants the
+    /// call sites use, so lowering either fails here.
+    #[test]
+    fn the_probe_and_task_pane_bases_keep_their_old_budgets() {
+        let probe = TERMINAL_PROBE_BASE * BASE_CALIBRATION * MIN_SCALE;
+        assert!(
+            probe >= Duration::from_secs(15),
+            "the terminal probe base must reproduce the 15s it replaced at the \
+             floor, got {probe:?}"
+        );
+        let task = TASK_PANE_PROMPT_BASE * BASE_CALIBRATION * MIN_SCALE;
+        assert!(
+            task >= Duration::from_millis(5000),
+            "the task-pane prompt base must reproduce the 5000ms it replaced at \
+             the floor, got {task:?}"
         );
     }
 


### PR DESCRIPTION
Part of #397; that issue stays open for the members without a captured failure.

Three members of the flaky-under-load class, each with a captured full-suite failure and each a different shape.

## The probe helper (six end-to-end tests)

`await_terminal_probe` waited a fixed 15 s. A full parallel run captured the probe command echoed on screen and still unanswered at 15 s, which is a starved shell, not a broken one. The helper now waits `spawn_budget(TERMINAL_PROBE_BASE)`: 15 s at the floor, up to twice that under load, and the panic still prints the screen. This covers `terminal_copy_paste_into_other_panes_works_in_split_and_maximised_layout` and `terminal_cmd_c_copies_even_when_search_sidebar_is_open`, both on the issue's list.

## The task-pane tests (three tests)

They waited up to 5000 ms for the pane's shell to return to its prompt and broke out of the loop silently on timeout. Under load the rerun then met a busy pane, opened a second one, and the count assertion reported "3 panes, expected 2" as if reuse were broken, which is the panic the issue records. They now go through `await_spawned(TASK_PANE_PROMPT_BASE)`: 5 s at the floor, and a timeout fails loudly naming what it waited for.

## The quick-select streaming test

It had row slack against a real shell's wrapped prompt. The captured failure showed the pane holding only that prompt and the trailing `x1 x2 x3` with the URL gone: the shell's prompt repaint after the maximize's SIGWINCH rewrote the rows between the feeds. Slack absorbs a prompt that appends, not one that repaints. The pane is now a silent `/bin/sh -c 'sleep 30'`, the same pattern the other silent-pane tests use; the subject is croft's label overlay following streamed content, which needs a grid, not a shell. The slack assertion stays because the scroll still needs the rows.

## Bases

Both bases live in `test_budget::tests` beside `RESTORED_SHELL_BASE`, with a pin test asserting each reproduces the constant it replaced at the floor, so lowering either fails there rather than at a call site.

## Not in this PR

The remaining fixed waits in `src/app/tests.rs` (about forty `waited < N` / `from_secs(15)` deadlines) are the same shape but have no captured failure; converting them blind is what this issue's history warns against. Test-only, no version bump.

## Verification

- The 20 affected tests (probe users, task-pane tests, quick-select, `test_budget`) pass through the host suite lock.
- The quick-select and three task-pane tests pass 15 consecutive runs through the lock.
- Local reviewer ran once; see the PR thread for anything it raised.
