### PR TITLE
docs: restore the module reasoning and the content gate that main is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,16 @@ jobs:
           set -euo pipefail
           base="$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)"
           python3 scripts/check_doc_ownership.py "$base" HEAD
+      # ARCHITECTURE.md's tree carries the reasons behind each module, and a
+      # rewrite can cut a line's rationale away while the row and its
+      # identifiers survive - which is what a row-level or identifier-level
+      # check sees as a pass. This one compares per-module description
+      # length and asks for a `### <module>` section wherever one shrank.
+      - name: No module may lose its reasoning
+        run: |
+          set -euo pipefail
+          base="$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)"
+          python3 scripts/check_arch_content.py "$base"
 
   test:
     name: clippy + tests

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -291,7 +291,7 @@ A tree-sitter highlighted editor with a full write path, mouse-drag selection, n
 
 **Breadcrumbs and sticky scroll.** `EditorTabs` renders both. App pushes `breadcrumbs` and `sticky_lines` each frame from the outline scope chain, and `breadcrumb_target_at` / `sticky_line_at` map clicks to jumps. Crumbs are budgeted and advanced in display CELLS via `set_stringn`, so a CJK segment is neither overpainted by the next crumb nor mis-hit. The sticky band floats over content but stops above the caret's PAINTED row, read back out of the frame's own row layout so a collapsed fold or comment box between the top and the caret cannot make the band overshoot. A caret under the band cannot be painted at all, so `caret_floor_row` keeps the scroll from parking it there in the first place — dragging it to the first row the band does not cover, instead of to `scroll`, which had suppressed the band for the whole of a wheel scroll.
 
-### remote.rs
+### src/remote.rs
 
 Remote (SSH) target metadata and launch dispatch, plus the ssh-pane re-root offer.
 
@@ -834,7 +834,7 @@ The curated MCP catalog, the AVAILABLE tier of the Extensions panel. Bundled `CA
 
 **Destructive actions need confirmation.** Add goes through the panel's +Add. Remove goes through the trash button or Delete, and both open a confirmation popup (`InputPurpose::ExtensionUninstall`, Enter uninstalls, Esc keeps), so a destructive action never fires from a single click or keypress.
 
-### client.rs
+### lsp/client.rs
 
 The async-lsp client wrapper. Its router forwards diagnostics and work-done progress (`$/progress`, for example rust-analyzer's "Indexing…") to the status bar, and acknowledges workspace refresh requests (`semanticTokens/refresh`, `inlayHint/refresh`) into shared re-pull flags the app polls.
 
@@ -1036,13 +1036,19 @@ The Run and Debug sidebar widget: an empty-state Run [filename] button, and when
 
 **Row mechanics.** A rejected expression renders `<not available>`, the `success:false` branch of `DapEvent::Evaluated`. Rows carry a right-edge remove `✕` with hit rects cleared per render, and the trailing "+ Add Expression" row and the palette's "Debug: Add Watch Expression" both open the input popup.
 
-### session.rs
+### dap/session.rs
 
 One launch session: the initialize -> setBreakpoints -> configurationDone -> stopped state machine, the event classifier, the stackTrace -> scopes -> variables inspection chain, `evaluate` (REPL, hover, watch), breakpoint-verification tracking, pause and reverse-request replies — all over one adapter-agnostic `launch_with`.
 
 **Conditional breakpoints and logpoints.** `SourceBreakpoint` carries `condition` and `log_message`. A logpoint's message is interpolated and printed by the adapter instead of pausing; it is set with Shift+Alt+F9 or the gutter menu and shows as an amber diamond in the gutter.
 
 **No vendored protocol types.** Requests are built from `Value`-based builders, and `AdapterKind` names the launch mechanisms.
+
+### src/session.rs
+
+Local session persistence. `croft attach` and `croft ls` run croft under the session host (`session_host.rs`) so terminals, LSP and DAP survive closing the window. Live legacy dtach sessions keep reattaching through dtach.
+
+**`ls` skips the collab relay socket.** The workspace's `<hash>.collab.sock` shares the directory and the keying but is not a session, so listing it printed a phantom row. Pruning it belongs to the relay's own bind path, not here.
 
 ### svg.rs
 
@@ -1094,6 +1100,184 @@ The navigator's local-model transport: one minimal Anthropic-compatible `/v1/mes
 
 **Keyed gateways.** `ANTHROPIC_AUTH_TOKEN` is read from the environment; a token is never persisted.
 
