### PR TITLE
docs(remote): explain the declined background update

### DIFF
--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -55,20 +55,11 @@ The **launching** machine needs `rsync` on its `PATH` — croft uses it to sync 
 
 Only the very first connect (no croft on the box yet) waits for an install. Every later connect attaches to the installed croft immediately: when your local source is newer, the cross-build and ship run in the background while you work, and the running session offers `F9` to reload into the new binary once it lands. Background self-updates use a dedicated throttled SSH lane so install bytes never queue ahead of live keystrokes, keeping input latency at zero even while a newer binary streams in.
 
-#### "Background croft update failed; staying on current version"
+### "Background croft update failed; staying on current version"
 
-A background update declines itself, rather than failing, when you are
-already attached to the remote croft and the fast cross-build path is not
-available. Both halves have to be true, and the outcome is deliberate: the
-only route left is a `cargo install` on the box itself, and starting an
-unrequested compile on the machine you are actively typing into would spend
-its cores and disk on a build nobody asked for. So croft declines, clears
-the `updating` marker, and leaves you on the running binary. Nothing is
-broken and nothing is half-installed; the update simply did not happen.
+A background update declines itself, rather than failing, when you are already attached to the remote croft and the fast cross-build path is not available. Both halves have to be true, and the outcome is deliberate: the only route left is a from-source compile on the box itself, and starting an unrequested build on the machine you are actively typing into would spend its cores and disk on work nobody asked for. So croft declines, clears the `updating` marker, and leaves you on the running binary. Nothing is broken and nothing is half-installed; the update simply did not happen.
 
-The status line is deliberately short, and the reason is written to the
-install log on the **launching** machine — the Mac or laptop you connected
-*from*, not the server named in the message:
+The status line is deliberately short, and the reason is written to the install log on the **launching** machine — the Mac or laptop you connected *from*, not the server named in the message:
 
 ```bash
 tail ~/.cache/croft/install.log
@@ -81,26 +72,16 @@ Local cross-build skipped: rustup target `x86_64-unknown-linux-musl` missing
 Update NOT installed: cross-build unavailable (...)
 ```
 
-The cause is usually a missing prerequisite for the cross-build: the musl
-target, `cargo-zigbuild`, or `zig`. Note that `rustup` targets are
-per-toolchain and this repo pins its channel in `rust-toolchain.toml`, so
-`rustup target list --installed` only answers for the pinned toolchain when
-run from a croft checkout, and a channel bump orphans every target you had
-added. Installing the prerequisites is one command on the launching
-machine:
+The cause is a missing prerequisite for the cross-build: `zig`, `cargo-zigbuild`, or one of the musl rustup targets. Note that rustup targets are per-toolchain and this repo pins its channel in `rust-toolchain.toml`, so `rustup target list --installed` only answers for the pinned toolchain when run from a croft checkout, and a channel bump orphans every target you had added. Install all three prerequisites on the launching machine with:
 
 ```bash
-croft setup-cross
+croft setup-cross          # prints a plan, then asks to confirm
+croft setup-cross --yes    # skip the prompt (scripts, unattended runs)
 ```
 
-It is idempotent, and it runs its `rustup` queries from the checkout so the
-pinned toolchain is the one it inspects. Then **reconnect** — the declined
-update is not retried on the existing session, so a fixed toolchain only
-takes effect on the next connect.
+It is idempotent (each already-present piece is reported and skipped), and it runs its rustup queries from the checkout so the pinned toolchain is the one it inspects. Answering anything but `y` prints `Aborted.` and exits 0 without changing anything, so check the output rather than the exit code. Then **reconnect** — the declined update is not retried on the existing session, so a fixed toolchain only takes effect on the next connect.
 
-Connecting with the dialog still up (no session attached yet) instead asks
-whether to fall back to compiling on the host, since at that point there is
-no live session to disturb.
+Connecting with the dialog still up (no session attached yet) instead asks whether to fall back to compiling on the host, since at that point there is no live session to disturb.
 
 ### Surviving sleep and network drops
 

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -57,31 +57,31 @@ Only the very first connect (no croft on the box yet) waits for an install. Ever
 
 ### "Background croft update failed; staying on current version"
 
