### PR TITLE
fix(overlays): refuse a post-draw overlay that does not fit the screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.909"
+version = "0.1.910"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.909"
+version = "0.1.910"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5931,6 +5931,22 @@ impl App {
         let cursor_on = self.cursor_should_be_visible();
         let _ = write!(out, "\x1b[?25l\x1b[s");
         for ((x, y), seq) in &overlays {
+            // Same screen bound as the image writers (#513): a raw
+            // absolute-CUP write that ratatui cannot repair, so the origin
+            // is checked before it is used.
+            //
+            // 1x1 is NARROWER than some payloads here, and knowingly so.
+            // `pending_activity_image_overlays` discards each block's
+            // `Rect` and returns only its origin, and a count badge is 2-3
+            // cells wide (`count_badge_cells_w`), so a badge whose left
+            // edge is on screen and right edge is not would pass this.
+            // Not reachable today -- the badges anchor to the left-hand
+            // activity bar -- and making it exact means returning the
+            // `Rect` from that function, which is a wider change than this
+            // guard. Recorded rather than left to be rediscovered.
+            if !self.overlay_fits_on_screen(*x, *y, 1, 1) {
+                continue;
+            }
             let _ = write!(out, "\x1b[{};{}H", y + 1, x + 1); // 1-based
             let _ = out.write_all(seq.as_bytes());
         }
@@ -5941,6 +5957,52 @@ impl App {
         let _ = out.flush();
         self.overlays.activity.mark_emitted();
         self.overlays.activity.store_positions(positions);
+    }
+
+    /// Whether a post-draw overlay at this cell rect may be emitted (#513).
+    ///
+    /// The flush block below writes with absolute CUP straight to stdout,
+    /// after ratatui's diff. Two properties make a wrong origin dangerous
+    /// rather than merely wrong: it is a raw write, not a buffer index, so
+    /// an out-of-range origin cannot panic the way `Buffer` would; and
+    /// ratatui has no record of the cells it touched, so nothing repairs
+    /// them on the next frame. The corruption persists instead of clearing
+    /// on repaint, which is what #510 looked like from the outside.
+    ///
+    /// So the payload is checked against the screen at EMIT time rather
+    /// than trusting whichever cached rect produced the layout. Every
+    /// writer in the block goes through it, which is the part #512's shape
+    /// could not give: that fixed the terminal carrier by clearing its
+    /// stored rect, but each other writer keeps its own rect with its own
+    /// lifecycle, so every future site a frame can decline to paint is one
+    /// more place to remember the clear.
+    ///
+    /// What this does NOT do, stated plainly because the bound is easy to
+    /// oversell: it removes OFF-SCREEN writes only. It is a screen bound,
+    /// not the owning widget's rect, so an overlay anchored on a stale rect
+    /// that still lands somewhere on screen passes it untouched -- and that
+    /// is the case #510 actually exhibited, a terminal image painted over a
+    /// sibling pane, the sidebar and the status bar, all of them mid-screen
+    /// (#512 records the landing sites). So this does not subsume #512 and
+    /// does not close #513's class; it removes the unbounded half, where a
+    /// wild origin can write anywhere in the terminal.
+    ///
+    /// The bound is the screen because the emitter does not know which
+    /// widget a payload belongs to. Making it exact needs each payload to
+    /// carry its owning rect, which is the wider change #513 describes.
+    fn overlay_fits_on_screen(&self, cell_x: u16, cell_y: u16, cell_w: u16, cell_h: u16) -> bool {
+        let area = self.last_frame_area;
+        if area.width == 0 || area.height == 0 {
+            // No frame has been drawn yet, so there is no screen to land on.
+            return false;
+        }
+        // A zero-sized payload has nothing to place; treat it as unemittable
+        // rather than trivially in-bounds, so a cleared rect cannot slip a
+        // bare cursor park through.
+        if cell_w == 0 || cell_h == 0 {
+            return false;
+        }
+        cell_x.saturating_add(cell_w) <= area.width && cell_y.saturating_add(cell_h) <= area.height
     }
 
     /// Reset the blink phase so the caret is solidly visible for the next
@@ -48323,7 +48385,14 @@ fn main_loop(app: &mut App, terminal: &mut CroftTerminal) -> Result<()> {
             // per editor split column (0 = left, 1 = right); when not
             // split only slot 0 ever has a payload.
             for side in 0..2 {
-                if let Some((osc, layout)) = app.editor_image_payload(side) {
+                if let Some((osc, layout)) = app.editor_image_payload(side)
+                    && app.overlay_fits_on_screen(
+                        layout.cell_x,
+                        layout.cell_y,
+                        layout.cell_w,
+                        layout.cell_h,
+                    )
+                {
                     use std::io::Write;
                     let mut out = stdout();
                     let cursor_on = app.cursor_should_be_visible();
@@ -48340,7 +48409,14 @@ fn main_loop(app: &mut App, terminal: &mut CroftTerminal) -> Result<()> {
             }
             // Terminal-pane inline image (captured imgcat output): same
             // bake-once / emit-each-frame overlay, anchored to its grid row.
-            if let Some((osc, layout)) = app.terminal_image_payload() {
+            if let Some((osc, layout)) = app.terminal_image_payload()
+                && app.overlay_fits_on_screen(
+                    layout.cell_x,
+                    layout.cell_y,
+                    layout.cell_w,
+                    layout.cell_h,
+                )
+            {
                 use std::io::Write;
                 let mut out = stdout();
                 let cursor_on = app.cursor_should_be_visible();
@@ -48356,7 +48432,14 @@ fn main_loop(app: &mut App, terminal: &mut CroftTerminal) -> Result<()> {
             }
             // Markdown-preview inline image (#176): same bake-once /
             // emit-each-frame overlay, anchored at its reserved rows.
-            if let Some((osc, layout)) = app.markdown_image_payload() {
+            if let Some((osc, layout)) = app.markdown_image_payload()
+                && app.overlay_fits_on_screen(
+                    layout.cell_x,
+                    layout.cell_y,
+                    layout.cell_w,
+                    layout.cell_h,
+                )
+            {
                 use std::io::Write;
                 let mut out = stdout();
                 let cursor_on = app.cursor_should_be_visible();
@@ -48372,7 +48455,14 @@ fn main_loop(app: &mut App, terminal: &mut CroftTerminal) -> Result<()> {
             }
             // Editor minimap: same bake-once / emit-each-frame overlay, painted
             // after ratatui's diff so the raster lands on the strip cells.
-            if let Some((osc, layout)) = app.minimap_image_payload() {
+            if let Some((osc, layout)) = app.minimap_image_payload()
+                && app.overlay_fits_on_screen(
+                    layout.cell_x,
+                    layout.cell_y,
+                    layout.cell_w,
+                    layout.cell_h,
+                )
+            {
                 use std::io::Write;
                 let mut out = stdout();
                 let cursor_on = app.cursor_should_be_visible();
@@ -48399,7 +48489,14 @@ fn main_loop(app: &mut App, terminal: &mut CroftTerminal) -> Result<()> {
             // Welcome-screen logo: same OSC-1337 trick, gated by its own
             // dirty flag and only emitted while the editor pane is in its
             // blank initial state.
-            if let Some((img, layout)) = app.welcome_image_emit_payload() {
+            if let Some((img, layout)) = app.welcome_image_emit_payload()
+                && app.overlay_fits_on_screen(
+                    layout.cell_x,
+                    layout.cell_y,
+                    layout.cell_w,
+                    layout.cell_h,
+                )
+            {
                 use std::io::Write;
                 let mut out = stdout();
                 let cursor_on = app.cursor_should_be_visible();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -42102,6 +42102,85 @@ fn folding_a_pane_hands_focus_to_its_neighbour_not_to_the_front_of_the_row() {
     );
 }
 
+/// A post-draw overlay whose rect does not fit the screen is not emitted
+/// (#513). The flush block writes with absolute CUP straight to stdout,
+/// so an out-of-range origin cannot panic and ratatui cannot repair it --
+/// the payload has to be refused before it is written.
+#[test]
+fn an_overlay_past_the_screen_edge_is_refused_before_it_is_written() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    let backend = ratatui::backend::TestBackend::new(80, 24);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    term.draw(|f| app.render(f)).unwrap();
+
+    // Inside the screen: emittable.
+    assert!(
+        app.overlay_fits_on_screen(0, 0, 80, 24),
+        "a payload filling the screen exactly must be allowed"
+    );
+    assert!(app.overlay_fits_on_screen(10, 5, 20, 10), "well inside");
+
+    // Past either edge: refused. These are the shapes a stale rect makes --
+    // the pre-maximize column of a pane that is now narrower, or a row
+    // index from a taller layout.
+    assert!(
+        !app.overlay_fits_on_screen(70, 0, 20, 5),
+        "past the right edge (70+20 > 80)"
+    );
+    assert!(
+        !app.overlay_fits_on_screen(0, 20, 10, 10),
+        "past the bottom edge (20+10 > 24)"
+    );
+    assert!(
+        !app.overlay_fits_on_screen(u16::MAX - 1, 0, 4, 4),
+        "a wild origin must saturate rather than wrap into range"
+    );
+
+    // A zero-sized payload has nothing to place. Refused rather than
+    // trivially in bounds, so a cleared rect cannot slip a bare cursor
+    // park through.
+    assert!(!app.overlay_fits_on_screen(0, 0, 0, 5), "zero width");
+    assert!(!app.overlay_fits_on_screen(0, 0, 5, 0), "zero height");
+}
+
+/// Every raw-CUP writer in the post-draw block is guarded, not just the
+/// ones that had a reported failure (#513). The block's six writers share
+/// one hazard -- an absolute-CUP write ratatui cannot repair -- so a guard
+/// on some of them leaves the same class open at the others. This counts
+/// the call sites rather than exercising each, which is crude but is what
+/// catches a SEVENTH writer being added later without one.
+#[test]
+fn every_post_draw_overlay_writer_checks_the_screen_bound() {
+    let src = include_str!("mod.rs");
+    let guards = src.matches("app.overlay_fits_on_screen(").count();
+    assert_eq!(
+        guards, 5,
+        "expected the five payload writers in the post-draw block to be \
+         guarded (editor split slots share one call site, plus terminal, \
+         markdown, minimap, welcome); the activity-bar writer calls \
+         `self.overlay_fits_on_screen` from inside its own method. A \
+         change here means a writer was added or removed - guard it."
+    );
+    assert!(
+        src.contains("if !self.overlay_fits_on_screen(*x, *y, 1, 1)"),
+        "the activity-bar writer keeps its own guard"
+    );
+}
+
+/// Before any frame is drawn there is no screen to land on, so nothing is
+/// emittable (#513). Guards the window between startup and the first
+/// render, where `last_frame_area` is still zeroed.
+#[test]
+fn no_overlay_is_emittable_before_the_first_frame() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = App::new(tmp.path().to_path_buf()).unwrap();
+    assert!(
+        !app.overlay_fits_on_screen(0, 0, 1, 1),
+        "no frame drawn yet: a 1x1 payload at the origin still has no screen"
+    );
+}
+
 #[test]
 fn maximize_ignores_the_collapse_flags_and_gives_them_back_on_exit() {
     // The two gestures are orthogonal: entering maximize does not clear the

--- a/src/release_notes/0.1.910.md
+++ b/src/release_notes/0.1.910.md
@@ -1,0 +1,1 @@
+fix: an inline image or activity-bar icon can no longer be painted outside the screen when a widget's cached rect goes stale. These overlays are written straight to the terminal after the frame is drawn, so a wrong position could not be repaired by a repaint and stayed on screen until the next full redraw; each one is now checked against the screen before it is emitted.


### PR DESCRIPTION
## Summary

Closes #513. The post-draw flush block writes overlays with absolute CUP straight to stdout, **after** ratatui has flushed its diff. Two properties make a wrong origin dangerous rather than merely wrong:

1. It is a raw write, not a buffer index, so an out-of-range origin **cannot panic** the way `Buffer` would.
2. ratatui holds no record of the cells it touched, so **nothing repairs them** on the next frame. The corruption persists instead of clearing on repaint — which is what #510 looked like from the outside.

#512 fixed one carrier by clearing the stored rect it read. Every other writer in the block keeps its own rect with its own lifecycle, so that shape needs the clear remembered at every future site a frame can decline to paint a widget — and this class exists precisely because someone remembered it for `last_area` and not for its twin on the adjacent line.

`overlay_fits_on_screen` checks the payload against `last_frame_area` at **emit** time instead. All six writers in the block go through it: the two editor split slots, the terminal pane, the markdown preview, the minimap, the welcome logo, and the activity-bar icons.

## What this does NOT do

Stated in the doc, because the bound is easy to oversell: **it removes off-screen writes only.**

A stale rect that still lands somewhere on screen passes untouched — and that is the case #510 actually exhibited, an image painted over a sibling pane, the sidebar and the status bar, all mid-screen. So this neither subsumes #512 nor closes #513's class. It removes the unbounded half, where a wild origin can write anywhere in the terminal. Making it exact needs each payload to carry its owning rect, which is the wider change #513 describes.

## Details worth knowing

- **A clipped payload retries.** The `mark_*_displayed()` calls sit inside the guarded blocks and `payload()` is not gated on `displayed`, so it is re-offered each frame rather than dropped for good. This was the risk worth being wrong about — a fix that trades a visual glitch for a permanently missing image would be worse than the bug.
- **The activity-bar bound is 1x1 and knowingly narrower** than its 2–3 cell count badges: that writer's helper discards each block's `Rect` and returns only an origin. Not reachable today, since the badges anchor to the left-hand bar. Recorded at the call site rather than left to be rediscovered.

## Tests

- `an_overlay_past_the_screen_edge_is_refused_before_it_is_written` — both edges, a saturating wild origin, and zero-sized payloads
- `no_overlay_is_emittable_before_the_first_frame` — the window before `last_frame_area` is set
- `every_post_draw_overlay_writer_checks_the_screen_bound` — counts guarded call sites, so a **seventh** writer added later without one fails rather than silently reopening the class

**Red control:** neutering the bound to `true` makes the first test fail (exit 101), so it tests the guard rather than passing incidentally. The second still passes under that mutation — it covers the zero-area early return, which the control does not touch.

The call-site test exists because the first revision of this change guarded **four of six** writers; the local review caught the minimap and welcome ones still emitting unguarded, both named in #513's own exposure table.

## Verification

At `e6fd02c`: `CLIPPY_EXIT=0`, `TEST_EXIT=0` (3 tests, each named in the output), `FMT_EXIT=0`. `check_doc_ownership.py` clean, `ships_nothing.py` exits 1 (it ships).

0.1.910 with a release note — main is 0.1.909 after #512.

Closes #513