+
+### agent_lane.rs
+
+A per-agent ledger of the files an agent changed while you were looking elsewhere. While a pane's agent is `Working`, every workspace content event is attributed to it.
+
+**Each row carries a review baseline.** The baseline is an FNV-1a content hash taken at the last "mark reviewed", so a row leaves the queue only once its content has actually been seen. Reviewing is not dismissing.
+
+**Concurrent writes are attributed, not guessed.** A write while two agents work is attributed to BOTH and flagged `shared`. A write with no agent working belongs to the user and never enters a lane.
+
+### dap/reaper.rs
+
+Sweeps orphaned vscode-js-debug processes left behind when croft crashes or force-quits without running `Drop` — both the server and its detached watchdog, which setsids into its own session and so survives a group-kill. It runs async at startup and after each session teardown.
+
+**It kills only scripts under `~/.croft/js-debug` that have been reparented to init (pid 1).** That restriction is what keeps a live session from ever being touched.
+
+### dap/registry.rs
+
+A data-driven debug-adapter registry. It maps a file extension to an `AdapterKind` using the `[[debug_adapters]]` blocks in the bundled and user manifests, and skips adapters whose extension is disabled in the Extensions panel.
+
+**Manifest data replaced a hardcoded match.** It supersedes the old `adapter_for_extension` match, but only the mapping is data-driven: the launch mechanisms themselves stay native, like the PDF/CSV viewers.
+
+### docx.rs
+
+A read-only preview for docx and odt. Both are zip+XML, so the walker emits markdown — headings from styles and outline levels, bold/italic runs, list items, tables as pipe rows, and embedded pictures extracted hash-named into scratch — which the proven markdown builder then renders, reusing its styling, wrap, and inline-image overlay.
+
+**The preview stores its `doc_path`** so a theme switch can re-walk the file.
+
+**The text side is a stub.** Reopen as Text routes the zip container onward to the archive browser, and then to hex.
+
+**Structure fidelity, not layout**, with a 50MB source cap.
+
+### history.rs
+
+Local history: per-save snapshots under `~/.config/croft/history`, FNV-keyed with legacy-key migration, stored as raw bytes so any encoding round-trips, deduped and capped. It merges into the Explorer TIMELINE beside git commits (out-of-root files list snapshots only) and backs snapshot diff and restore. Recording runs off the render thread.
+
+**Saves inside a 10s merge window replace the newest entry**, the way VS Code's mergeWindow does.
+
+**A `<millis>.seats` JSON sidecar records who typed each line.** It is written and removed with its snapshot, and read back onto an unchanged file.
+
+### iterm2.rs
+
+iTerm2 plist mutation helpers for fonts and Croft key mappings.
+
+**User-keybinding forwarders are tracked in a ledger.** They are recorded in a root-plist ledger (`Croft User Keymap Forwarders`, key to hex) and swept on the next setup run before any inserts, but only while their value is still the exact croft forwarder. That way a chord deleted from `keybindings.json` releases its Cmd chord without destroying an entry the user has since rewired in iTerm2 prefs.
+
+### keymap.rs
+
+User key bindings from `~/.config/croft/keybindings.json`. It parses chord strings (ctrl/alt/shift/cmd/mod + key) into normalized Chords mapped to palette Command ids.
+
+**User chords are consulted at the top of `handle_key`, ahead of the built-in chords** — only off the terminal, and only for modifier/function-key chords.
+
+**The parser is tolerant JSONC** (it strips `//` comments), and it reloads on save.
+
+### lsp/config.rs
+
+Per-language LSP config for basedpyright, ruff, ty, vtsls, rust-analyzer and gopls. The `ServerConfig` factories are the executable spec that the bundled manifests reproduce.
+
+**Language is an open newtype — an interned `lsp_id`, not a closed enum** — so an extension can contribute a new language with no Rust change. Per-language data (extensions, root markers, family) lives in the language table.
+
+### lsp/install.rs
+
+Croft-managed server provisioning: lazy background installs into `~/.croft/servers` through three backends. npm covers vtsls, JSON/HTML/CSS, yaml and bash; uv covers ty and ruff, including the uv bootstrap, and is rerouted to Termux's `pkg` on Android; Binary covers clangd, taplo and rust-analyzer, downloading and unzipping or gunzipping a host-agnostic per-platform release binary, PATH-first including `~/.cargo/bin`.
+
+**A Binary can carry a `termux_pkg`.** On Android the glibc release can't run on bionic, so such a backend reroutes to `pkg`, as rust-analyzer does.
+
+### lsp/semantic_cache.rs
+
+A content-keyed disk cache of semantic-token batches at `~/.croft/sem-cache`.
+
+**Only a batch whose `seq` still matches the live buffer is applied OR stored.** A reply can sit in the request retry backoff while an external tool rewrites the file; decoding it over the new lines would both mis-colour the buffer and persist that result under the NEW content's key, replaying it on every future open.
+
+### mcp/registry.rs
+
+Data-driven MCP registration. `contributed_commands()` does eager palette registration and skips disabled entries; `resolve_command_in_dir()` is lazy, yielding a tool plus a spawnable server with a pinned `Provision`, with the app passing the config dir it carries. Both read the `[[commands]]` and `[[mcp_servers]]` manifests.
+
+**Viewers come from the same manifest path.** `contributed_viewer_commands_in_dir()` and `viewer_for_path_in_dir()` read `[[viewers]]`, which is a terminal program run on a file in its own pane.
+
+### media.rs
+
+An audio/video info view for `.mp3`, `.wav`, `.flac`, `.m4a`, `.mp4`, `.m4v` and `.mov`.
+
+**Pure-Rust header parsers over a bounded head read; streams are never decoded.** The parsers are the WAV fmt chunk, FLAC STREAMINFO, MP3 ID3v2 text tags plus the first MPEG frame with a size-based duration estimate, and an MP4/MOV mvhd + tkhd box walk.
+
+**The card renders as markdown through the preview machinery**, with `doc_path` and media flags driving theme rebuilds. Video gets a hash-named ffmpeg poster frame when the tool exists on PATH, following the pdftoppm optional-tool pattern.
+
+**Junk wearing a media extension falls through to the binary path.**
+
+### notifications.rs
+
+Notification sinks, configured under the `notifications` config key: one delivery worker fed by a bounded queue, pure request builders for ntfy and webhooks, and `termux-notification` and `command` sinks that pass the payload in `CROFT_*` environment variables.
+
+**Events arrive from three sources**: the finished-command drain, the OSC 9 drain, and the Test Explorer's once-per-run failed latch.
+
+### outline_syntax.rs
+
+The tree-sitter outline provider. It extracts the OUTLINE panel's symbol tree — functions, structs, methods, fields and so on — directly from the buffer's syntax tree using hand-written per-language queries.
+
+**Tree-sitter first, LSP second.** The panel paints instantly instead of waiting for a cold language server to answer `documentSymbol`; the LSP reply supersedes the syntax-tree outline when it arrives. This is the same approach Zed and aerial.nvim take. Rust, Python, JS, TS, TSX and Go are covered by queries; other languages fall back to the LSP outline.
+
+### src/output.rs
+
+The in-process OUTPUT bus behind the panel group's OUTPUT tab. It holds named channels — one per language server, plus Debug Adapter, Git, Server Provisioning and Navigator (the resident AI pair programmer's commentary) — each a capped ring buffer of levelled lines.
+
+**Producers push here and mirror to disk.** Code across the codebase writes to the bus while also mirroring to the on-disk `lsp.log`. A generation counter lets the widget re-pull only when something actually changed.
+
+### plot.rs
+
+`croft plot` reads numbers, CSV/TSV or JSON lines on stdin — delimiter and header auto-detected, with `--x`/`--y` picking columns — and draws them as a line, bar, spark or histogram chart.
+
+**Image output, with a text fallback.** An SVG in the theme's colours is rasterised through `svg.rs` and emitted with the previews' inline-image escape. iTerm2/Kitty are detected from the environment; the sixel probe needs a raw tty on stdin, which here is the data pipe. With no image protocol, or with `--text`, the same data renders as braille (line/spark) or block (bar/hist) characters.
+
+**Long series are bucketed to the pixel/dot width.** That keeps 10k rows linear.
+
+### prefs.rs
+
+Durable user preferences — color theme, Customize Layout chrome, format-on-save, auto-save — persisted at `~/.config/croft/config.json`. The searchable "Preferences: Open Settings" hub toggles these and links to the raw JSON.
+
+**`host_accents` dresses terminal panes per host.** Its rules ({pattern glob, accent hex, badge}) are compiled to globset matchers in the App and re-read whenever `config.json` is saved.
+
+### snippets.rs
+
+User snippets loaded from `~/.config/croft/snippets.json` in VS Code format: prefix, body as a string or array, and an optional language scope. It reloads on save.
+
+**`parse_body` turns tab-stop syntax into stops the editor drives.** A body's `$1`/`$0`/`${1:placeholder}` syntax becomes insert text plus ordered stops that the editor walks on Tab.
+
+**Snippets also reach the completion popup.** Matching snippets are injected as `CompletionItem.is_snippet` and expanded on accept — the same path LSP snippet completions take.
+
+### sqlite_view.rs
+
+A read-only SQLite browser. Every table becomes a worksheet in the existing sheet grid, so navigation, the cell cursor and Tab table-switching are all reused. Rows are capped at 500 with the true count shown in the sheet name, and cells are typed (NULL empty, blobs summarised). Files are routed both by extension and by the magic-byte sniff.
+
+**Read-only over the bundled sqlite3.** It opens with `SQLITE_OPEN_READONLY` over the BUNDLED sqlite3, so there is no system dependency, and a live application database is never locked, mutated, or created. Locked or corrupt files surface their error.
+
+### testing/failure_site.rs
+
+Works out where a failing test actually failed. It parses libtest panic lines (both the current and the pre-2023 shapes), pytest traceback frames, and jest/vitest stack frames down to a `file:line`.
+
+**Only locations in the user's own code count.** A location under `.cargo/registry`, `node_modules`, `site-packages` or the standard library is rejected rather than offered, because a breakpoint there fires before the interesting state exists.
+
+**The LAST location in a failure block wins.** Every runner prints outward-in.
+
+### testing/registry.rs
+
+A data-driven test-runner registry. It maps a workspace root to a Runner using the `[[test_runners]]` blocks in the bundled and user manifests, matching on marker files and/or `package.json` (dev)dependency names.
+
+**Manifests replaced a hardcoded ladder.** This supersedes the old hardcoded `runner_for` ladder, and it skips runners whose extension is disabled in the Extensions panel. The run mechanisms — commands, parsers, binary resolution — stay native, like the debug adapters.
+
+### widgets/dependencies.rs
+
+A collapsible, language-aware DEPENDENCIES section, offered as a ⋯-menu Explorer sub-view and display-only. It detects the workspace's package ecosystem(s) from manifest files at the root (`Cargo.toml`→Rust via `cargo metadata`, `pyproject.toml`/`requirements.txt`→Python, `package.json`→Node, `go.mod`→Go), resolves the packages off-thread, and labels the header for what it found ("RUST DEPENDENCIES" and so on).
+
+**Gated on detection.** A folder with no manifest shows no dependency view and drops it from the ⋯ menu. The App holds the detected ecosystems in `dep_ecosystems`, recomputed on every re-root.
+
+### widgets/editor_find.rs
+
+A VS Code-style inline Find bar (Cmd+F) with an active-match orange highlight, Enter / Shift+Enter to walk matches, and case-sensitive / whole-word / regex toggles. The Replace row (Cmd+Opt+F) adds Tab to switch field, Enter to replace-and-advance, and Cmd+Opt+Enter to replace all in one undo step.
+
+**Replace All uses the same enumeration as the display.** It walks matches via the same `split_for_highlight` that the count, paint and navigation use, so it never touches what the bar cannot show, and it recounts afterwards.
+
+**Regex replacements expand `$n` captures** plus VS Code's `\n`/`\t` escapes, where a replacement newline splits the line.
+
+### widgets/history_popup.rs
+
+The Ctrl+Shift+H command-history popup over `command_history.rs`: a query line with a caret, newest-first deduped results (green/red exit dot, plus duration, cwd and non-zero exit meta), and Ctrl+R to cycle the scope filter.
+
+**A pure widget.** The App runs the search on each edit and types the pick via `paste_input`.
+
+### widgets/output.rs
+
+The panel group's OUTPUT tab: a read-only viewer over the `output.rs` bus with a channel dropdown, a minimum-level filter, an RPC trace toggle, and a clear action. It renders the selected channel's level-coloured tail and auto-follows new lines until the user scrolls up.
+
+**The open dropdown windows its list when the channels outnumber the body rows** (`dropdown_scroll`). It opens at the current selection, the wheel and PageUp/Down scroll the window instead of the log, and a one-column scrollbar (click-to-jump) marks the truncation. Before this, overflow channels were unreachable by any gesture.
+
+### widgets/workspace_symbols.rs
+
+VS Code's "Go to Symbol in Workspace", reached with `#` in Quick Open. The query box's text fans out to every running server as `workspace/symbol`. Rows show a kind icon, the name and the workspace-relative path; Enter opens the file at the definition.
+
+**Requests are debounced per keystroke burst and keyed by request id,** so stale replies are dropped. Selection restarts at the top on each reply.
 
 ### File encoding
 