-A background update declines itself, rather than failing, when you are already attached to the remote croft and the fast cross-build path is not available. Both halves have to be true, and the outcome is deliberate: the only route left is a from-source compile on the box itself, and starting an unrequested build on the machine you are actively typing into would spend its cores and disk on work nobody asked for. So croft declines, clears the `updating` marker, and leaves you on the running binary. Nothing is broken and nothing is half-installed; the update simply did not happen.
+This is a refusal, not a crash. It happens when you are already attached to the remote croft *and* the fast cross-build path is unavailable. The only route left would be compiling on the box you are typing into, so croft declines rather than spend its cores on an unrequested build. You stay on the running binary; nothing is half-installed.
 
-The status line is deliberately short, and the reason is written to the install log on the **launching** machine — the Mac or laptop you connected *from*, not the server named in the message:
+The reason is logged on the **launching** machine — the one you connected *from*, not the server in the message:
 
 ```bash
 tail ~/.cache/croft/install.log
 ```
 
-The line to look for names the missing piece:
+Look for the missing piece:
 
 ```
 Local cross-build skipped: rustup target `x86_64-unknown-linux-musl` missing
 Update NOT installed: cross-build unavailable (...)
 ```
 
-The cause is a missing prerequisite for the cross-build: `zig`, `cargo-zigbuild`, or one of the musl rustup targets. Note that rustup targets are per-toolchain and this repo pins its channel in `rust-toolchain.toml`, so `rustup target list --installed` only answers for the pinned toolchain when run from a croft checkout, and a channel bump orphans every target you had added. Install all three prerequisites on the launching machine with:
+The prerequisites are `zig`, `cargo-zigbuild`, and the musl rustup targets. Install them on the launching machine:
 
 ```bash
 croft setup-cross          # prints a plan, then asks to confirm
-croft setup-cross --yes    # skip the prompt (scripts, unattended runs)
+croft setup-cross --yes    # skip the prompt
 ```
 
-It is idempotent (each already-present piece is reported and skipped), and it runs its rustup queries from the checkout so the pinned toolchain is the one it inspects. Answering anything but `y` prints `Aborted.` and exits 0 without changing anything, so check the output rather than the exit code. Then **reconnect** — the declined update is not retried on the existing session, so a fixed toolchain only takes effect on the next connect.
+It is idempotent and reports what it skips. Answering anything but `y` prints `Aborted.` and exits 0, so read the output rather than the exit code. Then **reconnect** — a declined update is not retried on the running session.
 
-Connecting with the dialog still up (no session attached yet) instead asks whether to fall back to compiling on the host, since at that point there is no live session to disturb.
+Two things that catch people out. Rustup targets are per-toolchain, and this repo pins its channel in `rust-toolchain.toml`, so `rustup target list --installed` only answers for the pinned toolchain when run from a croft checkout; a channel bump orphans every target you added. And connecting with the dialog still up — no session attached — asks whether to compile on the host instead, since there is no live session to disturb.
 
 ### Surviving sleep and network drops
 

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -55,6 +55,53 @@ The **launching** machine needs `rsync` on its `PATH` — croft uses it to sync 
 
 Only the very first connect (no croft on the box yet) waits for an install. Every later connect attaches to the installed croft immediately: when your local source is newer, the cross-build and ship run in the background while you work, and the running session offers `F9` to reload into the new binary once it lands. Background self-updates use a dedicated throttled SSH lane so install bytes never queue ahead of live keystrokes, keeping input latency at zero even while a newer binary streams in.
 
