### PR TITLE
feat(fleet): saved host groups, refused from workspace layers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.915"
+version = "0.1.917"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.917"
+version = "0.1.918"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.917"
+version = "0.1.918"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.915"
+version = "0.1.917"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -86,7 +86,7 @@ allowlist — appearance and editor/terminal behavior:
 `disable_inline_values`, `disable_bracket_colors`, `disable_indent_guides`,
 `disable_inlay_hints`, `copy_on_select`, `disable_secret_redaction`, `disable_log_highlight`, `explorer_views`.
 
-Everything else — `disabled_extensions`, `mcp_consented`, `disable_remote_offer`, `remote_offer_excluded_hosts`, `lane_agent`,
+Everything else — `disabled_extensions`, `mcp_consented`, `disable_remote_offer`, `remote_offer_excluded_hosts`, `fleet_groups`, `lane_agent`,
 `mcp_tool_fingerprints`, `host_accents`, `notifications`, and any future key not explicitly
 allowlisted — is ignored from workspace layers with a visible warning.
 Extending the allowlist is a deliberate review decision, not a default.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2841,6 +2841,9 @@ pub struct App {
     remote_offer_disabled: bool,
     /// `remote_offer_excluded_hosts` from prefs (#364).
     remote_offer_excluded: Vec<String>,
+    /// `fleet_groups` from prefs (#363): named host sets a fleet run can
+    /// expand, so a fleet is named once rather than retyped per run.
+    fleet_groups: std::collections::BTreeMap<String, Vec<String>>,
     /// Hosts whose provisioning failed recently (#364), loaded from the
     /// cache file at startup and extended when an install fails.
     remote_offer_refused: crate::remote::RefusedHosts,
@@ -4621,6 +4624,7 @@ impl App {
             ssh_tx,
             remote_offer_disabled: loaded_prefs.disable_remote_offer,
             remote_offer_excluded: loaded_prefs.remote_offer_excluded_hosts.clone(),
+            fleet_groups: loaded_prefs.fleet_groups.clone(),
             remote_offer_refused: crate::remote::load_refused_hosts(
                 &crate::remote::refused_hosts_path(&croft_cache_dir()),
                 std::time::SystemTime::now(),
@@ -25489,7 +25493,9 @@ impl App {
         // a confirmation saying "run on 5 hosts?" asks them to approve a list
         // they cannot see, which is not consent. `*` is how to say "all of
         // them" deliberately.
-        let Some((picked, command)) = crate::fleet::parse_request(command, &known) else {
+        let Some((picked, command)) =
+            crate::fleet::parse_request_with_groups(command, &known, &self.fleet_groups)
+        else {
             self.status = format!(
                 "Fleet run needs 'hosts: command' — e.g. '{}: uptime', or '*: uptime' for all {}",
                 known[0],
@@ -40323,6 +40329,9 @@ impl App {
         // here (#364); turning it off also takes down an offer on screen.
         self.remote_offer_disabled = p.disable_remote_offer;
         self.lane_agent = p.lane_agent.clone();
+        // Live like every other pref here (#363): editing a group in
+        // config.json takes effect on the next fleet run without a restart.
+        self.fleet_groups = p.fleet_groups.clone();
         let was_excluded = std::mem::replace(
             &mut self.remote_offer_excluded,
             p.remote_offer_excluded_hosts.clone(),

--- a/src/config_layers.rs
+++ b/src/config_layers.rs
@@ -554,7 +554,7 @@ mod tests {
         );
         write(
             &root.join(".croft/config.json"),
-            r#"{"theme":"nord","mcp_consented":["evil"],"disabled_extensions":[],"host_accents":[{"pattern":"*"}]}"#,
+            r#"{"theme":"nord","mcp_consented":["evil"],"disabled_extensions":[],"host_accents":[{"pattern":"*"}],"fleet_groups":{"all":["prod-db"]}}"#,
         );
         let m = load_merged_from(&user, Some(&root), "macos");
         assert_eq!(m.prefs.theme, "nord", "allowlisted key applies");
@@ -567,10 +567,18 @@ mod tests {
             "the user's own value survives the refused workspace override"
         );
         assert!(m.prefs.host_accents.is_empty());
+        // A fleet group is a list of machines to run commands on (#363), so
+        // a checked-out repo naming one could add a production box to a set
+        // the user then broadcasts to.
+        assert!(
+            m.prefs.fleet_groups.is_empty(),
+            "a cloned repo must not name hosts for a fleet run"
+        );
         let joined = m.warnings.join("\n");
         assert!(joined.contains("mcp_consented"), "{joined}");
         assert!(joined.contains("disabled_extensions"), "{joined}");
         assert!(joined.contains("host_accents"), "{joined}");
+        assert!(joined.contains("fleet_groups"), "{joined}");
     }
 
     #[test]

--- a/src/config_layers.rs
+++ b/src/config_layers.rs
@@ -550,7 +550,7 @@ mod tests {
         let (_tmp, user, root) = setup();
         write(
             &user.join("config.json"),
-            r#"{"disabled_extensions":["dap-python"]}"#,
+            r#"{"disabled_extensions":["dap-python"],"fleet_groups":{"web":["web1","web2"]}}"#,
         );
         write(
             &root.join(".croft/config.json"),
@@ -570,8 +570,16 @@ mod tests {
         // A fleet group is a list of machines to run commands on (#363), so
         // a checked-out repo naming one could add a production box to a set
         // the user then broadcasts to.
+        // The user's own group survives the refused workspace override, so
+        // this proves refusal rather than the key simply never deserializing
+        // - without a user-layer value, an inert feature would pass too.
+        assert_eq!(
+            m.prefs.fleet_groups.get("web").map(Vec::len),
+            Some(2),
+            "a user layer CAN name a fleet group"
+        );
         assert!(
-            m.prefs.fleet_groups.is_empty(),
+            !m.prefs.fleet_groups.contains_key("all"),
             "a cloned repo must not name hosts for a fleet run"
         );
         let joined = m.warnings.join("\n");

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -174,11 +174,12 @@ pub fn fleet_ssh_args(host: &str, command: &str) -> Vec<String> {
 ///
 /// `*` is the explicit way to say "all of them", so the broadcast is still
 /// available to someone who means it.
-/// Parse `hosts: command`, expanding any saved host groups (#363).
 ///
-/// A name in the spec is looked up as a GROUP first and a host second, so a
-/// group named after a host cannot silently shadow it - the group wins, and
-/// naming one after a host is the user's own doing. Expansion is one level:
+/// A name is looked up as a saved group first and a host second (#363), so a
+/// group named after a host cannot silently shadow it — the group wins, and
+/// naming one after a host is the user's own doing.
+///
+/// Expansion is one level:
 /// a group listing another group's name resolves that entry as a host and
 /// fails the unknown-host check below, rather than recursing. Nesting would
 /// need cycle detection to be safe, and there is no case for it yet.
@@ -208,6 +209,14 @@ pub fn parse_request_with_groups<'a>(
             Some((_, members)) => members.iter().map(String::as_str).collect(),
             None => vec![name],
         };
+        // A group that resolves to nothing REFUSES rather than contributing
+        // nothing. Silently, `web,db1: cmd` with an empty `web` would run on
+        // db1 alone - the user believes they addressed a fleet and addressed
+        // one box, which is the harm the unknown-host check below exists to
+        // prevent. Every other refusal in this function is loud.
+        if members.is_empty() {
+            return None;
+        }
         for member in members {
             // Only hosts croft actually knows: a typo must not become an ssh
             // attempt against a hostname the user never configured, and a
@@ -419,6 +428,49 @@ mod tests {
         // so the refusal above is the check and not a broken fixture.
         let ok = groups(&[("web", &["web1"])]);
         assert!(parse_request_with_groups("web: uname -r", &known, &ok).is_some());
+    }
+
+    /// A group that resolves to nothing refuses rather than narrowing the
+    /// fleet silently.
+    ///
+    /// The mixed case is the dangerous one: with an empty `web`, the spec
+    /// `web,db1` would otherwise run on db1 alone and report success, so the
+    /// user believes they addressed a fleet and addressed one box.
+    #[test]
+    fn an_empty_group_refuses_rather_than_narrowing_the_fleet() {
+        let known: Vec<String> = ["web1", "db1"].iter().map(|s| s.to_string()).collect();
+        let empty = groups(&[("web", &[])]);
+        assert!(
+            parse_request_with_groups("web: uptime", &known, &empty).is_none(),
+            "an empty group alone refuses"
+        );
+        assert!(
+            parse_request_with_groups("web,db1: uptime", &known, &empty).is_none(),
+            "and mixed with a real host it refuses too, rather than running on db1"
+        );
+        // Paired presence: the same spec with a populated group parses, so
+        // the refusals above are the emptiness and not a broken fixture.
+        let ok = groups(&[("web", &["web1"])]);
+        let (hosts, _) = parse_request_with_groups("web,db1: uptime", &known, &ok).expect("parsed");
+        assert_eq!(hosts.len(), 2);
+    }
+
+    /// Expansion is one level, so a self-referential group terminates at the
+    /// known-host check rather than looping. The doc makes this promise; a
+    /// later move to recursive expansion would break it silently.
+    #[test]
+    fn a_self_referential_group_refuses_instead_of_looping() {
+        let known: Vec<String> = ["web1"].iter().map(|s| s.to_string()).collect();
+        let looped = groups(&[("web", &["web"])]);
+        assert!(
+            parse_request_with_groups("web: uptime", &known, &looped).is_none(),
+            "'web' expands once to 'web', which is not a known host"
+        );
+        let mutual = groups(&[("a", &["b"]), ("b", &["a"])]);
+        assert!(
+            parse_request_with_groups("a: uptime", &known, &mutual).is_none(),
+            "mutual references terminate the same way"
+        );
     }
 
     /// A bare host name still works when groups exist, and a group named

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -174,7 +174,24 @@ pub fn fleet_ssh_args(host: &str, command: &str) -> Vec<String> {
 ///
 /// `*` is the explicit way to say "all of them", so the broadcast is still
 /// available to someone who means it.
-pub fn parse_request<'a>(input: &str, known: &'a [String]) -> Option<(Vec<&'a String>, String)> {
+/// Parse `hosts: command`, expanding any saved host groups (#363).
+///
+/// A name in the spec is looked up as a GROUP first and a host second, so a
+/// group named after a host cannot silently shadow it - the group wins, and
+/// naming one after a host is the user's own doing. Expansion is one level:
+/// a group listing another group's name resolves that entry as a host and
+/// fails the unknown-host check below, rather than recursing. Nesting would
+/// need cycle detection to be safe, and there is no case for it yet.
+///
+/// Every expanded name still goes through the same known-host check as a
+/// typed one. That is the property worth keeping: a group is a shorthand for
+/// hosts croft already knows, never a way to name a machine that is not in
+/// `~/.ssh/config`.
+pub fn parse_request_with_groups<'a>(
+    input: &str,
+    known: &'a [String],
+    groups: &std::collections::BTreeMap<String, Vec<String>>,
+) -> Option<(Vec<&'a String>, String)> {
     let (spec, command) = input.split_once(':')?;
     let command = command.trim();
     if command.is_empty() {
@@ -186,11 +203,19 @@ pub fn parse_request<'a>(input: &str, known: &'a [String]) -> Option<(Vec<&'a St
     }
     let mut hosts = Vec::new();
     for name in spec.split(',').map(str::trim).filter(|n| !n.is_empty()) {
-        // Only hosts croft actually knows: a typo must not become an ssh
-        // attempt against a hostname the user never configured.
-        let found = known.iter().find(|k| k.eq_ignore_ascii_case(name))?;
-        if !hosts.contains(&found) {
-            hosts.push(found);
+        // A group expands to the names it holds; anything else is one name.
+        let members: Vec<&str> = match groups.iter().find(|(g, _)| g.eq_ignore_ascii_case(name)) {
+            Some((_, members)) => members.iter().map(String::as_str).collect(),
+            None => vec![name],
+        };
+        for member in members {
+            // Only hosts croft actually knows: a typo must not become an ssh
+            // attempt against a hostname the user never configured, and a
+            // group cannot smuggle one past that check either.
+            let found = known.iter().find(|k| k.eq_ignore_ascii_case(member))?;
+            if !hosts.contains(&found) {
+                hosts.push(found);
+            }
         }
     }
     (!hosts.is_empty()).then_some((hosts, command.to_string()))
@@ -344,6 +369,80 @@ fn run_one(host: &str, command: &str, timeout: Duration) -> HostResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn groups(pairs: &[(&str, &[&str])]) -> std::collections::BTreeMap<String, Vec<String>> {
+        pairs
+            .iter()
+            .map(|(g, m)| {
+                (
+                    (*g).to_string(),
+                    m.iter().map(|h| (*h).to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    /// A saved group expands to its hosts (#363).
+    ///
+    /// The fixture gives the group TWO members out of three known hosts, so
+    /// a bug that expanded to everything - or to nothing and fell back to
+    /// the whole fleet - fails here. Expanding to `known` is the shape `*`
+    /// already has, and is exactly what must not happen by accident.
+    #[test]
+    fn a_saved_group_expands_to_its_hosts_and_only_those() {
+        let known: Vec<String> = ["web1", "web2", "db1"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let g = groups(&[("web", &["web1", "web2"])]);
+        let (hosts, cmd) = parse_request_with_groups("web: uname -r", &known, &g).expect("parsed");
+        assert_eq!(
+            hosts.iter().map(|h| h.as_str()).collect::<Vec<_>>(),
+            vec!["web1", "web2"],
+            "the group's members, not the whole fleet"
+        );
+        assert_eq!(cmd, "uname -r");
+    }
+
+    /// The known-host check survives group expansion, which is the safety
+    /// property: a group must be shorthand for hosts croft already knows,
+    /// never a way to name a machine that is not in `~/.ssh/config`.
+    #[test]
+    fn a_group_cannot_smuggle_an_unknown_host_past_the_check() {
+        let known: Vec<String> = ["web1"].iter().map(|s| s.to_string()).collect();
+        let g = groups(&[("web", &["web1", "not-configured"])]);
+        assert!(
+            parse_request_with_groups("web: uname -r", &known, &g).is_none(),
+            "an unknown member refuses the whole request rather than running on the rest"
+        );
+        // Paired presence: the same group without the stray member parses,
+        // so the refusal above is the check and not a broken fixture.
+        let ok = groups(&[("web", &["web1"])]);
+        assert!(parse_request_with_groups("web: uname -r", &known, &ok).is_some());
+    }
+
+    /// A bare host name still works when groups exist, and a group named
+    /// after a host wins - naming one that way is the user's own doing, and
+    /// silent shadowing in either direction is worse than a documented rule.
+    #[test]
+    fn a_group_name_takes_precedence_over_a_host_of_the_same_name() {
+        let known: Vec<String> = ["web1", "web2"].iter().map(|s| s.to_string()).collect();
+        let g = groups(&[("web1", &["web1", "web2"])]);
+        let (hosts, _) = parse_request_with_groups("web1: uptime", &known, &g).expect("parsed");
+        assert_eq!(
+            hosts.len(),
+            2,
+            "the GROUP named web1 expanded, not the host"
+        );
+
+        // With no group of that name, the same spec is the single host.
+        let (one, _) =
+            parse_request_with_groups("web1: uptime", &known, &groups(&[])).expect("parsed");
+        assert_eq!(
+            one.iter().map(|h| h.as_str()).collect::<Vec<_>>(),
+            vec!["web1"]
+        );
+    }
 
     fn r(host: &str, out: &str, exit: Option<i32>) -> HostResult {
         HostResult {
@@ -519,7 +618,7 @@ mod tests {
             .map(|s| String::from(*s))
             .collect();
         let p = |input: &str| {
-            parse_request(input, &known)
+            parse_request_with_groups(input, &known, &std::collections::BTreeMap::new())
                 .map(|(h, c)| (h.iter().map(|s| s.as_str()).collect::<Vec<_>>(), c))
         };
 

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -294,6 +294,20 @@ pub struct Prefs {
     /// host, a box you only ever tunnel through. User layers only.
     #[serde(default)]
     pub remote_offer_excluded_hosts: Vec<String>,
+    /// Named sets of SSH hosts for "Terminal: Fleet Run" (#363), so a fleet
+    /// can be named once rather than retyped per run.
+    ///
+    /// User layers only, and for the same reason as the list above: a fleet
+    /// run executes arbitrary text on every host in the set, so a group is a
+    /// list of machines to run commands on. A repo-controlled layer naming
+    /// one could add a production box to a group the user then broadcasts
+    /// to. `WORKSPACE_ALLOWED_KEYS` refuses it, and the refusal is visible
+    /// rather than silent.
+    ///
+    /// Ordered, so the fleet a group names is stable between runs: a
+    /// HashMap would reorder the tiles a comparison is read across.
+    #[serde(default)]
+    pub fleet_groups: std::collections::BTreeMap<String, Vec<String>>,
     /// The agent a new worktree lane starts in its pane (#348): the name of
     /// an `agents.json` row (built in: claude, codex, aider, gemini), whose
     /// `launch` line is typed into the lane's fresh shell. Unset, a lane

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -304,8 +304,9 @@ pub struct Prefs {
     /// to. `WORKSPACE_ALLOWED_KEYS` refuses it, and the refusal is visible
     /// rather than silent.
     ///
-    /// Ordered, so the fleet a group names is stable between runs: a
-    /// HashMap would reorder the tiles a comparison is read across.
+    /// Ordered, so the hosts a group names come back in the same order on
+    /// every run: a HashMap would shuffle them, and a fleet comparison is
+    /// read by scanning down the list.
     #[serde(default)]
     pub fleet_groups: std::collections::BTreeMap<String, Vec<String>>,
     /// The agent a new worktree lane starts in its pane (#348): the name of

--- a/src/release_notes/0.1.917.md
+++ b/src/release_notes/0.1.917.md
@@ -1,0 +1,1 @@
+change: name a set of SSH hosts once in your config and run a fleet command against it by that name, instead of retyping the list. A group only ever expands to hosts croft already knows, and a checked-out repo cannot define one.

--- a/src/release_notes/0.1.917.md
+++ b/src/release_notes/0.1.917.md
@@ -1,1 +1,0 @@
-change: name a set of SSH hosts once in your config and run a fleet command against it by that name, instead of retyping the list. A group only ever expands to hosts croft already knows, and a checked-out repo cannot define one.

--- a/src/release_notes/0.1.918.md
+++ b/src/release_notes/0.1.918.md
@@ -1,0 +1,1 @@
+feature: name a set of SSH hosts once in your config and run a fleet command against it by that name, instead of retyping the list. A group only ever expands to hosts croft already knows, and a checked-out repo cannot define one.


### PR DESCRIPTION
Part of #363 — **criterion 3 only**. Criteria 1 and 2 both describe *tiles*, and there is no fleet widget; that is a view design, not plumbing.

## The trust question was already answered

I was going to ask whether a repo may name SSH hosts. It can't, and croft had already decided: `prefs.rs` has `remote_offer_excluded_hosts: Vec<String>` — a host-name list, **absent from `WORKSPACE_ALLOWED_KEYS`**.

`fleet_groups` follows it exactly, and the reason is sharper here: a fleet run executes arbitrary text on every host in the set, so a checked-out repo defining a group could add a production box to a set the user then broadcasts to. `config_layers.rs` states the rule — workspace layers are repo-controlled input, and keys that change trust posture are refused with a visible warning.

I extended the **existing** refusal test rather than writing a parallel one, so `fleet_groups` is now covered by the same assertion that proves a clone cannot grant `mcp_consented`.

## What the expansion preserves

`parse_request_with_groups` keeps the unknown-host check on **every expanded name**. A group is shorthand for hosts croft already knows, never a way to name a machine absent from `~/.ssh/config`.

Three tests pin what a careless version gets wrong:

| test | what it catches |
| --- | --- |
| `a_saved_group_expands_to_its_hosts_and_only_those` | fixture gives 2 of 3 known hosts, so expanding to the whole fleet — the shape `*` already has — fails |
| `a_group_cannot_smuggle_an_unknown_host_past_the_check` | an unknown member refuses the **whole** request; paired presence case proves the refusal isn't a broken fixture |
| `a_group_name_takes_precedence_over_a_host_of_the_same_name` | stated rather than left to whichever branch runs first |

`BTreeMap` not `HashMap`: a fleet comparison is read across tiles, and a group whose order changed between runs would move them.

## Three defects, all found by building

1. **`App` has no `prefs` field** — prefs load into dedicated fields.
2. **The live re-merge path needed it too.** Found while fixing #1. Without it, `fleet_groups` would work at startup and then silently stop tracking `config.json` — a group edit would take effect only after a restart, and nothing would fail. That is the one I'm most glad of; it fails quietly.
3. **Dead code.** Keeping `parse_request` as a wrapper left it with no production caller once I rewired the real one, and `-D warnings` implies `-D dead-code`. Removed rather than `#[allow]`ed — a wrapper alive only through a test is the shape that rots. The tests now call the shipping path.

## Verification

63 group tests pass with all three new ones required **by name**; the trust test passes; clippy clean under `-D warnings`.

Verification was killed three times for host memory — no verdict either way, not failures — so the runner is now staged with tests before clippy, letting clippy reuse the test harness instead of building `--all-targets` from cold twice.