### PR TITLE
feat(terminal): draw the focused pane's border in heavy glyphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.911"
+version = "0.1.912"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.911"
+version = "0.1.912"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5876,6 +5876,49 @@ fn render_welcome_does_not_panic_in_default_80x25_with_many_notes() {
     term.draw(|f| app.render_welcome(f, area)).unwrap();
 }
 
+/// The focused pane's box is drawn in HEAVY glyphs and an unfocused one
+/// in light, so which pane owns the keyboard reads from weight and not
+/// only from colour (#470). Both weights keep the rounded corners: there
+/// is no heavy arc glyph, and the corners are the house look every other
+/// caller of the gradient box shares.
+#[test]
+fn the_gradient_box_comes_in_two_weights() {
+    use ratatui::buffer::Buffer;
+    let area = ratatui::layout::Rect {
+        x: 0,
+        y: 0,
+        width: 8,
+        height: 4,
+    };
+    let sym = |b: &Buffer, x: u16, y: u16| b[(x, y)].symbol().to_string();
+
+    let mut light = Buffer::empty(area);
+    crate::gradient::paint_gradient_box(&mut light, area);
+    let mut heavy = Buffer::empty(area);
+    crate::gradient::paint_gradient_box_heavy(&mut heavy, area);
+
+    // All four edges, not just two: the bug this was written for replaced
+    // one horizontal edge and left the other light, so a test that reads
+    // only the top would miss its own inverse.
+    for (x, y, what) in [(3u16, 0u16, "top"), (3, 3, "bottom")] {
+        assert_eq!(sym(&light, x, y), "\u{2500}", "light {what} edge");
+        assert_eq!(sym(&heavy, x, y), "\u{2501}", "heavy {what} edge");
+    }
+    for (x, y, what) in [(0u16, 1u16, "left"), (7, 1, "right")] {
+        assert_eq!(sym(&light, x, y), "\u{2502}", "light {what} edge");
+        assert_eq!(sym(&heavy, x, y), "\u{2503}", "heavy {what} edge");
+    }
+    // The corners are shared, which is what keeps the two boxes the same
+    // shape rather than two different visual languages.
+    for (x, y) in [(0, 0), (7, 0), (0, 3), (7, 3)] {
+        assert_eq!(
+            sym(&light, x, y),
+            sym(&heavy, x, y),
+            "corner ({x},{y}) is the same arc in both weights"
+        );
+    }
+}
+
 #[test]
 fn paint_gradient_box_draws_rounded_corners_with_corner_colours() {
     let rect = Rect {
@@ -27939,11 +27982,21 @@ fn osc_9_4_progress_paints_a_border_gauge_and_pill_percent() {
     let inner = app.terminals[0].last_inner;
     let rows = screen_rows(&term);
     let border_row = &rows[(area.y + area.height - 1) as usize];
+    // The gauge's fill glyph contrasts with the pane's own border weight
+    // (#470): a focused pane draws a heavy border, so its fill is `═`
+    // against `━`; an unfocused one draws light, so its fill is `━`
+    // against `─`. Counting the glyph that marks FILL keeps this test
+    // about the gauge rather than about which border weight is in force.
+    let fill_glyph = if app.terminals[0].focused {
+        '═'
+    } else {
+        '━'
+    };
     let fill: usize = border_row
         .chars()
         .skip(inner.x as usize)
         .take(inner.width as usize)
-        .filter(|c| *c == '━')
+        .filter(|c| *c == fill_glyph)
         .count();
     let expected = (inner.width as u32 * 46 / 100) as usize;
     assert!(
@@ -27970,8 +28023,11 @@ fn osc_9_4_progress_paints_a_border_gauge_and_pill_percent() {
     term.draw(|f| app.render(f)).unwrap();
     let rows = screen_rows(&term);
     let border_row = &rows[(area.y + area.height - 1) as usize];
+    // No FILL glyph remains. `━` is the border's own glyph on a focused
+    // pane (#470), so a literal check here would fail on an intact border
+    // rather than on a leftover gauge.
     assert!(
-        !border_row.contains('━'),
+        !border_row.contains(fill_glyph),
         "a cleared gauge restores the plain border: {border_row:?}"
     );
     assert!(

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -59,6 +59,28 @@ pub fn rgb_color((r, g, b): (u8, u8, u8)) -> Color {
 /// (e.g., a 80x25 default startup buffer with a tall recents list) draws
 /// nothing instead of panicking inside `set_string`.
 pub fn paint_gradient_box(buf: &mut Buffer, rect: Rect) {
+    paint_gradient_box_weighted(buf, rect, false)
+}
+
+/// The gradient box in either weight (#470).
+///
+/// `heavy` swaps the light line-drawing glyphs for their heavy siblings so
+/// a focused terminal pane reads as focused on the Black theme too, where
+/// this overlay REPLACES the block border the rest of the app draws -- a
+/// `BorderType::Thick` underneath would be painted straight over. The
+/// corners stay rounded in both weights: there is no heavy rounded corner
+/// in the box-drawing block, and the arc glyphs are the house look every
+/// other caller of this function shares.
+pub fn paint_gradient_box_heavy(buf: &mut Buffer, rect: Rect) {
+    paint_gradient_box_weighted(buf, rect, true)
+}
+
+fn paint_gradient_box_weighted(buf: &mut Buffer, rect: Rect, heavy: bool) {
+    // The one guard for both entry points. It lived in `paint_gradient_box`
+    // and a weaker copy landed here when the weight parameter was added,
+    // which left the heavy path able to panic on a rect the light path
+    // safely declined -- the offsets and the lower bounds matter whenever
+    // the buffer does not start at (0,0).
     if rect.width < 2 || rect.height < 2 {
         return;
     }
@@ -70,6 +92,8 @@ pub fn paint_gradient_box(buf: &mut Buffer, rect: Rect) {
     {
         return;
     }
+    let horiz = if heavy { "\u{2501}" } else { "\u{2500}" };
+    let vert = if heavy { "\u{2503}" } else { "\u{2502}" };
     let max_x = rect.width - 1;
     let max_y = rect.height - 1;
     for x in 0..rect.width {
@@ -85,14 +109,14 @@ pub fn paint_gradient_box(buf: &mut Buffer, rect: Rect) {
         } else if x == max_x {
             "\u{256e}"
         } else {
-            "\u{2500}"
+            horiz
         };
         let bot_ch = if x == 0 {
             "\u{2570}"
         } else if x == max_x {
             "\u{256f}"
         } else {
-            "\u{2500}"
+            horiz
         };
         buf.set_string(
             rect.x + x,
@@ -118,13 +142,13 @@ pub fn paint_gradient_box(buf: &mut Buffer, rect: Rect) {
         buf.set_string(
             rect.x,
             rect.y + y,
-            "\u{2502}",
+            vert,
             Style::default().fg(rgb_color(left)),
         );
         buf.set_string(
             rect.x + max_x,
             rect.y + y,
-            "\u{2502}",
+            vert,
             Style::default().fg(rgb_color(right)),
         );
     }

--- a/src/release_notes/0.1.912.md
+++ b/src/release_notes/0.1.912.md
@@ -1,0 +1,1 @@
+feature: the focused terminal pane draws its border in heavy line-drawing glyphs against the unfocused panes' light ones, so which pane has the keyboard reads at a glance rather than from the border colour alone. The emphasis costs no space: a literally doubled border would be a second box one cell inside the first, taking a row and a column from every pane's shell.

--- a/src/widgets/terminal.rs
+++ b/src/widgets/terminal.rs
@@ -4461,15 +4461,32 @@ impl Widget for &mut PtyTerminal {
         // The panel group's tab strip already labels this region "TERMINAL", so
         // each pane stays titleless — a bare bordered box, matching VS Code's
         // unlabelled split terminal panes. The border alone frames the pane.
+        //
+        // The focused pane draws its box in heavy line-drawing glyphs
+        // (┏━┓) against the unfocused pane's light ones (┌─┐), so which
+        // pane has the keyboard reads at a glance and not only from the
+        // border's colour (#470).
+        //
+        // Weight rather than a second ring: the issue asks for "twice as
+        // thick", and a terminal cell is the smallest unit there is, so a
+        // literally doubled border means a second box one cell inside the
+        // first -- costing the shell a row and a column on every side of
+        // every pane. Heavy glyphs give the emphasis for free, which is
+        // what iTerm2 and WezTerm do for the same reason.
         let block = Block::default()
             .borders(Borders::ALL)
+            .border_type(if self.focused {
+                ratatui::widgets::BorderType::Thick
+            } else {
+                ratatui::widgets::BorderType::Plain
+            })
             .border_style(block_style);
         let inner = block.inner(area);
         block.render(area, buf);
         // Black theme: replace the solid focus border with the orange→green
         // gradient (matching the welcome activity box).
         if self.focused && self.focus_gradient && self.accent.is_none() {
-            crate::gradient::paint_gradient_box(buf, area);
+            crate::gradient::paint_gradient_box_heavy(buf, area);
         }
         self.last_area = area;
         self.last_inner = inner;
@@ -4810,10 +4827,18 @@ impl Widget for &mut PtyTerminal {
                 _ => self.theme.ui(Color::Rgb(0x1b, 0x81, 0xa8)),
             };
             let by = area.y + area.height - 1;
+            // The fill glyph has to be HEAVIER than the border it sits on,
+            // or the gauge reads as full (#470): a focused pane's border is
+            // already `━`, so painting `━` over it leaves only colour to
+            // distinguish filled from unfilled -- and the focused pane is
+            // the one most likely to be running the build being measured.
+            // `═` against a heavy border is the same trick `━` plays
+            // against a light one.
+            let fill_glyph = if self.focused { "═" } else { "━" };
             for i in 0..fill_len.min(w) {
                 let x = inner.x + (fill_from + i) as u16;
                 let cell = &mut buf[(x, by)];
-                cell.set_symbol("━");
+                cell.set_symbol(fill_glyph);
                 cell.set_style(Style::default().fg(color));
             }
         }


### PR DESCRIPTION
## Summary

Closes #470. The focused pane's box is drawn in heavy line-drawing glyphs (`┏━┓`) against the unfocused panes' light ones (`┌─┐`), so which pane has the keyboard reads from **weight** and not only from the border's colour.

**Weight rather than a second ring.** The issue asks for "twice as thick", and a terminal cell is the smallest unit there is — so a literally doubled border means a second box one cell inside the first, costing the shell a row and a column on every side of every pane. Heavy glyphs give the emphasis for free, which is what iTerm2 and WezTerm do for the same reason. The title's stated goal is "a more obvious visual cue"; the thickness was the proposed means.

## Three collisions, none obvious from the diff

**The OSC 9;4 progress gauge.** It paints its fill over the bottom border, and read as fill only because the border was `─` and the fill `━`. A heavy border made both `━`, so the gauge showed **100% on the focused pane** — the one most likely to be running the build being measured. The fill glyph is now picked against the border's weight: `═` on heavy, `━` on light, each the same contrast trick one step up. `═` appears nowhere else in the codebase, so the "cleared gauge" assertion cannot be satisfied by an intact border.

**The Black theme.** There `paint_gradient_box` *replaces* the block's border with its own glyphs, so a `BorderType::Thick` underneath is painted straight over — the change would have appeared to work on every theme except the one it was drawn over. That function has 28 call sites, so it keeps its light weight and gains a `paint_gradient_box_heavy` sibling that only the focused terminal pane uses. All 27 non-terminal callers are unaffected.

**A guard I degraded while refactoring.** Adding the weight parameter left `paint_gradient_box_weighted` with a weaker bounds check than the original — it dropped the lower-bound tests and the buffer-origin offsets, so the heavy path could panic on a rect the light path safely declines. Both entry points now share the original guard.

Corners stay rounded in both weights: there is no heavy arc glyph, and the arcs are the house look every caller of the gradient box shares. `Block::inner()` is unaffected by border type, so the PTY does not resize on focus change.

## Tests

`the_gradient_box_comes_in_two_weights` pins all four edges in both weights and asserts the corners match. Four rather than two because the first revision replaced one horizontal edge twice and left the other light — a test reading only the top would have missed its own inverse.

The gauge test's two hard-coded `'━'` literals now derive from focus state. The local review checked this was not a weakening by reverting only the fix and re-running the *updated* test: it still fails (`left: 0, right: 23`), so it still catches the exact bug it was edited around.

## Verification

At `eb680db`: clippy `-D warnings` exit 0, `cargo fmt --check` exit 0, doc-ownership clean, `ships_nothing.py` exit 1.

Unfiltered suite: 4268 passed / 5 failed — 3 pass in isolation (load flakes), and 2 fail identically on base `a970d5f` (a missing `aarch64-unknown-linux-musl` rustup target; a socket-path-length `EINVAL` under the long scratchpad prefix). Zero failures attributable to this branch.

0.1.912 with a release note — main is 0.1.911 after #493's PDF fix.

Closes #470