### PR TITLE
test(terminal): sweep every collapse-recovery path (part of #468)

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -42324,6 +42324,127 @@ fn maximize_ignores_the_collapse_flags_and_gives_them_back_on_exit() {
     );
 }
 
+/// Closing the last EXPANDED pane leaves a panel of nothing but strips,
+/// and something must bring one back (part of #468).
+///
+/// `toggle_terminal_collapse` refuses to fold the last expanded pane,
+/// but closing reaches that state from the other side, which is a route
+/// the fold guard cannot see. `ensure_a_terminal_pane_is_expanded` is
+/// the answer and has exactly one caller; this pins that the caller is
+/// on the path that needs it.
+#[test]
+fn closing_the_last_expanded_pane_leaves_one_expanded_behind() {
+    let (_tmp, mut app, mut term) = app_with_terminal_panes(2);
+    term.draw(|f| app.render(f)).unwrap();
+
+    app.toggle_terminal_collapse(1);
+    assert!(app.terminals[1].collapsed, "premise: pane 1 is folded");
+    assert!(
+        !app.terminals[0].collapsed,
+        "premise: pane 0 is the only expanded one"
+    );
+
+    // Close the expanded one. The fold guard never fires -- nothing is
+    // being folded -- so the panel would be all strips without the
+    // close path's own guard.
+    app.close_terminal_at(0);
+    term.draw(|f| app.render(f)).unwrap();
+
+    assert_eq!(app.terminals.len(), 1, "one pane left");
+    assert!(
+        !app.terminals[0].collapsed,
+        "the surviving pane must be expanded: a panel of nothing but strips \
+         has no cursor and no way back that does not depend on the strip \
+         click still working"
+    );
+}
+
+/// EXHAUSTIVE recovery sweep for #468: every pane index, both side bar
+/// positions, and with a resize or a maximize cycle interleaved, must be
+/// recoverable from its strip.
+///
+/// Four theories about this bug died against the tree by inspection --
+/// the editor/panel splitter's grab zone, the maximize/collapse flag
+/// interaction, index 0 being special, and the last-expanded guard. This
+/// stops arguing and drives the combinations instead, because "I could
+/// not construct the path" is a much weaker claim than "the paths were
+/// enumerated and all of them recover".
+///
+/// If this ever goes red it names the reproduction directly.
+#[test]
+fn every_collapsed_pane_recovers_from_its_strip_in_every_layout() {
+    for panes in [2usize, 3] {
+        for right_bar in [false, true] {
+            for perturb in ["none", "resize", "maximize"] {
+                for idx in 0..panes {
+                    let (_tmp, mut app, mut term) = app_with_terminal_panes(panes);
+                    app.side_bar_position = if right_bar {
+                        crate::app::SideBarPosition::Right
+                    } else {
+                        crate::app::SideBarPosition::Left
+                    };
+                    term.draw(|f| app.render(f)).unwrap();
+
+                    app.toggle_terminal_collapse(idx);
+                    assert!(
+                        app.terminals[idx].collapsed,
+                        "premise: pane {idx} folds ({panes} panes, right_bar={right_bar})"
+                    );
+
+                    // The perturbations #475 and #478 make plausible: a
+                    // resize leaves stale geometry behind, and maximize
+                    // bypasses the pane-constraint path entirely.
+                    match perturb {
+                        "resize" => {
+                            term =
+                                ratatui::Terminal::new(ratatui::backend::TestBackend::new(120, 24))
+                                    .unwrap();
+                        }
+                        "maximize" => {
+                            app.toggle_terminal_pane_maximize();
+                            term.draw(|f| app.render(f)).unwrap();
+                            app.toggle_terminal_pane_maximize();
+                        }
+                        _ => {}
+                    }
+                    term.draw(|f| app.render(f)).unwrap();
+
+                    // The perturbation must PRESERVE the fold. A `continue`
+                    // here would let a maximize cycle that clears `collapsed`
+                    // pass the case without ever clicking a strip, so the
+                    // sweep would report paths it never walked -- the exact
+                    // shape of green this test exists to refuse.
+                    assert!(
+                        app.terminals[idx].collapsed,
+                        "pane {idx} must still be folded after {perturb} \
+                         ({panes} panes, right_bar={right_bar}); if this \
+                         perturbation legitimately unfolds panes the case \
+                         needs its own assertion, not a skip"
+                    );
+                    let strip = app.terminal_strip_rects[idx];
+                    assert_eq!(
+                        strip.width, 1,
+                        "pane {idx} keeps a one-column strip after {perturb} \
+                         ({panes} panes, right_bar={right_bar})"
+                    );
+
+                    app.handle_mouse(mouse(
+                        crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
+                        strip.x,
+                        strip.y,
+                    ));
+                    assert!(
+                        !app.terminals[idx].collapsed,
+                        "pane {idx} must unfold from its strip at ({}, {}) after \
+                         {perturb} ({panes} panes, right_bar={right_bar})",
+                        strip.x, strip.y
+                    );
+                }
+            }
+        }
+    }
+}
+
 #[test]
 fn a_collapsed_strip_carries_the_pane_name_down_its_column() {
     // The strip is what makes the gesture obviously reversible, so it has to


### PR DESCRIPTION
## Summary

Part of #468. **Does not fix it** — the sweep comes back green, which is itself the finding.

## Why this exists

Four theories about #468 have died against the tree:

1. The editor/panel splitter's grab zone — the chevron sits a row clear of it.
2. `toggle_terminal` clearing `terminal_maximized` but not `collapsed` — a real inconsistency, but recoverable with `Cmd+K ]`.
3. Index 0 being special — disproven by #514, now permanent coverage.
4. The last-expanded guard — it makes the state *unreachable* rather than unrecoverable.

Each died **by inspection**, and that is a weaker claim than it sounds. "I could not construct the path" and "the paths do not exist" are different statements, and only the second is worth acting on. This enumerates instead of arguing.

## What it covers

36 combinations: **2 and 3 panes** × **both side bar positions** × **nothing / a resize / a maximize cycle** × **every pane index**. Each folds a pane, applies the perturbation, and asserts the pane comes back from its one-column strip.

The perturbations are not arbitrary. #475 fixed a resize-related repaint bug, so resize is the one input already known to leave stale geometry behind; maximize bypasses the pane-constraint function entirely.

All 36 recover.

## What that means for #468

The reported failure needs a condition outside this space — and the space is now written down rather than argued about. If a future change breaks any of these paths, this test names the case directly, which is worth having whether or not it ever helps with the original report.

The single most useful thing on that issue remains one observation from the reporter: **did `Ctrl+L`, or resizing the window by a column, bring the pane back?** That splits a paint-path bug from state corruption in one answer.

## Verification

Test-only (`src/app/tests.rs` alone), so no version bump — CI strips that path before `ships_nothing.py` runs, matching #503, #507 and #514.

At `493980a`: clippy `-D warnings` exit 0, `cargo fmt --check` exit 0, doc-ownership clean, the new test passes in 6.36s.

Part of #468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage verifying that collapsed panes remain stable across supported layouts, resizing, and maximize actions.
  * Verified that clicking a collapsed pane’s strip consistently restores the pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->