### PR TITLE
test(terminal): put 17 more shell waits on the shared load-scaled base (part of #397)

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2972,12 +2972,11 @@ fn terminal_decoration_dot_click_is_not_hijacked_by_the_sidebar_splitter() {
         tmp.path(),
     )
     .unwrap();
-    let mut waited = 0u32;
-    while app.terminals[0].command_decorations().is_empty() {
-        assert!(waited < 8000, "no decoration mark arrived");
-        std::thread::sleep(std::time::Duration::from_millis(40));
-        waited += 40;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the shell to emit a decoration mark",
+        || !app.terminals[0].command_decorations().is_empty(),
+    );
     let backend = ratatui::backend::TestBackend::new(120, 40);
     let mut term = ratatui::Terminal::new(backend).unwrap();
     term.draw(|frame| app.render(frame)).unwrap();
@@ -3643,18 +3642,18 @@ fn cmd_opt_up_parks_the_previous_prompt_mark_at_the_viewport_top() {
         tmp.path(),
     )
     .unwrap();
-    let mut waited = 0u32;
-    while app.terminals[0].prompt_lines().is_empty()
-        || !app.terminals[0]
-            .grid_lines()
-            .0
-            .iter()
-            .any(|l| l.contains("filler-39"))
-    {
-        assert!(waited < 4000, "mark/filler output never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the prompt mark and filler output",
+        || {
+            !app.terminals[0].prompt_lines().is_empty()
+                && app.terminals[0]
+                    .grid_lines()
+                    .0
+                    .iter()
+                    .any(|l| l.contains("filler-39"))
+        },
+    );
     app.focus_pane(Pane::Terminal);
     assert_eq!(
         app.terminal().viewport_top_line(),
@@ -3697,19 +3696,19 @@ fn ctrl_shift_space_quick_select_labels_matches_and_a_label_commits() {
     // sentinels, so wait until the SHA shows up on its own echoed row too
     // (a second occurrence); otherwise quick-select can open on a
     // header-only viewport and the hint set is timing-dependent.
-    let mut waited = 0u32;
-    while app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .filter(|l| l.contains("de40bdf12ab34"))
-        .count()
-        < 2
-    {
-        assert!(waited < 4000, "output never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "both copies of the pasted hash",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .filter(|l| l.contains("de40bdf12ab34"))
+                .count()
+                >= 2
+        },
+    );
     app.focus_pane(Pane::Terminal);
     assert!(app.terminal_quick_select.is_none(), "starts off");
 
@@ -3786,17 +3785,17 @@ fn shift_pageup_pages_the_scrollback_and_shift_end_snaps_back() {
         tmp.path(),
     )
     .unwrap();
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("page-79"))
-    {
-        assert!(waited < 4000, "filler output never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the filler output",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("page-79"))
+        },
+    );
     app.focus_pane(Pane::Terminal);
     let at_bottom = app.terminal().viewport_top_line();
 
@@ -3886,18 +3885,18 @@ fn pane_inline_image_overlay_anchors_hides_when_scrolled_off_and_returns() {
         tmp.path(),
     )
     .unwrap();
-    let mut waited = 0u32;
-    while app.terminals[0].pane_images().is_empty()
-        || !app.terminals[0]
-            .grid_lines()
-            .0
-            .iter()
-            .any(|l| l.contains("fill-79"))
-    {
-        assert!(waited < 8000, "image/filler never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the image and its filler",
+        || {
+            !app.terminals[0].pane_images().is_empty()
+                && app.terminals[0]
+                    .grid_lines()
+                    .0
+                    .iter()
+                    .any(|l| l.contains("fill-79"))
+        },
+    );
     app.focus_pane(Pane::Terminal);
     let backend = ratatui::backend::TestBackend::new(140, 50);
     let mut term = ratatui::Terminal::new(backend).unwrap();
@@ -3951,19 +3950,19 @@ fn quick_select_paints_gold_labels_and_broadcast_paints_modal_and_pills() {
         tmp.path(),
     )
     .unwrap();
-    let mut waited = 0u32;
-    while app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .filter(|l| l.contains("example.com/paint"))
-        .count()
-        < 2
-    {
-        assert!(waited < 4000, "output never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "both copies of the pasted URL",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .filter(|l| l.contains("example.com/paint"))
+                .count()
+                >= 2
+        },
+    );
     app.focus_pane(Pane::Terminal);
     // Render once BEFORE opening quick select: the first render resizes the
     // pane to its layout size (reflowing the grid), and hints must be
@@ -4067,16 +4066,15 @@ fn cmd_k_i_broadcasts_input_to_every_pane_with_confirm_and_auto_off() {
         app.handle_terminal_key(key(KeyCode::Char(c), KeyModifiers::NONE));
     }
     app.handle_terminal_key(key(KeyCode::Enter, KeyModifiers::NONE));
-    let mut waited = 0u32;
-    while !app
-        .terminals
-        .iter()
-        .all(|t| t.grid_lines().0.iter().any(|l| l.contains("got-hi")))
-    {
-        assert!(waited < 8000, "broadcast input never reached every pane");
-        std::thread::sleep(std::time::Duration::from_millis(40));
-        waited += 40;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the broadcast input to reach every pane",
+        || {
+            app.terminals
+                .iter()
+                .all(|t| t.grid_lines().0.iter().any(|l| l.contains("got-hi")))
+        },
+    );
 
     // Cmd+K Shift+I toggles the active pane out of the broadcast set.
     assert!(app.handle_cmd_k_chord(key(KeyCode::Char('I'), KeyModifiers::SHIFT)));
@@ -19000,20 +18998,17 @@ fn bare_f10_reaches_the_shell_when_terminal_is_focused_with_no_debug_session() {
     .unwrap();
     app.focus_pane(Pane::Terminal);
     let _ = app.handle_key(key(KeyCode::F(10), KeyModifiers::NONE));
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("^[[21~"))
-    {
-        assert!(
-            waited < 4000,
-            "F10 was swallowed instead of being forwarded to the PTY"
-        );
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "F10 to reach the PTY rather than being swallowed",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("^[[21~"))
+        },
+    );
 }
 
 #[test]
