### PR TITLE
docs(remote): quote the log lines as croft actually writes them

### DIFF
--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -59,20 +59,20 @@ Only the very first connect (no croft on the box yet) waits for an install. Ever
 
 This is a refusal, not a crash. It happens when you are already attached to the remote croft *and* the fast cross-build path is unavailable. The only route left would be compiling on the box you are typing into, so croft declines rather than spend its cores on an unrequested build. You stay on the running binary; nothing is half-installed.
 
-The reason is logged on the **launching** machine — the one you connected *from*, not the server in the message:
+The reason is logged on the **launching** machine — the one you connected *from*, not the server in the message. Read it **before** reconnecting: each connect truncates the file.
 
 ```bash
 tail ~/.cache/croft/install.log
 ```
 
-Look for the missing piece:
+Look for the missing piece. Every line carries a Unix timestamp:
 
 ```
-Local cross-build skipped: rustup target `x86_64-unknown-linux-musl` missing
-Update NOT installed: cross-build unavailable (...)
+[1788730108] Local cross-build skipped: rustup target `x86_64-unknown-linux-musl` missing (run `rustup target add x86_64-unknown-linux-musl` once to enable the fast path)
+[1788730108] Update NOT installed: cross-build unavailable (rustup target `x86_64-unknown-linux-musl` missing (…)). Run `croft setup-cross` on this machine, then reconnect — updates then ship a prebuilt binary in seconds.
 ```
 
-The prerequisites are `zig`, `cargo-zigbuild`, and the musl rustup targets. Install them on the launching machine:
+The prerequisites are `zig`, `cargo-zigbuild`, and both musl rustup targets (`x86_64-` and `aarch64-unknown-linux-musl`). Install them on the launching machine:
 
 ```bash
 croft setup-cross          # prints a plan, then asks to confirm
@@ -81,7 +81,7 @@ croft setup-cross --yes    # skip the prompt
 
 It is idempotent and reports what it skips. Answering anything but `y` prints `Aborted.` and exits 0, so read the output rather than the exit code. Then **reconnect** — a declined update is not retried on the running session.
 
-Two things that catch people out. Rustup targets are per-toolchain, and this repo pins its channel in `rust-toolchain.toml`, so `rustup target list --installed` only answers for the pinned toolchain when run from a croft checkout; a channel bump orphans every target you added. And connecting with the dialog still up — no session attached — asks whether to compile on the host instead, since there is no live session to disturb.
+Two things catch people out. Rustup targets are per-toolchain, and this repo pins its channel in `rust-toolchain.toml`, so `rustup target list --installed` only answers for the pinned toolchain when run from a croft checkout; a channel bump orphans every target you added. And connecting with the dialog still up — no session attached — asks whether to compile on the host instead, since there is no live session to disturb.
 
 ### Surviving sleep and network drops
 


### PR DESCRIPTION
Follow-up to #505, which merged before these fixes landed.

The fallback review on #505 ([comment](https://github.com/vitali87/croft/pull/505#issuecomment-5562773057)) returned REQUEST_CHANGES with two majors. #505 was merged at `1f25e2d` while the fix commit was still on the branch, so `main` currently carries the defect.

## The two majors

Both quoted log lines were truncated versions of what croft actually writes — in a section that tells the reader to search the log for them.

**First line.** `src/remote.rs:697-700` composes the reason as ``rustup target `{triple}` missing (run `rustup target add {triple}` once to enable the fast path)`` and logs `Local cross-build skipped: {reason}`. The doc dropped the parenthetical, which names the one-command fix the log itself offers.

**Second line.** `src/remote.rs:380-382` writes the reason followed by `Run \`croft setup-cross\` on this machine, then reconnect — updates then ship a prebuilt binary in seconds.` The doc replaced both with a literal `(...)` — the diagnostic value and the remedy, elided.

A reader following the instruction to search for these lines would have failed to find either.

## Also fixed

- **Timestamp prefix.** Every line in that file is written as `[{secs}] {line}` (`spawn_log_tee`, `src/remote.rs:419`), so the quoted block matched nothing a reader sees. Verified against a real `install.log` on the launching machine.
- **Read it before reconnecting.** `install.log` is opened with `File::create` (`src/remote.rs:411`), so it is truncated on every connect — and the section's own advice ("Then reconnect") would have destroyed the evidence first.
- Both musl targets named, since `setup-cross` installs the pair (`CROSS_TARGETS`, `src/cli.rs:1358`) while the quoted line names only x86_64.

Docs-only: exempt from the release gate, whose `shipped` filter selects only `src/`, `assets/`, `build.rs` and the Cargo files.