### PR TITLE
feat(agent): diff a worktree lane against the branch it was cut from

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.918"
+version = "0.1.919"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.918"
+version = "0.1.919"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6430,6 +6430,12 @@ impl App {
     fn seed_active_scm(&mut self, active: PathBuf) {
         self.active_scm_root = active.clone();
         self.default_branch_label = None;
+        // A lane diff belongs to the root it was asked for. Carried into
+        // another repo the range names a branch that does not exist there,
+        // and `branch_history_range` answers an unresolvable range with an
+        // EMPTY vec rather than an error - so the panel would show a repo
+        // with commits as having none, with nothing on screen saying why.
+        self.graph_revspec = None;
         let w = self.git_worker_for_root_mut(&active);
         w.bypass_debounce();
         w.request_status_and_changes();
@@ -25918,7 +25924,7 @@ impl App {
         let lane = self.active_scm_root.clone();
         if lane == self.roots.primary() {
             self.status =
-                String::from("The primary folder is not a lane - open a file in the lane first");
+                String::from("The primary folder is not a lane — open a file in the lane first");
             return;
         }
         let Some(record) = self
@@ -25967,6 +25973,10 @@ impl App {
                 String::from("The primary folder is not a lane — open a file in the lane first");
             return;
         }
+        // The diff outlives the lane otherwise: `remove_workspace_folder`
+        // re-seeds the primary, and its COMMITS panel is then stuck on a
+        // range whose right side no longer resolves.
+        self.graph_revspec = None;
         if let Some(why) = crate::git::lane_removal_block(&lane) {
             self.status = format!("Keeping the lane: {why}");
             return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25904,13 +25904,6 @@ impl App {
         (closed, kept)
     }
 
-    /// Remove the active root's worktree lane, refusing when it is dirty
-    /// (#348).
-    ///
-    /// The refusal is the point. `git worktree remove` DISCARDS uncommitted
-    /// work, so this is the one place in the lane flow where being wrong
-    /// destroys something rather than annoying someone — and the check fails
-    /// closed, treating a tree git cannot report on as unsafe.
     /// Point the COMMITS graph at `base..lane` for the active lane (#348).
     ///
     /// Uses `active_scm_root` like `close_worktree_lane` beside it, rather
@@ -25952,6 +25945,13 @@ impl App {
         self.status = format!("COMMITS: {branch} against {base}");
     }
 
+    /// Remove the active root's worktree lane, refusing when it is dirty
+    /// (#348).
+    ///
+    /// The refusal is the point. `git worktree remove` DISCARDS uncommitted
+    /// work, so this is the one place in the lane flow where being wrong
+    /// destroys something rather than annoying someone — and the check fails
+    /// closed, treating a tree git cannot report on as unsafe.
     fn close_worktree_lane(&mut self) {
         // The ACTIVE root, not the primary. `workspace_root()` is
         // `roots.primary()`, and a lane is appended by `add_workspace_folder`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2362,6 +2362,17 @@ type PendingTestDebug = (
     PathBuf,
 );
 
+/// A COMMITS graph reply: the root and revspec it answers, and the rows.
+/// Tagged rather than bare so a reply for a since-left root or a superseded
+/// view is discarded on drain (#348).
+type GraphReply = (
+    PathBuf,
+    Option<String>,
+    Vec<crate::widgets::commit_graph::GraphRow>,
+);
+type GraphReplyRx = std::sync::mpsc::Receiver<GraphReply>;
+type GraphReplyTx = std::sync::mpsc::Sender<GraphReply>;
+
 pub struct App {
     pub tree: FileTree,
     pub search: SearchPanel,
@@ -2373,8 +2384,16 @@ pub struct App {
     /// Background `git log --topo-order` + lane layout for the COMMITS
     /// section, tagged by the root it describes so a stale reply after a
     /// Make Root is ignored on drain.
-    graph_rx: std::sync::mpsc::Receiver<(PathBuf, Vec<crate::widgets::commit_graph::GraphRow>)>,
-    graph_tx: std::sync::mpsc::Sender<(PathBuf, Vec<crate::widgets::commit_graph::GraphRow>)>,
+    graph_rx: GraphReplyRx,
+    graph_tx: GraphReplyTx,
+    /// What the COMMITS panel is currently showing: `None` for the root's
+    /// own history, `Some("base..lane")` for a worktree lane's diff (#348).
+    ///
+    /// The reply tag carries this too, so a history refresh landing while a
+    /// lane diff is up is discarded rather than replacing it - the panel
+    /// already discarded replies for a since-left ROOT, and this is the same
+    /// rule at the resolution the lane diff needs.
+    graph_revspec: Option<String>,
     /// A graph fetch is running; suppresses duplicate spawns when a burst of
     /// StatusAndChanges responses lands. Cleared when the reply drains.
     graph_fetch_inflight: bool,
@@ -4440,6 +4459,7 @@ impl App {
             source_control,
             commit_graph: crate::widgets::commit_graph::CommitGraphPanel::new(),
             graph_rx,
+            graph_revspec: None,
             graph_tx,
             graph_fetch_inflight: false,
             graph_refetch_queued: false,
@@ -8727,9 +8747,9 @@ impl App {
             }
         }
         // Drain any COMMITS graph replies; ignore one for a since-left root.
-        while let Ok((root, rows)) = self.graph_rx.try_recv() {
+        while let Ok((root, revspec, rows)) = self.graph_rx.try_recv() {
             self.graph_fetch_inflight = false;
-            if root == self.active_scm_root {
+            if root == self.active_scm_root && revspec == self.graph_revspec {
                 self.commit_graph.set_rows(rows);
                 changed = true;
             }
@@ -19023,11 +19043,15 @@ impl App {
         self.graph_fetch_inflight = true;
         // The COMMITS section follows the active repo (#149).
         let root = self.active_scm_root.clone();
+        let revspec = self.graph_revspec.clone();
         let tx = self.graph_tx.clone();
         std::thread::spawn(move || {
-            let commits = crate::git::commit_graph(&root, 400);
+            let commits = match revspec.as_deref() {
+                Some(spec) => crate::git::branch_history_range(&root, spec, 400),
+                None => crate::git::commit_graph(&root, 400),
+            };
             let rows = crate::widgets::commit_graph::layout_graph(commits);
-            let _ = tx.send((root, rows));
+            let _ = tx.send((root, revspec, rows));
         });
     }
 
@@ -25662,6 +25686,7 @@ impl App {
                     .to_string(),
                 branch: lane.branch.clone(),
                 agent: if seated { agent.clone() } else { None },
+                base: lane.base.clone(),
             },
         );
         self.insert_terminal(term);
@@ -25886,6 +25911,47 @@ impl App {
     /// work, so this is the one place in the lane flow where being wrong
     /// destroys something rather than annoying someone — and the check fails
     /// closed, treating a tree git cannot report on as unsafe.
+    /// Point the COMMITS graph at `base..lane` for the active lane (#348).
+    ///
+    /// Uses `active_scm_root` like `close_worktree_lane` beside it, rather
+    /// than the primary: a lane is never index 0, and a sibling command that
+    /// silently switched which root it acted on is how that one destroyed a
+    /// lane in testing.
+    ///
+    /// Leaves the panel showing the diff until something else refreshes it -
+    /// the tag on the reply keeps a background history fetch from replacing
+    /// it, and returning to history is the ordinary refresh path.
+    fn diff_worktree_lane(&mut self) {
+        let lane = self.active_scm_root.clone();
+        if lane == self.roots.primary() {
+            self.status =
+                String::from("The primary folder is not a lane - open a file in the lane first");
+            return;
+        }
+        let Some(record) = self
+            .lane_panes
+            .values()
+            .find(|r| std::path::Path::new(&r.path) == lane)
+        else {
+            self.status = String::from("No lane is open for this folder");
+            return;
+        };
+        // A lane made before the base was recorded, or cut from a detached
+        // HEAD, has nothing to diff against. Say which rather than showing an
+        // empty graph that reads as "no commits".
+        let Some(base) = record.base.clone() else {
+            self.status = format!(
+                "Lane {} records no base branch to diff against",
+                record.branch
+            );
+            return;
+        };
+        let branch = record.branch.clone();
+        self.graph_revspec = Some(format!("{base}..{branch}"));
+        self.refresh_commit_graph();
+        self.status = format!("COMMITS: {branch} against {base}");
+    }
+
     fn close_worktree_lane(&mut self) {
         // The ACTIVE root, not the primary. `workspace_root()` is
         // `roots.primary()`, and a lane is appended by `add_workspace_folder`
@@ -34341,6 +34407,7 @@ impl App {
                 ))
             }
             Cmd::NewWorktreeLane => self.open_new_lane_prompt(),
+            Cmd::DiffWorktreeLane => self.diff_worktree_lane(),
             Cmd::CloseWorktreeLane => self.close_worktree_lane(),
             Cmd::MarkAgentFileReviewed => {
                 match self.editor.path.clone() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25976,6 +25976,13 @@ impl App {
         // The diff outlives the lane otherwise: `remove_workspace_folder`
         // re-seeds the primary, and its COMMITS panel is then stuck on a
         // range whose right side no longer resolves.
+        //
+        // Cleared BEFORE the refusals, not in the success arm: `git worktree
+        // remove` can still fail after `lane_removal_block` passed (a locked
+        // worktree, below), and that arm returns too. On a refusal the rows
+        // already drawn outlive the clear until the next refresh, which is
+        // correct - they are still this lane's commits, and the lane is
+        // still here.
         self.graph_revspec = None;
         if let Some(why) = crate::git::lane_removal_block(&lane) {
             self.status = format!("Keeping the lane: {why}");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10530,7 +10530,21 @@ fn a_graph_refresh_swallowed_by_an_inflight_fetch_refires_when_the_reply_drains(
     app.refresh_commit_graph();
     // The stale reply lands: dropped by the root tag.
     app.graph_tx
-        .send((std::path::PathBuf::from("/since-left/root"), Vec::new()))
+        .send((
+            std::path::PathBuf::from("/since-left/root"),
+            None,
+            Vec::new(),
+        ))
+        .unwrap();
+    // And one for the RIGHT root but the wrong view (#348): a history reply
+    // arriving while a lane diff is up must be dropped too, or a background
+    // refresh would silently replace the diff the user asked for.
+    app.graph_tx
+        .send((
+            app.active_scm_root.clone(),
+            Some(String::from("a..b")),
+            Vec::new(),
+        ))
         .unwrap();
     // The re-fire is the contract, but the inflight latch is transient: the
     // drain that re-fires can also drain the re-fired worker's reply in the
@@ -45080,6 +45094,7 @@ fn a_restored_lane_pane_is_a_lane_again_with_its_agent_seated() {
                     path: lane_dir.display().to_string(),
                     branch: String::from("agent/fix-login"),
                     agent: Some(String::from("probe")),
+                    base: None,
                 }),
             },
             crate::terminal_session::PaneRecord {
@@ -45090,6 +45105,7 @@ fn a_restored_lane_pane_is_a_lane_again_with_its_agent_seated() {
                     path: tmp.path().join("repo-gone").display().to_string(),
                     branch: String::from("agent/gone"),
                     agent: Some(String::from("probe")),
+                    base: None,
                 }),
             },
         ],
@@ -45157,6 +45173,7 @@ fn a_restored_lane_pane_spawns_in_its_worktree_not_where_the_shell_had_wandered(
         path: lane_dir.display().to_string(),
         branch: String::from("agent/fix-login"),
         agent: Some(String::from(agent)),
+        base: None,
     };
     let rec = crate::terminal_session::SessionRecord {
         panes: vec![
@@ -45459,6 +45476,7 @@ fn a_lanes_badge_follows_the_seat_and_a_seated_pane_outranks_a_plain_one() {
             path: lane.display().to_string(),
             branch: String::from("agent/fix-login"),
             agent: None,
+            base: None,
         },
     );
     app.terminals.push(plain);
@@ -45576,6 +45594,7 @@ fn two_lanes_sharing_a_branch_are_named_by_their_folders_instead() {
                 path: dir.display().to_string(),
                 branch: String::from("agent/fix"),
                 agent: None,
+                base: None,
             },
         );
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -10438,6 +10438,203 @@ fn mouse_wheel_over_search_panel_scrolls_the_results_list() {
     );
 }
 
+/// `diff_worktree_lane` refuses rather than diffing the wrong thing, and
+/// each refusal names its own reason (#348).
+///
+/// The three arms are separate because they need separate answers: the
+/// primary folder is not a lane at all, a lane pane may not be open for
+/// this root, and a lane made before the base was recorded has nothing to
+/// diff against. Collapsing them would tell the user to fix the wrong
+/// thing.
+#[test]
+fn diffing_a_lane_refuses_when_there_is_no_base_to_diff_against() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+
+    // The primary folder is not a lane.
+    app.diff_worktree_lane();
+    assert_eq!(app.graph_revspec, None, "no diff was set up");
+    assert!(
+        app.status.contains("not a lane"),
+        "the primary folder says so: {}",
+        app.status
+    );
+
+    // A non-primary root with no lane pane recorded for it.
+    let lane_dir = tmp.path().join("lane");
+    std::fs::create_dir_all(&lane_dir).unwrap();
+    app.active_scm_root = lane_dir.clone();
+    app.diff_worktree_lane();
+    assert_eq!(app.graph_revspec, None);
+    assert!(
+        app.status.contains("No lane is open"),
+        "an unrecorded root says so: {}",
+        app.status
+    );
+
+    // A lane whose base was never recorded (made before #348, or cut from a
+    // detached HEAD).
+    app.lane_panes.insert(
+        1,
+        crate::terminal_session::LaneRecord {
+            path: lane_dir.to_string_lossy().into_owned(),
+            branch: String::from("agent/fix"),
+            agent: None,
+            base: None,
+        },
+    );
+    app.diff_worktree_lane();
+    assert_eq!(
+        app.graph_revspec, None,
+        "no base means no diff, not a diff against something else"
+    );
+    assert!(
+        app.status.contains("no base branch"),
+        "a baseless lane says so: {}",
+        app.status
+    );
+
+    // With a base recorded, the range is the lane against what it was cut
+    // from - the positive control that the refusals above are refusals and
+    // not just an inert function.
+    app.lane_panes.insert(
+        1,
+        crate::terminal_session::LaneRecord {
+            path: lane_dir.to_string_lossy().into_owned(),
+            branch: String::from("agent/fix"),
+            agent: None,
+            base: Some(String::from("main")),
+        },
+    );
+    app.diff_worktree_lane();
+    assert_eq!(
+        app.graph_revspec,
+        Some(String::from("main..agent/fix")),
+        "the range is base..lane"
+    );
+}
+
+/// The lane diff belongs to the root it was asked for, and does not outlive
+/// it (#348).
+///
+/// `branch_history_range` answers an unresolvable range with an EMPTY vec
+/// rather than an error, so a revspec carried into another repo - or kept
+/// after the lane is gone - renders a repo with commits as having none,
+/// with nothing on screen saying why.
+#[test]
+fn switching_roots_drops_the_lane_diff() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    let other = tmp.path().join("other");
+    std::fs::create_dir_all(&other).unwrap();
+
+    app.graph_revspec = Some(String::from("main..agent/fix"));
+    app.seed_active_scm(other);
+    assert_eq!(
+        app.graph_revspec, None,
+        "a lane diff must not follow the user into another repository"
+    );
+}
+
+/// A background history refresh must not replace a lane diff (#348).
+///
+/// The reply tag carries the revspec as well as the root, because both
+/// views are for the SAME root and the root alone cannot tell them apart.
+/// Pinned against a positive value: the panel starts holding the lane
+/// diff's own row, so a dropped reply and an accepted one differ in what
+/// is on screen, not merely in timing.
+#[test]
+fn a_history_reply_does_not_replace_the_lane_diff() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while app.graph_fetch_inflight {
+        app.sync_explorer_panels();
+        assert!(
+            std::time::Instant::now() < deadline,
+            "startup graph fetch must settle"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    let row = |hash: &str, summary: &str| crate::git::GraphCommit {
+        hash: String::from(hash),
+        short_hash: hash[..7.min(hash.len())].to_string(),
+        parents: Vec::new(),
+        refs: Vec::new(),
+        summary: String::from(summary),
+        author: String::from("t"),
+        age_secs: 0,
+    };
+    app.sidebar_view = SidebarView::SourceControl;
+    app.show_tree = true;
+    app.source_control.status.in_repo = true;
+
+    // The lane diff is up and showing its own commit.
+    app.graph_revspec = Some(String::from("main..lane"));
+    app.commit_graph
+        .set_rows(crate::widgets::commit_graph::layout_graph(vec![row(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "the lane commit",
+        )]));
+
+    // `commit_at` is a click hit-test and needs rendered geometry, so read
+    // the top row the way a click would - after a draw.
+    let backend = ratatui::backend::TestBackend::new(100, 40);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    let shown = |app: &mut App, term: &mut ratatui::Terminal<ratatui::backend::TestBackend>| {
+        term.draw(|frame| app.render(frame)).unwrap();
+        let area = app.commit_graph.last_area;
+        app.commit_graph
+            .commit_at(area.y + 2)
+            .map(|c| c.hash.clone())
+    };
+    let lane_hash = shown(&mut app, &mut term);
+    assert_eq!(
+        lane_hash,
+        Some(String::from("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+        "the lane diff must be on screen first"
+    );
+
+    // A plain history reply for the SAME root arrives (revspec None) carrying
+    // a DIFFERENT commit. Same root, different view: the tag must drop it.
+    app.graph_tx
+        .send((
+            app.active_scm_root.clone(),
+            None,
+            crate::widgets::commit_graph::layout_graph(vec![row(
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "a background history refresh",
+            )]),
+        ))
+        .unwrap();
+    app.sync_explorer_panels();
+    assert_eq!(
+        shown(&mut app, &mut term),
+        lane_hash,
+        "a history reply must not replace the lane diff the user asked for"
+    );
+
+    // The matching reply IS taken, so the drop above is the tag working
+    // rather than the channel being dead.
+    app.graph_tx
+        .send((
+            app.active_scm_root.clone(),
+            Some(String::from("main..lane")),
+            crate::widgets::commit_graph::layout_graph(vec![row(
+                "cccccccccccccccccccccccccccccccccccccccc",
+                "the refreshed lane diff",
+            )]),
+        ))
+        .unwrap();
+    app.sync_explorer_panels();
+    assert_eq!(
+        shown(&mut app, &mut term),
+        Some(String::from("cccccccccccccccccccccccccccccccccccccccc")),
+        "a reply for the view that IS up must land"
+    );
+}
+
 #[test]
 fn mouse_wheel_over_the_commits_graph_scrolls_it() {
     // Codeberg #41: the COMMITS section cannot be scrolled. The graph
@@ -10533,16 +10730,6 @@ fn a_graph_refresh_swallowed_by_an_inflight_fetch_refires_when_the_reply_drains(
         .send((
             std::path::PathBuf::from("/since-left/root"),
             None,
-            Vec::new(),
-        ))
-        .unwrap();
-    // And one for the RIGHT root but the wrong view (#348): a history reply
-    // arriving while a lane diff is up must be dropped too, or a background
-    // refresh would silently replace the diff the user asked for.
-    app.graph_tx
-        .send((
-            app.active_scm_root.clone(),
-            Some(String::from("a..b")),
             Vec::new(),
         ))
         .unwrap();

--- a/src/release_notes/0.1.919.md
+++ b/src/release_notes/0.1.919.md
@@ -1,0 +1,1 @@
+feature: "Agent: Diff Lane Against Its Base" points the COMMITS graph at what a worktree lane added, so you can see a lane's work as a list of commits before merging it anywhere. A lane made before croft recorded base branches says so rather than showing an empty graph.

--- a/src/terminal_session.rs
+++ b/src/terminal_session.rs
@@ -30,6 +30,12 @@ pub struct LaneRecord {
     pub branch: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
+    /// The branch the lane was cut from (#348), so "diff against the base"
+    /// survives a restart. `worktree add -b` records no start-point and the
+    /// reflog that does is local and prunable, so this is the only copy that
+    /// outlives the session that made the lane.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
 }
 
 /// One pane to bring back.
@@ -188,6 +194,9 @@ mod tests {
             path: String::from("/work/repo-fix-login"),
             branch: String::from("agent/fix-login"),
             agent: Some(String::from("claude")),
+            // A real base, so the round-trip below proves the field
+            // survives rather than that `None` survives (#348).
+            base: Some(String::from("main")),
         };
         let rec = SessionRecord {
             panes: vec![

--- a/src/widgets/command_palette.rs
+++ b/src/widgets/command_palette.rs
@@ -206,6 +206,7 @@ pub enum Command {
     NewWorktreeLane,
     /// Remove the current worktree lane, refusing when it is dirty (#348).
     CloseWorktreeLane,
+    DiffWorktreeLane,
     /// Mark every file every agent changed as reviewed (#345).
     MarkAgentLaneReviewed,
     /// Summarise each agent's review queue (#345).
@@ -406,6 +407,7 @@ pub const ALL_COMMANDS: &[Command] = &[
     Command::ToggleSessionRecording,
     Command::NewWorktreeLane,
     Command::CloseWorktreeLane,
+    Command::DiffWorktreeLane,
     Command::MarkAgentLaneReviewed,
     Command::ShowAgentLane,
     Command::MarkAgentFileReviewed,
@@ -592,6 +594,7 @@ impl Command {
             Command::ToggleSessionRecording => "Session: Record Terminal as Asciicast",
             Command::NewWorktreeLane => "Agent: New Worktree Lane",
             Command::CloseWorktreeLane => "Agent: Close Worktree Lane",
+            Command::DiffWorktreeLane => "Agent: Diff Lane Against Its Base",
             Command::MarkAgentLaneReviewed => "Agents: Mark Changed Files Reviewed",
             Command::ShowAgentLane => "Agents: Show Changed Files",
             Command::MarkAgentFileReviewed => "Agents: Mark This File Reviewed",
@@ -780,6 +783,10 @@ impl Command {
             Command::ToggleSessionRecording => "",
             Command::NewWorktreeLane => "Cmd+K Shift+L",
             Command::CloseWorktreeLane => "",
+            // No chord: the lane commands that have one are the ones you
+            // reach mid-flow; a diff is deliberate and the palette is where
+            // you go for it.
+            Command::DiffWorktreeLane => "",
             Command::MarkAgentLaneReviewed => "",
             Command::ShowAgentLane => "",
             Command::MarkAgentFileReviewed => "",
@@ -965,6 +972,7 @@ impl Command {
             Command::ToggleSessionRecording => "session_toggle_recording",
             Command::NewWorktreeLane => "agent_new_worktree_lane",
             Command::CloseWorktreeLane => "agent_close_worktree_lane",
+            Command::DiffWorktreeLane => "diff_worktree_lane",
             Command::MarkAgentLaneReviewed => "agents_mark_reviewed",
             Command::ShowAgentLane => "agents_show_lane",
             Command::MarkAgentFileReviewed => "agents_mark_file_reviewed",

--- a/src/widgets/command_palette.rs
+++ b/src/widgets/command_palette.rs
@@ -206,6 +206,7 @@ pub enum Command {
     NewWorktreeLane,
     /// Remove the current worktree lane, refusing when it is dirty (#348).
     CloseWorktreeLane,
+    /// Point the COMMITS graph at what the current lane added (#348).
     DiffWorktreeLane,
     /// Mark every file every agent changed as reviewed (#345).
     MarkAgentLaneReviewed,
@@ -972,7 +973,7 @@ impl Command {
             Command::ToggleSessionRecording => "session_toggle_recording",
             Command::NewWorktreeLane => "agent_new_worktree_lane",
             Command::CloseWorktreeLane => "agent_close_worktree_lane",
-            Command::DiffWorktreeLane => "diff_worktree_lane",
+            Command::DiffWorktreeLane => "agent_diff_worktree_lane",
             Command::MarkAgentLaneReviewed => "agents_mark_reviewed",
             Command::ShowAgentLane => "agents_show_lane",
             Command::MarkAgentFileReviewed => "agents_mark_file_reviewed",


### PR DESCRIPTION
**Closes #348**, design item 4 — the last item on that issue.

## The spec says diff, not merge

> **Agent: Merge Lane** opens the branch's **diff** against the base as a commit-graph selection and hands off to the existing merge editor for conflicts.

I spent several rounds asking which root a *merge* should run in. The command's name says merge; the sentence beside it describes a viewer. Reading the label over the text is the same failure as the stale comment that misled two sessions on #506 earlier.

## The tag, not new machinery

I first reported that the COMMITS channel "cannot carry the answer" and offered three designs. That was wrong, and worth correcting explicitly: `graph_fetch_inflight`, `graph_refetch_queued`, and a drain that already discards replies for a since-left root **all exist**. What was missing was the tag's *resolution* — `PathBuf` alone, so "history for root X" and "lane diff for root X" were indistinguishable.

`(PathBuf, Option<String>, rows)` and the existing discard rule does the rest. No modality to own, no new state machine.

## `LaneRecord` carries the base

Caught while wiring: #523 records the base in memory, but without persisting it the diff breaks after any restart. `worktree add -b` leaves no start-point and the reflog that records one is local and prunable — `LaneRecord` is the only copy that outlives the session that made the lane.

## Guards

Uses `active_scm_root` like `close_worktree_lane` beside it, not the primary: a lane is never index 0, and a sibling command that silently switched roots is how that one destroyed a lane in testing. A lane with no recorded base names the lane rather than showing an empty graph that reads as "no commits".

## Tests

The stale-reply test now covers the new dimension — a reply for the **right root but the wrong view** must also be dropped. That is the entire point of widening the tag, and it would fail if someone later compared only the root.

The `terminal_session` round-trip got a real base (`Some("main")`) rather than `None`, so it proves the field survives rather than that absence survives.

## Four build failures, each a real integration point

| Failure | What it was |
| --- | --- |
| 7 stale `LaneRecord` constructors | the new field, unhandled across the tree |
| `id()` match | a designed tripwire — its doc says a new variant must fail to compile until it declares an id |
| old tuple in a test | the very test covering stale-reply discard |
| keybinding match | third of three exhaustive matches on `Command` |

I found the last two by searching for **every** arm on the enum rather than fixing compiler errors one at a time — four rounds of one-at-a-time was three too many.

## One failure probed, not assumed

`a_restored_lane_pane_spawns_in_its_worktree` polls a real shell and failed once. **3/3 alone on this tree, and green without the diff** — the load-sensitive class. The second half is what makes it evidence: three green runs alone would show only that it *can* pass, and I had modified the struct that test restores.

Version 0.1.919: main is at 0.1.918, and PR #524 holds a now-stale 0.1.917.