--- a/docs/MATCHERS.md
+++ b/docs/MATCHERS.md
@@ -5,7 +5,7 @@ every finished command in a terminal pane runs through built-in matchers
 for rustc/cargo, tsc (both output shapes), gcc/clang and anything else
 using the `file:line:col: severity: message` shape, Python tracebacks
 (the deepest frame), and eslint's stylish format. Rerunning a command in
-a pane replaces that pane's entries, so a clean rebuild clears its
+a pane replaces that pane's previous entries, so a clean rebuild clears its
 errors.
 
 `matchers.json` extends that to tools croft does not know, and to watch

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -49,7 +49,7 @@ This is the decisive one. croft's visual identity is painted with the **iTerm2 O
 
 The stock Windows console stack (`conhost`, and the Windows Terminal that fronts PowerShell) implements **none** of them. So even with every syscall above ported and the binary running cleanly under PowerShell, the result would be the image-less fallback: Nerd Font glyphs for icons and a metadata-header line for previews — exactly the degraded mode croft already warns about at startup, on any OS.
 
-The only way to get the real UI on Windows is a terminal emulator implementing the protocols, which in practice means **WezTerm**. And once you run WezTerm on Windows, the natural way to give it a POSIX environment is WSL — which puts you back at the supported Linux build. That is why the recommendation is "WSL2 + WezTerm" rather than a native port: the port's best case still requires WezTerm, and WSL gets you there without rewriting the syscall and clipboard layers.
+The only way to get the real UI on Windows is a terminal emulator implementing the protocols, which in practice means **WezTerm** (cross-platform, speaks both). And once you run WezTerm on Windows, the natural way to give it a POSIX environment is WSL — which puts you back at the supported Linux build. That is why the recommendation is "WSL2 + WezTerm" rather than a native port: the port's best case still requires WezTerm, and WSL gets you there without rewriting the syscall and clipboard layers.
 
 ## Summary
 

