### PR TITLE
feat(git): record a lane's base branch and range the commit graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.915"
+version = "0.1.916"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.915"
+version = "0.1.916"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25502,7 +25502,7 @@ impl App {
     /// and the Explorer would show the lane inside the root it was cut from.
     fn create_worktree_lane(&mut self, name: &str) {
         let repo = self.workspace_root().to_path_buf();
-        let Some(lane) = crate::git::WorktreeLane::plan(&repo, name) else {
+        let Some(mut lane) = crate::git::WorktreeLane::plan(&repo, name) else {
             // Refused rather than defaulted: a name with nothing usable in
             // it would otherwise become the branch `agent/`.
             self.status = format!("{name:?} has no letters or digits to name a lane after");
@@ -25512,7 +25512,7 @@ impl App {
             self.status = format!("{} already exists — pick another name", lane.path.display());
             return;
         }
-        match crate::git::add_worktree_lane(&repo, &lane) {
+        match crate::git::add_worktree_lane(&repo, &mut lane) {
             Ok(()) => {
                 self.add_workspace_folder(lane.path.clone());
                 self.open_lane_pane(&lane);

--- a/src/git.rs
+++ b/src/git.rs
@@ -1008,6 +1008,18 @@ pub struct WorktreeLane {
     pub path: PathBuf,
     /// The branch created for the lane.
     pub branch: String,
+    /// The branch the lane was cut FROM, recorded at creation (#348).
+    ///
+    /// Not derivable later. `worktree add -b` takes no start-point, so the
+    /// lane forks from whatever HEAD was; git records that only in the
+    /// reflog, which is local, prunable and absent from a fresh clone — so a
+    /// lane made on one machine has no base to recover on another.
+    /// `merge-base` cannot help either: it needs the candidate, which is the
+    /// thing being asked for. Creation is the only moment the answer is free.
+    ///
+    /// `None` when HEAD was detached at creation, which has no branch name
+    /// to record and must not be guessed at.
+    pub base: Option<String>,
 }
 
 impl WorktreeLane {
@@ -1033,6 +1045,10 @@ impl WorktreeLane {
         Some(Self {
             path: parent.join(format!("{base}-{slug}")),
             branch: format!("agent/{slug}"),
+            // `plan` is pure - it runs no git. The base is filled in by
+            // `add_worktree_lane`, which is already running git and is the
+            // moment HEAD is still the branch being forked from.
+            base: None,
         })
     }
 }
@@ -1162,11 +1178,25 @@ fn run_git_mut(dir: &Path, args: &[&str]) -> Result<(), String> {
 }
 
 /// Add `lane` as a worktree of `repo` on a new branch.
-pub fn add_worktree_lane(repo: &Path, lane: &WorktreeLane) -> Result<(), String> {
-    let Some(path) = lane.path.to_str() else {
+pub fn add_worktree_lane(repo: &Path, lane: &mut WorktreeLane) -> Result<(), String> {
+    let Some(path) = lane.path.to_str().map(str::to_owned) else {
         return Err(String::from("lane path is not valid UTF-8"));
     };
-    run_git_mut(repo, &["worktree", "add", "-b", &lane.branch, path])
+    // Read HEAD BEFORE creating the worktree, while it is still the branch
+    // the lane forks from, and record it (#348). Afterwards it is gone: see
+    // `WorktreeLane::base`.
+    lane.base = current_branch(repo);
+    run_git_mut(repo, &["worktree", "add", "-b", &lane.branch, &path])
+}
+
+/// The branch HEAD is on, or `None` when detached.
+///
+/// `--quiet` so a detached HEAD is an empty result rather than an error the
+/// caller has to distinguish from a failure.
+pub fn current_branch(root: &Path) -> Option<String> {
+    let out = run_git(root, &["symbolic-ref", "--quiet", "--short", "HEAD"]).ok()?;
+    let name = out.trim();
+    (!name.is_empty()).then(|| name.to_string())
 }
 
 /// Remove `lane`'s worktree.
@@ -1200,6 +1230,21 @@ pub fn remove_worktree_lane(lane: &Path) -> Result<(), String> {
 /// Empty on any failure — no repo, no commits, no git — so the caller shows
 /// an empty state rather than an error, matching `commit_graph`.
 pub fn branch_history(root: &Path, limit: usize) -> Vec<GraphCommit> {
+    branch_history_range(root, "HEAD", limit)
+}
+
+/// [`branch_history`] over an explicit revision spec rather than `HEAD`.
+///
+/// Takes the spec as a string so a caller can pass a range: `base..lane`
+/// lists the commits a lane added and none of the base's, which is what
+/// "the branch's diff against the base" means for a worktree lane (#348).
+/// `HEAD` reproduces the unranged behaviour exactly, which is why
+/// `branch_history` is now a one-line call rather than a second copy of
+/// this body.
+///
+/// Empty on any failure, like its caller: an unknown revision is a git
+/// error, and the graph shows an empty state rather than an error row.
+pub fn branch_history_range(root: &Path, revspec: &str, limit: usize) -> Vec<GraphCommit> {
     let Some(path_str) = root.to_str() else {
         return Vec::new();
     };
@@ -1209,7 +1254,7 @@ pub fn branch_history(root: &Path, limit: usize) -> Vec<GraphCommit> {
             path_str,
             "log",
             "--first-parent",
-            "HEAD",
+            revspec,
             &format!("-n{limit}"),
             "--format=%H\x1f%h\x1f%P\x1f%D\x1f%s\x1f%an\x1f%ct",
         ])
@@ -3152,6 +3197,35 @@ mod tests {
         String::from_utf8_lossy(&out.stdout).trim().is_empty()
     }
 
+    /// The base is recorded at creation and is not derivable afterwards
+    /// (#348). Asserts against a branch the fixture NAMES, so a bug that
+    /// wrote a constant, or the lane's own branch, fails here rather than
+    /// looking plausible.
+    #[test]
+    fn a_lane_records_the_branch_it_was_cut_from() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path();
+        init_repo_with_commit(p);
+        // A NON-default name, so passing "main"/"master" through cannot pass.
+        run_git_mut(p, &["checkout", "-b", "release-42"]).expect("branch");
+
+        let mut lane = WorktreeLane::plan(p, "parser work").expect("planned");
+        assert_eq!(lane.base, None, "plan is pure and reads no git");
+        add_worktree_lane(p, &mut lane).expect("git worktree add should succeed");
+
+        assert_eq!(
+            lane.base.as_deref(),
+            Some("release-42"),
+            "the lane records the branch HEAD was on, not a default"
+        );
+        assert_ne!(
+            lane.base.as_deref(),
+            Some(lane.branch.as_str()),
+            "the base is what it forked FROM, never the lane's own branch"
+        );
+        remove_worktree_lane(&lane.path).expect("cleanup");
+    }
+
     /// A lane round-trips through the real git commands (#348).
     ///
     /// Driven through `add_worktree_lane` / `remove_worktree_lane` rather
@@ -3164,10 +3238,10 @@ mod tests {
         let p = tmp.path();
         init_repo_with_commit(p);
 
-        let lane = WorktreeLane::plan(p, "parser work").expect("planned");
+        let mut lane = WorktreeLane::plan(p, "parser work").expect("planned");
         assert!(lane.path.starts_with(p.parent().unwrap()), "a sibling");
 
-        add_worktree_lane(p, &lane).expect("git worktree add should succeed");
+        add_worktree_lane(p, &mut lane).expect("git worktree add should succeed");
         assert!(lane.path.is_dir(), "the lane directory exists");
 
         // The branch really was created, and the lane is on it.
@@ -3186,7 +3260,7 @@ mod tests {
         // A second lane of the same name is refused by git rather than
         // silently reusing the branch.
         assert!(
-            add_worktree_lane(p, &lane).is_err(),
+            add_worktree_lane(p, &mut lane).is_err(),
             "a duplicate lane must fail rather than adopt the existing one"
         );
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1182,11 +1182,15 @@ pub fn add_worktree_lane(repo: &Path, lane: &mut WorktreeLane) -> Result<(), Str
     let Some(path) = lane.path.to_str().map(str::to_owned) else {
         return Err(String::from("lane path is not valid UTF-8"));
     };
-    // Read HEAD BEFORE creating the worktree, while it is still the branch
-    // the lane forks from, and record it (#348). Afterwards it is gone: see
-    // `WorktreeLane::base`.
-    lane.base = current_branch(repo);
-    run_git_mut(repo, &["worktree", "add", "-b", &lane.branch, &path])
+    // READ before the command, while HEAD is still the branch the lane forks
+    // from - afterwards it is gone, see `WorktreeLane::base`. But ASSIGN only
+    // once creation succeeded: a failed `worktree add` leaves no lane, and a
+    // base recorded on one that does not exist is a fact about nothing that a
+    // retry would then carry.
+    let base = current_branch(repo);
+    run_git_mut(repo, &["worktree", "add", "-b", &lane.branch, &path])?;
+    lane.base = base;
+    Ok(())
 }
 
 /// The branch HEAD is on, or `None` when detached.
@@ -3195,6 +3199,34 @@ mod tests {
             .output()
             .expect("git status");
         String::from_utf8_lossy(&out.stdout).trim().is_empty()
+    }
+
+    /// A failed creation leaves the base untouched (#348).
+    ///
+    /// The read has to happen BEFORE the command, while HEAD is still the
+    /// fork point - but writing it before the command succeeds records a
+    /// base for a lane that does not exist, which a retry would then carry.
+    /// Driven through the real duplicate-name refusal rather than a mocked
+    /// failure, so it fails the way callers actually see it.
+    #[test]
+    fn a_failed_lane_creation_leaves_the_base_unset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path();
+        init_repo_with_commit(p);
+        run_git_mut(p, &["checkout", "-b", "release-9"]).expect("branch");
+
+        let mut first = WorktreeLane::plan(p, "parser work").expect("planned");
+        add_worktree_lane(p, &mut first).expect("the first lane is created");
+        assert_eq!(first.base.as_deref(), Some("release-9"), "precondition");
+
+        // Same name: git refuses, so nothing was created to have a base.
+        let mut second = WorktreeLane::plan(p, "parser work").expect("planned");
+        assert!(add_worktree_lane(p, &mut second).is_err(), "precondition");
+        assert_eq!(
+            second.base, None,
+            "a lane git refused to create records no base"
+        );
+        remove_worktree_lane(&first.path).expect("cleanup");
     }
 
     /// The base is recorded at creation and is not derivable afterwards

--- a/src/release_notes/0.1.916.md
+++ b/src/release_notes/0.1.916.md
@@ -1,0 +1,1 @@
+change: a worktree lane now remembers the branch it was cut from, so a later "diff this lane against its base" has a base to name. Nothing in the UI uses it yet; git itself keeps that fact only in a local reflog that a second machine never sees.


### PR DESCRIPTION
Part of #348 — the two structural pieces design item 4 needs. **Not the command itself**, and deliberately so; see the bottom.

## What item 4 actually asks for

> **Agent: Merge Lane** opens the branch's **diff** against the base as a commit-graph selection and hands off to the existing merge editor for conflicts.

I had been reading that as a merge and asking which root it should run in. It says *diff*. The command name misled me, which is worth recording because it's the same shape as the stale comment that misled two sessions on #506 tonight — a label disagreeing with the text beside it.

Neither half of "the branch's diff against the base" was expressible.

## `branch_history_range`

`branch_history` ran `git log --first-parent HEAD` with no range, so `base..lane` — the commits a lane added and none of the base's — could not be asked for.

Refactored rather than copied: `branch_history` is now a one-line call into the ranged version with `"HEAD"`, so there's one body and one place for the `--first-parent` reasoning to live.

## `WorktreeLane.base`

`worktree add -b` takes no start-point (`git.rs:1169`), so a lane forks from whatever HEAD happened to be. Git records that **only in the reflog** — which is local, prunable at `gc.reflogExpire`, and absent from a fresh clone. A lane created on a laptop has no base to recover on a desktop. `merge-base` can't help either: it needs the candidate, which is the thing being asked for.

So the base is knowable at creation and unrecoverable afterwards. `add_worktree_lane` now reads HEAD **before** creating the worktree, while it's still the branch being forked from. `Option<String>` because a detached HEAD has no branch name and must not be guessed at.

## The test

Names a **non-default** branch — `release-42`, not `main` — so an implementation that passed a hardcoded default through would fail rather than look plausible. It also pins the two shapes a careless version takes:

- `plan` leaves `base` as `None`, since it's pure and reads no git
- the base is never the lane's *own* branch

## Verification

`cargo check`, `clippy -D warnings`, and the lane tests all pass, with the new test required **by name** in the runner.

One test failed on the way — `a_new_lane_opens_a_named_pane`, which polls a real shell. Probed rather than assumed: **3/3 alone on this tree, and green without the diff**, so it's the load-sensitive class rather than this change. The second half is the control; three green runs alone would only show it *can* pass, not that a signature change I made was innocent.

Merged 52 commits of main and re-ran everything, since a build that passed before that merge proves nothing about after it.

## Why the command isn't here

The remaining work is a palette entry, a dispatch arm, and the hand-off to `open_merge_editor_for` — all mechanical now that the base and the range exist. What isn't mechanical is whether item 4 is *only* the diff viewer it describes, or a diff viewer plus an actual merge. If it's the latter, the direction question matters: `git merge <lane>` in the primary brings the lane's work home, in the lane it refreshes the lane from base — and `close_worktree_lane` deliberately acts on `active_scm_root`, with a comment recording that targeting the primary destroyed a lane in testing.

These two pieces are needed either way, so they land now rather than waiting on that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktree lanes now remember the branch they were created from.
  * Branch history can be retrieved for custom revision ranges, supporting comparisons between a lane and its base branch.
  * Detached worktrees continue to work without base-branch metadata.

* **Documentation**
  * Added release notes for version 0.1.916, including current limitations around displaying lane-base information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->