@@ -26160,17 +26155,17 @@ fn copy_mode_navigates_scrollback_with_vi_keys_and_copies_char_line_and_block() 
     )
     .unwrap();
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("ccc3"))
-    {
-        assert!(waited < 8000, "pane output never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the pane output \"ccc3\"",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("ccc3"))
+        },
+    );
     let enter_copy_mode = key(
         KeyCode::Char('y'),
         KeyModifiers::CONTROL | KeyModifiers::SHIFT,
@@ -26400,17 +26395,17 @@ fn finished_commands_land_in_durable_history_and_the_popup_types_them() {
         "Enter closes the popup"
     );
     app.terminals[0].write_input(b"\n");
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("typed-kubectl get pods"))
-    {
-        assert!(waited < 8000, "typed command never reached the shell");
-        std::thread::sleep(std::time::Duration::from_millis(40));
-        waited += 40;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the typed command to reach the shell",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("typed-kubectl get pods"))
+        },
+    );
 }
 
 #[test]
@@ -27349,12 +27344,11 @@ fn osc_9_4_progress_paints_a_border_gauge_and_pill_percent() {
         .unwrap(),
     );
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while app.terminals[0].progress() != Some((1, 46)) {
-        assert!(waited < 8000, "progress report never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the 1-of-46 progress report",
+        || app.terminals[0].progress() == Some((1, 46)),
+    );
 
     let backend = ratatui::backend::TestBackend::new(140, 50);
     let mut term = ratatui::Terminal::new(backend).unwrap();
@@ -27396,12 +27390,11 @@ fn osc_9_4_progress_paints_a_border_gauge_and_pill_percent() {
 
     // State 0 clears: the gauge and the pill percent both vanish.
     app.terminals[0].write_input(b"\n");
-    let mut waited = 0u32;
-    while app.terminals[0].progress().is_some() {
-        assert!(waited < 8000, "state 0 never cleared the progress");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "state 0 to clear the progress",
+        || app.terminals[0].progress().is_none(),
+    );
     term.draw(|f| app.render(f)).unwrap();
     let rows = screen_rows(&term);
     let border_row = &rows[(area.y + area.height - 1) as usize];
@@ -27431,17 +27424,17 @@ fn cmd_k_d_dumps_the_pane_scrollback_into_a_rendered_log_tab() {
     app.terminals[0].set_manual_name(Some(String::from("bldlog")));
     app.scrollback_dir = tmp.path().join("dumps");
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("scrollback-payload-7"))
-    {
-        assert!(waited < 8000, "pane output never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the pane output \"scrollback-payload-7\"",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("scrollback-payload-7"))
+        },
+    );
 
     assert!(app.handle_cmd_k_chord(key(KeyCode::Char('d'), KeyModifiers::NONE)));
     assert!(
@@ -28248,17 +28241,17 @@ fn timestamps_gutter_toggles_on_and_shows_arrival_times() {
     )
     .unwrap();
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.starts_with("gutter-row-9"))
-    {
-        assert!(waited < 8000, "pane output never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the pane output \"gutter-row-9\"",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.starts_with("gutter-row-9"))
+        },
+    );
     fn screen_rows(term: &ratatui::Terminal<ratatui::backend::TestBackend>) -> Vec<String> {
         let buf = term.backend().buffer();
         (0..buf.area.height)
@@ -28331,12 +28324,11 @@ fn sticky_command_header_pins_the_command_while_scrolled_into_its_output() {
     )
     .unwrap();
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while app.terminals[0].command_decorations().is_empty() {
-        assert!(waited < 8000, "the command never finished");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the command to finish",
+        || !app.terminals[0].command_decorations().is_empty(),
+    );
     fn screen_rows(term: &ratatui::Terminal<ratatui::backend::TestBackend>) -> Vec<String> {
         let buf = term.backend().buffer();
         (0..buf.area.height)
@@ -28492,17 +28484,17 @@ fn a_plain_click_on_the_prompt_row_moves_the_shell_cursor() {
     )
     .unwrap();
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("hello-world"))
-    {
-        assert!(waited < 8000, "prompt text never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the prompt text",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("hello-world"))
+        },
+    );
     let backend = ratatui::backend::TestBackend::new(120, 40);
     let mut term = ratatui::Terminal::new(backend).unwrap();
     term.draw(|f| app.render(f)).unwrap();