--- a/scripts/check_arch_content.py
+++ b/scripts/check_arch_content.py
@@ -15,21 +15,25 @@ this-way is gone. That check cannot fail in the case it is needed for. This one
 compares each module's description LENGTH against the base revision and asks
 for a prose section whenever it shrank substantially.
 
-Both ways of being wrong are cheap here, so the threshold is deliberately
-generous: a module trimmed by less than 400 characters was edited, not gutted,
-and asking for a section it does not need costs one heading.
-
 Usage: check_arch_content.py [base-revision]   (default: origin/main)
 Exit 0 when every shortened module has a home, 1 when one does not.
 """
 
+import collections
 import re
 import subprocess
 import sys
 
 PATH = "docs/ARCHITECTURE.md"
-# Below this, a shrunken line is an edit rather than a gutting.
-SHRINK_THRESHOLD = 400
+# A line that lost this many characters lost a sentence, not a comma.
+#
+# Set from the corpus, not from a round number. The first pass used 400 on
+# the reasoning that both ways of being wrong are cheap, and 400 turned out
+# to sit just above a cluster of real losses - the largest unguarded shrink
+# was 353 characters, so the gate was tuned to pass. Measure before picking:
+# a threshold chosen without looking at the distribution it guards can admit
+# every case it exists to catch and still report success.
+SHRINK_THRESHOLD = 120
 
 
 def tree_descriptions(text):
@@ -43,9 +47,16 @@ def tree_descriptions(text):
     script exists to catch.
     """
     lines = text.split("\n")