+#### "Background croft update failed; staying on current version"
+
+A background update declines itself, rather than failing, when you are
+already attached to the remote croft and the fast cross-build path is not
+available. Both halves have to be true, and the outcome is deliberate: the
+only route left is a `cargo install` on the box itself, and starting an
+unrequested compile on the machine you are actively typing into would spend
+its cores and disk on a build nobody asked for. So croft declines, clears
+the `updating` marker, and leaves you on the running binary. Nothing is
+broken and nothing is half-installed; the update simply did not happen.
+
+The status line is deliberately short, and the reason is written to the
+install log on the **launching** machine — the Mac or laptop you connected
+*from*, not the server named in the message:
+
+```bash
+tail ~/.cache/croft/install.log
+```
+
+The line to look for names the missing piece:
+
+```
+Local cross-build skipped: rustup target `x86_64-unknown-linux-musl` missing
+Update NOT installed: cross-build unavailable (...)
+```
+
+The cause is usually a missing prerequisite for the cross-build: the musl
+target, `cargo-zigbuild`, or `zig`. Note that `rustup` targets are
+per-toolchain and this repo pins its channel in `rust-toolchain.toml`, so
+`rustup target list --installed` only answers for the pinned toolchain when
+run from a croft checkout, and a channel bump orphans every target you had
+added. Installing the prerequisites is one command on the launching
+machine:
+
+```bash
+croft setup-cross
+```
+
+It is idempotent, and it runs its `rustup` queries from the checkout so the
+pinned toolchain is the one it inspects. Then **reconnect** — the declined
+update is not retried on the existing session, so a fixed toolchain only
+takes effect on the next connect.
+
+Connecting with the dialog still up (no session attached yet) instead asks
+whether to fall back to compiling on the host, since at that point there is
+no live session to disturb.
+
 ### Surviving sleep and network drops
 
 A remote session is launched under [`dtach`](https://github.com/crigler/dtach), so closing your laptop or changing networks no longer kills it. When the SSH transport dies (its keepalive gives up after ~30s of no response), the croft process keeps running on the host inside its dtach session; croft auto-reconnects (showing `Reconnecting to <host>…`, Ctrl+C to stop) and reattaches with your tabs, layout, and terminals intact.


### PR DESCRIPTION
## Why

A user hit `Background croft update failed; staying on current version` in the status bar of a remote session and asked why. Nothing in the docs covered it, and the message is the hardest of the three update-failure messages to diagnose:

- It is the only one of the three (`Staged`, `SelfInstall`, `Watch`) that names **no log path** — the other two print theirs.
- The reason lands in the **launching** machine's `~/.cache/croft/install.log`, while the user is looking at a *remote* session on another host. So the natural place to look is the wrong one.
- The wording reads like a crash, but it is a deliberate refusal: with the fast cross-build path unavailable and a session already attached, the only route left is a from-source compile on the box the user is typing into, so `install_only_streaming_over`'s `present` gate declines it rather than loading their live session.

## What

One new `###` subsection in `docs/LINUX.md`, under the existing `## Remote: croft remote <host>` section: what the message means, why it is a refusal rather than a failure, where the reason is actually written, the prerequisites to install, and that a **reconnect** is required afterwards (the declined update is not retried on the running session).

Docs-only — no shipped change, so the release-hygiene gate's docs exemption applies.

## Verification

Every technical claim was checked against the source rather than inferred:

| Claim | Source |
| --- | --- |
| Refusal needs `present` **and** no cross-build | `src/remote.rs:376-387` |
| `clear_remote_updating` → marker vanishes → `Failed` → this string | `src/remote.rs:388-391`, `src/update_watch.rs:378-389`, `src/app/mod.rs:26208` |
| Log path resolves against the **local** `HOME` | `src/remote.rs:429-434` |
| `setup-cross` installs zig + cargo-zigbuild + targets, queries from the checkout | `src/cli.rs:1361-1386`, `1448-1474` |
| Not retried; reconnect required | `spawn_background_install` called once, `src/remote.rs:822` |
| Prerequisites named are the ones probed | `src/remote.rs:698`, `1838-1839` |

Both quoted log lines are verbatim against their `format!` strings.

Two corrections were made during review. An earlier draft called a toolchain bump "the usual cause" — inferred from a code comment, not evidence — and it now names the three prerequisites the code actually probes. The draft also called `setup-cross` "one command", but it prints a plan and blocks on `[y/N]`, and anything but `y` prints `Aborted.` and **exits 0**; following the doc unattended would have been a silent no-op, so the prompt, `--yes`, and "check the output not the exit code" are documented.