@@ -28561,17 +28553,17 @@ fn arrow_keys_reach_an_app_cursor_mode_child_as_ss3() {
     )
     .unwrap();
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.contains("READY_MARK"))
-    {
-        assert!(waited < 8000, "the child never turned on app cursor mode");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the child to turn on app cursor mode",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.contains("READY_MARK"))
+        },
+    );
     for code in [
         KeyCode::Up,
         KeyCode::Down,
@@ -28635,16 +28627,15 @@ fn broadcast_arrows_encode_per_pane_cursor_mode() {
     app.active_terminal = 0;
     app.broadcast_input = true;
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while !app
-        .terminals
-        .iter()
-        .all(|t| t.grid_lines().0.iter().any(|l| l.contains("READY_MARK")))
-    {
-        assert!(waited < 8000, "the children never reached their prompts");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the children to reach their prompts",
+        || {
+            app.terminals
+                .iter()
+                .all(|t| t.grid_lines().0.iter().any(|l| l.contains("READY_MARK")))
+        },
+    );
     app.handle_terminal_key(key(KeyCode::Up, KeyModifiers::NONE));
     let mut waited = 0u32;
     loop {
@@ -28675,17 +28666,17 @@ fn cmd_k_n_annotates_the_selection_and_a_click_shows_the_note() {
     )
     .unwrap();
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while !app.terminals[0]
-        .grid_lines()
-        .0
-        .iter()
-        .any(|l| l.starts_with("mark-this-output"))
-    {
-        assert!(waited < 8000, "output never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the pane output \"mark-this-output\"",
+        || {
+            app.terminals[0]
+                .grid_lines()
+                .0
+                .iter()
+                .any(|l| l.starts_with("mark-this-output"))
+        },
+    );
     let backend = ratatui::backend::TestBackend::new(120, 40);
     let mut term = ratatui::Terminal::new(backend).unwrap();
     term.draw(|f| app.render(f)).unwrap();
@@ -28822,12 +28813,11 @@ fn host_accent_rules_dress_matching_panes() {
         .unwrap(),
     );
     app.focus_pane(Pane::Terminal);
-    let mut waited = 0u32;
-    while app.terminals[0].shell_host().as_deref() != Some("prod-db-1") {
-        assert!(waited < 8000, "the OSC 7 host never arrived");
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        waited += 20;
-    }
+    crate::test_budget::await_spawned(
+        crate::test_budget::tests::SHELL_PAINT_BASE,
+        "the OSC 7 host",
+        || app.terminals[0].shell_host().as_deref() == Some("prod-db-1"),
+    );
     let backend = ratatui::backend::TestBackend::new(140, 40);
     let mut term = ratatui::Terminal::new(backend).unwrap();
     term.draw(|f| app.render(f)).unwrap();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3698,7 +3698,7 @@ fn ctrl_shift_space_quick_select_labels_matches_and_a_label_commits() {
     // header-only viewport and the hint set is timing-dependent.
     crate::test_budget::await_spawned(
         crate::test_budget::tests::SHELL_PAINT_BASE,
-        "both copies of the pasted hash",
+        "the hash on its own echoed row as well as in the run-label header",
         || {
             app.terminals[0]
                 .grid_lines()
@@ -3952,7 +3952,7 @@ fn quick_select_paints_gold_labels_and_broadcast_paints_modal_and_pills() {
     .unwrap();
     crate::test_budget::await_spawned(
         crate::test_budget::tests::SHELL_PAINT_BASE,
-        "both copies of the pasted URL",
+        "the URL on its own echoed row as well as in the run-label header",
         || {
             app.terminals[0]
                 .grid_lines()

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -270,20 +270,29 @@ pub(crate) mod tests {
     /// and merely starved -- the case a load-scaled budget exists for.
     pub(crate) const TERMINAL_PROBE_BASE: Duration = Duration::from_millis(3750);
 
-    /// The base for waiting on a real shell to PAINT something into the grid
-    /// (#397): the linked cell of an OSC 8 hyperlink, a marker line from the
-    /// shell's main loop.
+    /// The base for waiting on a real shell to PAINT something into a pane
+    /// (#397): a grid line, a decoration or prompt mark, an inline image, an
+    /// OSC-reported host or progress state.
     ///
     /// Separate from `TERMINAL_PROBE_BASE` because the two replaced
     /// different constants — 15s there, 8000ms here — and the house rule is
     /// that each base reproduces its own at the floor, which one number
     /// cannot do for both. The operation they wait on is the same.
     ///
-    /// Two of the three call sites reproduce their old 8000ms exactly. The
-    /// third, the re-root test's foreground poll, is a deliberate RAISE from
-    /// 4000ms: that loop never asserted on timeout, so its number was never
-    /// a deadline the test could fail on, and matching it would have left
-    /// the shorter of two waits on one shell inside the same test.
+    /// The rule, rather than a list that goes stale with every batch of
+    /// conversions: every call site reproduces the 8000ms it replaced, and
+    /// the rest are deliberate RAISES from a 4000ms bound. Each of those sat
+    /// on a shell that other waits in the same suite already gave 8000ms, so
+    /// the short bound was an accident of where it was written rather than a
+    /// measured deadline — and one of them, the re-root test's foreground
+    /// poll, never asserted on timeout at all, so its number could not fail
+    /// a test in the first place.
+    ///
+    /// Nothing here is ever CUT: a raise cannot introduce a flake, and the
+    /// floor assertion below guards the direction that can. That assertion
+    /// checks the constant, not its call sites, so converting a wait whose
+    /// old bound EXCEEDED 8000ms would need its own base rather than this
+    /// one — none exists today, and this is the note that says why.
     ///
     /// 2s because `BASE_CALIBRATION * MIN_SCALE` is 4 at the floor, so the
     /// call sites keep the 8000ms they had on a quiet machine and get up to
@@ -461,10 +470,9 @@ pub(crate) mod tests {
         let paint = SHELL_PAINT_BASE * BASE_CALIBRATION * MIN_SCALE;
         assert!(
             paint >= Duration::from_millis(8000),
-            "the shell-paint base must reproduce at the floor the largest \
-             constant its call sites replaced - 8000ms, at two of the three; \
-             the re-root test's second wait was a 4000ms loop that never \
-             asserted on timeout, so it is deliberately raised - got {paint:?}"
+            "the shell-paint base must reproduce 8000ms at the floor, the \
+             constant its call sites replaced; the few that replaced 4000ms \
+             are deliberate raises, named in the doc above - got {paint:?}"
         );
     }
 

--- a/src/test_budget.rs
+++ b/src/test_budget.rs
@@ -292,7 +292,8 @@ pub(crate) mod tests {
     /// floor assertion below guards the direction that can. That assertion
     /// checks the constant, not its call sites, so converting a wait whose
     /// old bound EXCEEDED 8000ms would need its own base rather than this
-    /// one — none exists today, and this is the note that says why.
+    /// one — no such call site exists among these, and this is the note
+    /// that says why.
     ///
     /// 2s because `BASE_CALIBRATION * MIN_SCALE` is 4 at the floor, so the
     /// call sites keep the 8000ms they had on a quiet machine and get up to


### PR DESCRIPTION
## Summary

Part of #397, the first batch of the residual #501 named: 30 hand-rolled `waited < N` loops still in `src/app/tests.rs`.

This converts the 20 that already assert on timeout. Each waits on a real shell to produce something into a pane — a shell-integration decoration mark, an inline image, a broadcast line reaching every pane, a progress report, an OSC 7 host — which is the operation `SHELL_PAINT_BASE` already covers. Each keeps the budget it had at the floor and now stretches under load instead of failing on a busy box.

**Scope, deliberately narrow.** All 20 already asserted on timeout, so this is a conversion and not a change of teeth. The loops that instead `break` silently, and the ones doing work inside the body (pumping `drain_terminal_bells`, or asserting on intermediate state), are left for a later batch: each of those is a judgement about that test's operation rather than a rewrite, and mixing them in would hide the mechanical change among the interesting ones.

**Five raises, recorded as a rule.** Fifteen sites replaced 8000ms exactly; five replaced 4000ms and so are raises. `SHELL_PAINT_BASE`'s doc now states the rule — every call site reproduces its 8000ms, the rest are raises from 4000ms — rather than naming them, since a list needs an edit per batch and that is exactly the staleness the rule replaces. The doc also records that a wait whose old bound *exceeded* 8000ms would need its own base, since the floor assertion checks the constant rather than its call sites. A raise cannot introduce a flake; the assertion guards the direction that can.

**Predicates.** The rewrite was mechanical, then hand-polished, so the risk is a negation that silently weakens a wait: a test that still passes but no longer waits for what it did. Each closure is the exact negation of the loop condition it replaces, including the two compound conditions where de Morgan was applied by hand (`!(a || !b)` → `!a && b`), which still refuse to return true on a half-arrived condition, and two `count() < 2` conditions that became `count() >= 2`. Each description names what is awaited rather than restating the old failure text, since `await_spawned` renders it as "waiting for {what}", and names the sentinel it waits on where four sites would otherwise read identically.

## Tests

All 20 converted tests pass, as do the 12 `test_budget::` tests. Clippy with `-D warnings`, the doc-ownership gate and `ships_nothing.py` are clean.

## No version bump

Test-only: the diff touches `src/app/tests.rs` and the `#[cfg(test)]` module of `src/test_budget.rs`, so the shipped binary is unchanged and `scripts/ships_nothing.py` exits 0. Same as #501 and #489 before it.

10 `waited < N` bounds remain (8 at 8000, 2 at 4000), so the issue stays open.

Part of #397