+    # Anchor on the heading, not on a line number. Keying the search off a
+    # bare `i > 12` meant the parse depended on how much prose happened to
+    # sit above the tree: adding a fenced example to an earlier section
+    # would silently retarget it at that fence and compare unrelated text.
     try:
+        heading = next(
+            i for i, l in enumerate(lines) if l.strip() == "## Project layout"
+        )
         opening = next(
-            i for i, l in enumerate(lines) if l.strip() == "```" and i > 12
+            i for i in range(heading + 1, len(lines)) if lines[i].strip() == "```"
         )
         closing = next(
             i for i in range(opening + 1, len(lines)) if lines[i].strip() == "```"
@@ -75,32 +86,54 @@ def tree_descriptions(text):
     return out
 
 
-def main():
-    base = sys.argv[1] if len(sys.argv) > 1 else "origin/main"
-    old = subprocess.check_output(["git", "show", f"{base}:{PATH}"], text=True)
-    new = open(PATH).read()
+def section_keys(name, ambiguous=frozenset()):
+    """The names a `### ` heading may use for this module.
 
+    The full path always counts. The bare filename counts only when it names
+    exactly one row: `session.rs` and `dap/session.rs` both live in this tree,
+    and a single `### session.rs` heading was accepted as covering both, so one
+    of them kept a lost fact while the gate reported success.
+    """
+    bare = name.rstrip("/")
+    parts = bare.split("/")
+    keys = set()
+    # Every trailing slice of the path - `src/lsp/install.rs`, `lsp/install.rs`,
+    # `install.rs` - except a bare filename two rows share.
+    for i in range(len(parts)):
+        suffix = "/".join(parts[i:])
+        if "/" not in suffix and suffix in ambiguous:
+            continue
+        keys |= {suffix, suffix + "/"}
+    return keys
+
+
+def compare(old, new):
+    """(shrunk-with-no-section, dropped-rows) between two versions of the doc."""
     before, after = tree_descriptions(old), tree_descriptions(new)
-    # A section may be headed by the full tree path, by the bare filename, or
-    # by a directory with its trailing slash. Normalise all three to compare.
-    def keys(name):
-        bare = name.rstrip("/")
-        return {bare, bare + "/", bare.split("/")[-1], bare.split("/")[-1] + "/"}
+    # A basename carried by more than one row cannot stand in for a path.
+    seen = collections.Counter(p.rstrip("/").split("/")[-1] for p in before)
+    ambiguous = frozenset(leaf for leaf, n in seen.items() if n > 1)
 
     documented = set()
-    for h in re.findall(r"^### (\S+)", new, re.M):
-        documented |= keys(h)
+    for heading in re.findall(r"^### (\S+)", new, re.M):
+        documented |= section_keys(heading, ambiguous)
 
-    gutted = [
+    shrunk = [
         (name, len(desc), len(after[name]))
         for name, desc in before.items()
         if name in after
         and len(desc) - len(after[name]) > SHRINK_THRESHOLD
-        and not (keys(name) & documented)
+        and not (section_keys(name, ambiguous) & documented)
     ]
-    dropped = sorted(set(before) - set(after))
+    return sorted(shrunk, key=lambda r: r[2] - r[1]), sorted(set(before) - set(after))
 
-    for name, was, now in sorted(gutted, key=lambda r: r[2] - r[1]):
+
+def main():
+    base = sys.argv[1] if len(sys.argv) > 1 else "origin/main"
+    old = subprocess.check_output(["git", "show", f"{base}:{PATH}"], text=True)
+    gutted, dropped = compare(old, open(PATH).read())
+
+    for name, was, now in gutted:
         print(f"{name}: {was} -> {now} chars, with no `### {name}` section")
     for name in dropped:
         print(f"{name}: row gone from the tree entirely")

--- a/scripts/tests/test_check_arch_content.py
+++ b/scripts/tests/test_check_arch_content.py
@@ -1,0 +1,123 @@
+"""Tests for scripts/check_arch_content.py: ARCHITECTURE.md's reasoning gate.
+
+The tree in that file carries each module's design rationale, and a rewrite
+can cut a line's reasoning away while leaving the row and its identifiers
+exactly where they were. A row-level or identifier-level check reads that as
+a pass, which is the failure this script exists to catch and which it was
+caught by twice while being written: first with a threshold set above the
+real losses, then with a parse that collapsed repeated basenames.
+
+So the cases below are the two blind spots, not a coverage sweep. The
+same-basename case is the one worth having: `registry.rs` appears four times
+in this tree and `mod.rs` three, so a dict keyed on the filename keeps only
+the last of each and reports the wrong path - or nothing at all.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_arch_content as gate  # noqa: E402
+
+
+def doc(tree_rows, sections=()):
+    """An ARCHITECTURE.md-shaped document: prose, the layout fence, sections."""
+    body = ["# croft architecture", "", "Some preamble.", "", "## Project layout", "", "```"]
+    body += tree_rows
+    body += ["```", ""]
+    for name in sections:
+        body += [f"### {name}", "", "Why it is this way.", ""]
+    return "\n".join(body)
+
+
+class TreeParse(unittest.TestCase):
+    def test_keys_on_path_so_repeated_basenames_stay_distinct(self):
+        parsed = gate.tree_descriptions(
+            doc(
+                [
+                    "src/",
+                    "├── output.rs            the in-process output bus",
+                    "└── widgets/",
+                    "    └── output.rs        the panel group's OUTPUT tab",
+                ]
+            )
+        )
+        self.assertEqual(
+            sorted(parsed),
+            ["src/output.rs", "src/widgets/output.rs"],
+        )
+        self.assertEqual(parsed["src/output.rs"], "the in-process output bus")
+
+    def test_anchors_on_the_heading_not_a_line_number(self):
+        """A fenced example above the tree must not become the tree."""
+        text = doc(["src/", "└── a.rs                 does a thing"])
+        text = text.replace(
+            "Some preamble.",
+            "Some preamble:\n\n```bash\ncroft --version\n```\n",
+        )
+        parsed = gate.tree_descriptions(text)
+        self.assertEqual(list(parsed), ["src/a.rs"])
+
+
+class Gutting(unittest.TestCase):
+    """Whether a shrunken description is reported depends on having a home."""
+
+    LONG = "x" * 400
+    ROW = "src/", "└── a.rs                 "
+
+    def gutted(self, sections=()):
+        before = doc([self.ROW[0], self.ROW[1] + self.LONG])
+        after = doc([self.ROW[0], self.ROW[1] + "short"], sections)
+        return gate.compare(before, after)
+
+    def test_gutted_row_with_no_section_is_reported(self):
+        shrunk, dropped = self.gutted()
+        self.assertEqual([n for n, _, _ in shrunk], ["src/a.rs"])
+        self.assertEqual(dropped, [])
+
+    def test_gutted_row_with_a_section_is_accepted(self):
+        self.assertEqual(self.gutted(sections=["a.rs"])[0], [])
+
+    def test_a_section_named_by_full_path_also_counts(self):
+        self.assertEqual(self.gutted(sections=["src/a.rs"])[0], [])
+
+    def test_only_the_gutted_one_of_two_same_named_rows_is_reported(self):
+        rows = [
+            "src/",
+            "├── registry.rs          " + self.LONG,
+            "└── dap/",
+            "    └── registry.rs      " + self.LONG,
+        ]
+        after = list(rows)
+        after[3] = "    └── registry.rs      short"
+        shrunk, _ = gate.compare(doc(rows), doc(after))
+        self.assertEqual([n for n, _, _ in shrunk], ["src/dap/registry.rs"])
+
+    def test_a_dropped_row_is_reported(self):
+        before = doc(["src/", "├── a.rs                 does a thing", "└── b.rs   and b"])
+        after = doc(["src/", "└── b.rs   and b"])
+        self.assertEqual(gate.compare(before, after)[1], ["src/a.rs"])
+
+
+class Threshold(unittest.TestCase):
+    """The bound is a measured value; these pin which side of it a shrink lands."""
+
+    def shrink_by(self, n):
+        keep = 500 - n
+        before = doc(["src/", "└── a.rs                 " + "x" * 500])
+        after = doc(["src/", "└── a.rs                 " + "x" * keep])
+        return gate.compare(before, after)[0]
+
+    def test_just_over_the_threshold_is_reported(self):
+        self.assertEqual(len(self.shrink_by(gate.SHRINK_THRESHOLD + 1)), 1)
+
+    def test_just_under_the_threshold_is_not(self):
+        self.assertEqual(self.shrink_by(gate.SHRINK_THRESHOLD - 1), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#508 was merged at `0bc0cfc`, the commit *before* its review fixes. The fallback review on that PR returned REQUEST_CHANGES with three majors; I fixed all three plus a fourth in `cc525ed` and pushed `6d19bb5`, but GitHub's PR head lagged and never updated, so the merge took the reviewed-and-rejected state.

`main` today is the version that scored **3/5**. This PR is `cc525ed`, cherry-picked onto current main. The re-review of that exact commit scored **5/5 APPROVE**, verified with positive controls rather than inspection.

## What main is missing

| | on `main` now | with this PR |
|---|---|---|
| `### ` module sections | 73 | 100 |
| `SHRINK_THRESHOLD` | 400 | 120 |
| Gate wired into CI | no | yes |
| Unit test for the gate | none | 9 cases |

## The three majors

**27 modules lost their reasoning with nowhere to put it.** ~19,500 characters deleted, not relocated: `widgets/output.rs`'s `dropdown_scroll` and "overflow channels used to be unreachable by any gesture"; `plot.rs`'s reason the sixel probe cannot be used there ("needs a raw tty on stdin, which is the data pipe here"); `media.rs`'s header-parser list; `sqlite_view.rs`'s "no system dependency"; `session.rs`'s phantom-row fact.

**The threshold was tuned to pass.** I set 400 on the argument that both error directions are cheap. The largest unguarded shrink was 353 — the gate sat just above the cluster of real losses. Now 120, taken from the measured distribution, with the mistake recorded in the docstring rather than quietly corrected. The reviewer sanity-checked it independently: the nearest unsectioned loss below 120 is 20 characters away, and everything above it has a section.

**The gate ran nowhere.** `grep` for `check_arch_content` returned only its own docstring — no ci.yml step, no test. A guard nothing executes cannot fail, which is the exact shape it was written to catch. It is now a step in the `docs` job on the same merge-base contract as `check_doc_ownership.py`.

## A fourth, found by checking rather than assuming

The reviewer listed `session.rs`'s phantom-row fact as lost. Rather than assume the restore covered it, I grepped: it had not. `session.rs` and `dap/session.rs` both exist, and one `### session.rs` heading satisfied the gate for **both** — so the shorter module kept a lost fact while the gate reported success. That is the same collapse-on-basename bug in its third form (first a threshold above the losses, then a dict keyed on filename, then heading-matching).

`section_keys` now accepts any unambiguous path suffix and refuses a bare filename two rows share, which forced four headings to be qualified. The reviewer reproduced this: renaming `### src/session.rs` back to a bare `### session.rs` makes the new code flag **both** rows where the old code flagged **neither**.

## Verification

`scripts/tests/test_check_arch_content.py`, 9 cases: path-keying, the heading-anchored fence, the threshold either side, a dropped row, and the same-basename regression. Full script suite **125 tests, OK** (`/tmp/cgr-suite-logs/20260906T234618Z-82224.log` — the summary is in the log, not the terminal).

The reviewer additionally ran four positive controls against the real document, and measured every row rather than only the ones named: of 101 shrunken rows, the only three without sections are −100, −48 and one fully carried by `### testing/`.

Docs plus `scripts/` — outside ci.yml's `shipped` filter, so no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture documentation with clearer source references and descriptions of key modules and capabilities.
  * Clarified terminal problem-entry behavior in matcher documentation.
  * Updated Windows guidance for using WezTerm with the real UI.

* **Quality Improvements**
  * Added automated checks and tests to detect unintended reductions or omissions in architecture documentation.
  * Improved validation for modules with similar filenames and documentation layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->