### PR TITLE
feat(agent): diff a lane file against the snapshot you reviewed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.918"
+version = "0.1.921"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.918"
+version = "0.1.921"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/agent_lane.rs
+++ b/src/agent_lane.rs
@@ -30,6 +30,13 @@ pub struct LaneFile {
     /// Content hash when the user last marked it reviewed; `None` until the
     /// first review, which is what makes a newly-touched file unreviewed.
     pub reviewed_hash: Option<u64>,
+    /// Milliseconds of the local-history snapshot holding the content that
+    /// became the baseline, so the row can be DIFFED against what the user
+    /// approved rather than only compared to it (#345). `None` when the
+    /// snapshot could not be taken — the store is best-effort, and a row
+    /// with no anchor refuses the diff rather than showing one against a
+    /// baseline it cannot name.
+    pub reviewed_millis: Option<u64>,
     /// Content hash at the most recent attributed write.
     pub current_hash: u64,
     /// How many attributed writes have landed since the last review.
@@ -200,6 +207,7 @@ impl AgentLedger {
                         LaneFile {
                             path: path.to_path_buf(),
                             reviewed_hash: None,
+                            reviewed_millis: None,
                             current_hash: hash,
                             writes_since_review: 1,
                             last_write_seq: seq,
@@ -322,7 +330,18 @@ impl AgentLedger {
     /// hash now, which may differ from the last attributed write if the
     /// user edited it themselves in between — reviewing means "I have seen
     /// what is on disk", not "I have seen what the agent last wrote".
-    pub fn mark_reviewed(&mut self, agent: &str, path: &Path, current: u64) -> bool {
+    ///
+    /// `snapshot_millis` anchors WHICH local-history snapshot holds that
+    /// content, so the row can later be diffed against it. `None` is a
+    /// legitimate outcome, not an error: the store is best-effort, and a row
+    /// without an anchor is still reviewed — it just cannot show a diff.
+    pub fn mark_reviewed(
+        &mut self,
+        agent: &str,
+        path: &Path,
+        current: u64,
+        snapshot_millis: Option<u64>,
+    ) -> bool {
         let Some(lane) = self.lanes.get_mut(agent) else {
             return false;
         };
@@ -330,6 +349,7 @@ impl AgentLedger {
             return false;
         };
         entry.reviewed_hash = Some(current);
+        entry.reviewed_millis = snapshot_millis;
         entry.current_hash = current;
         entry.writes_since_review = 0;
         self.settle_if_empty();
@@ -347,6 +367,7 @@ impl AgentLedger {
         &mut self,
         agent: &str,
         read: impl Fn(&Path) -> Baseline,
+        snapshot: impl Fn(&Path) -> Option<u64>,
     ) -> (usize, usize) {
         let Some(lane) = self.lanes.get_mut(agent) else {
             return (0, 0);
@@ -360,6 +381,10 @@ impl AgentLedger {
             match read(&entry.path) {
                 Baseline::Hash(current) => {
                     entry.reviewed_hash = Some(current);
+                    // Per row, not once for the lane: each file has its own
+                    // snapshot, and one that failed to record must not
+                    // inherit a sibling's anchor.
+                    entry.reviewed_millis = snapshot(&entry.path);
                     entry.current_hash = current;
                     entry.writes_since_review = 0;
                     cleared += 1;
@@ -467,7 +492,7 @@ mod tests {
 
         // Reviewing one clears just that row, and it leaves the lane's
         // ordering with the unreviewed file first.
-        assert!(led.mark_reviewed("claude", &p("/w/src/a.rs"), 1));
+        assert!(led.mark_reviewed("claude", &p("/w/src/a.rs"), 1, None));
         assert_eq!(led.unreviewed_count("claude"), 1);
         assert!(!led.is_unreviewed(&p("/w/src/a.rs")));
         let rows = led.lane("claude");
@@ -482,7 +507,7 @@ mod tests {
         assert_eq!(led.unreviewed_count("claude"), 2);
 
         // A write that restores the reviewed content does NOT re-queue it.
-        led.mark_reviewed("claude", &p("/w/src/a.rs"), 99);
+        led.mark_reviewed("claude", &p("/w/src/a.rs"), 99, None);
         assert!(!led.record_write(&p("/w/src/a.rs"), 99, &claude));
         assert!(!led.is_unreviewed(&p("/w/src/a.rs")));
     }
@@ -508,7 +533,7 @@ mod tests {
 
         // Reviewing it in one lane leaves the other's row standing: each
         // agent's queue is its own.
-        led.mark_reviewed("claude", &p("/w/x.rs"), 7);
+        led.mark_reviewed("claude", &p("/w/x.rs"), 7, None);
         assert_eq!(led.unreviewed_count("claude"), 0);
         assert_eq!(led.unreviewed_count("codex"), 1);
         assert_eq!(led.total_unreviewed(), 1, "one row left");
@@ -557,13 +582,17 @@ mod tests {
 
         // `a.rs` moved on disk since the agent's write (the user edited it);
         // `gone.rs` no longer exists.
-        let (cleared, dropped) = led.mark_lane_reviewed("claude", |path| {
-            if path == p("/w/a.rs") {
-                Baseline::Hash(42)
-            } else {
-                Baseline::Gone
-            }
-        });
+        let (cleared, dropped) = led.mark_lane_reviewed(
+            "claude",
+            |path| {
+                if path == p("/w/a.rs") {
+                    Baseline::Hash(42)
+                } else {
+                    Baseline::Gone
+                }
+            },
+            |_| None,
+        );
         assert_eq!(
             (cleared, dropped),
             (1, 1),
@@ -592,6 +621,79 @@ mod tests {
         assert!(!led.forget("claude"));
     }
 
+    /// Reviewing records WHICH snapshot became the baseline, not just its
+    /// hash. A hash answers "changed?"; diffing the row against what the
+    /// user actually approved needs the content, and the snapshot millis is
+    /// the anchor that retrieves it (#345).
+    #[test]
+    fn reviewing_records_the_snapshot_it_baselined_against() {
+        let mut led = AgentLedger::new();
+        let agent = vec![String::from("claude")];
+        led.record_write(&p("/w/a.rs"), 1, &agent);
+
+        // Before any review there is no baseline to diff against. Paired
+        // with the positive case below so this cannot pass vacuously.
+        let row = led.lane("claude")[0];
+        assert_eq!(row.reviewed_millis, None, "nothing reviewed yet");
+
+        assert!(led.mark_reviewed("claude", &p("/w/a.rs"), 42, Some(1_700)));
+        let row = led.lane("claude")[0];
+        assert_eq!(
+            row.reviewed_millis,
+            Some(1_700),
+            "the snapshot that became the baseline is retrievable later"
+        );
+        assert_eq!(row.reviewed_hash, Some(42));
+
+        // A later write keeps the anchor: the row is unreviewed AGAINST that
+        // snapshot, which is exactly what the diff needs.
+        led.record_write(&p("/w/a.rs"), 43, &agent);
+        let row = led.lane("claude")[0];
+        assert!(row.unreviewed());
+        assert_eq!(
+            row.reviewed_millis,
+            Some(1_700),
+            "a new write does not erase the baseline it is measured against"
+        );
+    }
+
+    /// A whole-lane review records each row's snapshot too, and a row whose
+    /// content could not be snapshotted records none rather than borrowing
+    /// another row's — a diff against the wrong baseline is worse than none.
+    #[test]
+    fn marking_a_whole_lane_records_each_rows_snapshot() {
+        let mut led = AgentLedger::new();
+        let agent = vec![String::from("claude")];
+        led.record_write(&p("/w/a.rs"), 1, &agent);
+        led.record_write(&p("/w/b.rs"), 2, &agent);
+
+        let (cleared, dropped) = led.mark_lane_reviewed(
+            "claude",
+            |path| {
+                if path == p("/w/a.rs") {
+                    Baseline::Hash(10)
+                } else {
+                    Baseline::Hash(20)
+                }
+            },
+            // Snapshotting `b.rs` failed (the store is best-effort), so it
+            // gets a baseline hash but no retrievable content.
+            |path| (path == p("/w/a.rs")).then_some(2_500),
+        );
+        assert_eq!((cleared, dropped), (2, 0));
+
+        let rows = led.lane("claude");
+        let a = rows.iter().find(|f| f.path == p("/w/a.rs")).unwrap();
+        let b = rows.iter().find(|f| f.path == p("/w/b.rs")).unwrap();
+        assert_eq!(a.reviewed_millis, Some(2_500));
+        assert_eq!(
+            b.reviewed_millis, None,
+            "a row that could not be snapshotted records no anchor rather \
+             than inheriting the other row's"
+        );
+        assert_eq!(b.reviewed_hash, Some(20), "it is still reviewed");
+    }
+
     /// The queue is ordered by RECENCY, not by path: the file the agent
     /// just wrote belongs at the top even when its name sorts last.
     #[test]
@@ -612,7 +714,7 @@ mod tests {
 
         // Reviewed rows sink below every unreviewed one regardless of when
         // they were written.
-        led.mark_reviewed("claude", &p("/w/a.rs"), 3);
+        led.mark_reviewed("claude", &p("/w/a.rs"), 3, None);
         assert_eq!(led.lane("claude")[0].path, p("/w/z.rs"));
         assert_eq!(led.lane("claude")[1].path, p("/w/a.rs"));
     }
@@ -671,7 +773,7 @@ mod tests {
                     .find(|x| x.path == f)
                     .unwrap()
                     .current_hash;
-                led.mark_reviewed("claude", &f, h);
+                led.mark_reviewed("claude", &f, h, None);
             }
         }
         let groups = led.lane_by_root("claude", &roots);
@@ -722,14 +824,14 @@ mod tests {
         // Reviewing SOME of the queue keeps the doubt: a dropped write may
         // be among what is left.
         led.record_write(&p("/w/b.rs"), 2, &a);
-        led.mark_reviewed("claude", &p("/w/a.rs"), 1);
+        led.mark_reviewed("claude", &p("/w/a.rs"), 1, None);
         assert!(led.may_be_incomplete());
 
         // Emptying it through mark_reviewed ALONE must settle it too: the
         // previous version of this test emptied the queue with
         // mark_lane_reviewed, so it passed whether or not mark_reviewed
         // cleared the flag.
-        led.mark_reviewed("claude", &p("/w/b.rs"), 2);
+        led.mark_reviewed("claude", &p("/w/b.rs"), 2, None);
         assert!(
             !led.may_be_incomplete(),
             "reviewing the last queued file one-by-one settles the doubt too"
@@ -763,7 +865,7 @@ mod tests {
         led.record_write(&p("/w/d.rs"), 4, &a);
 
         // Emptying it settles the question: nothing is left to be wrong.
-        let (reviewed, _) = led.mark_lane_reviewed("claude", |_| Baseline::Hash(4));
+        let (reviewed, _) = led.mark_lane_reviewed("claude", |_| Baseline::Hash(4), |_| None);
         assert_eq!(reviewed, 1);
         assert!(
             !led.may_be_incomplete(),
@@ -782,7 +884,8 @@ mod tests {
         assert_eq!(led.unreviewed_count("claude"), 1);
 
         // The read fails this instant, whatever the disk holds.
-        let (cleared, dropped) = led.mark_lane_reviewed("claude", |_| Baseline::Unreadable);
+        let (cleared, dropped) =
+            led.mark_lane_reviewed("claude", |_| Baseline::Unreadable, |_| None);
         assert_eq!(
             (cleared, dropped),
             (0, 0),
@@ -796,7 +899,7 @@ mod tests {
 
         // And it is still recoverable once the read succeeds.
         assert_eq!(
-            led.mark_lane_reviewed("claude", |_| Baseline::Hash(555)),
+            led.mark_lane_reviewed("claude", |_| Baseline::Hash(555), |_| None),
             (1, 0)
         );
         assert_eq!(led.unreviewed_count("claude"), 0);

--- a/src/agent_lane.rs
+++ b/src/agent_lane.rs
@@ -356,8 +356,9 @@ impl AgentLedger {
         true
     }
 
-    /// Mark every file in one lane reviewed, using `read` to see each
-    /// file's current content.
+    /// Mark every file in one lane reviewed, using `read` to see each file's
+    /// current content and, in the same call, the local-history snapshot
+    /// holding exactly those bytes.
     ///
     /// Returns `(reviewed, dropped)`: rows whose current content became the
     /// baseline, and rows removed because the file is gone. They are counted
@@ -366,8 +367,7 @@ impl AgentLedger {
     pub fn mark_lane_reviewed(
         &mut self,
         agent: &str,
-        read: impl Fn(&Path) -> Baseline,
-        snapshot: impl Fn(&Path) -> Option<u64>,
+        read: impl Fn(&Path) -> (Baseline, Option<u64>),
     ) -> (usize, usize) {
         let Some(lane) = self.lanes.get_mut(agent) else {
             return (0, 0);
@@ -378,13 +378,16 @@ impl AgentLedger {
             if !entry.unreviewed() {
                 continue;
             }
-            match read(&entry.path) {
+            // One call per row returns both, from ONE read of the file: a
+            // second read could see different bytes, and the baseline hash
+            // would then describe content the anchor does not hold. Per row,
+            // never once for the lane - a snapshot that failed to record must
+            // not inherit a sibling's anchor.
+            let (baseline, snapshot_millis) = read(&entry.path);
+            match baseline {
                 Baseline::Hash(current) => {
                     entry.reviewed_hash = Some(current);
-                    // Per row, not once for the lane: each file has its own
-                    // snapshot, and one that failed to record must not
-                    // inherit a sibling's anchor.
-                    entry.reviewed_millis = snapshot(&entry.path);
+                    entry.reviewed_millis = snapshot_millis;
                     entry.current_hash = current;
                     entry.writes_since_review = 0;
                     cleared += 1;
@@ -582,17 +585,13 @@ mod tests {
 
         // `a.rs` moved on disk since the agent's write (the user edited it);
         // `gone.rs` no longer exists.
-        let (cleared, dropped) = led.mark_lane_reviewed(
-            "claude",
-            |path| {
-                if path == p("/w/a.rs") {
-                    Baseline::Hash(42)
-                } else {
-                    Baseline::Gone
-                }
-            },
-            |_| None,
-        );
+        let (cleared, dropped) = led.mark_lane_reviewed("claude", |path| {
+            if path == p("/w/a.rs") {
+                (Baseline::Hash(42), None)
+            } else {
+                (Baseline::Gone, None)
+            }
+        });
         assert_eq!(
             (cleared, dropped),
             (1, 1),
@@ -667,19 +666,15 @@ mod tests {
         led.record_write(&p("/w/a.rs"), 1, &agent);
         led.record_write(&p("/w/b.rs"), 2, &agent);
 
-        let (cleared, dropped) = led.mark_lane_reviewed(
-            "claude",
-            |path| {
-                if path == p("/w/a.rs") {
-                    Baseline::Hash(10)
-                } else {
-                    Baseline::Hash(20)
-                }
-            },
-            // Snapshotting `b.rs` failed (the store is best-effort), so it
-            // gets a baseline hash but no retrievable content.
-            |path| (path == p("/w/a.rs")).then_some(2_500),
-        );
+        let (cleared, dropped) = led.mark_lane_reviewed("claude", |path| {
+            if path == p("/w/a.rs") {
+                (Baseline::Hash(10), Some(2_500))
+            } else {
+                // Snapshotting `b.rs` failed (the store is best-effort), so
+                // it gets a baseline hash but no retrievable content.
+                (Baseline::Hash(20), None)
+            }
+        });
         assert_eq!((cleared, dropped), (2, 0));
 
         let rows = led.lane("claude");
@@ -865,7 +860,7 @@ mod tests {
         led.record_write(&p("/w/d.rs"), 4, &a);
 
         // Emptying it settles the question: nothing is left to be wrong.
-        let (reviewed, _) = led.mark_lane_reviewed("claude", |_| Baseline::Hash(4), |_| None);
+        let (reviewed, _) = led.mark_lane_reviewed("claude", |_| (Baseline::Hash(4), None));
         assert_eq!(reviewed, 1);
         assert!(
             !led.may_be_incomplete(),
@@ -884,8 +879,7 @@ mod tests {
         assert_eq!(led.unreviewed_count("claude"), 1);
 
         // The read fails this instant, whatever the disk holds.
-        let (cleared, dropped) =
-            led.mark_lane_reviewed("claude", |_| Baseline::Unreadable, |_| None);
+        let (cleared, dropped) = led.mark_lane_reviewed("claude", |_| (Baseline::Unreadable, None));
         assert_eq!(
             (cleared, dropped),
             (0, 0),
@@ -899,7 +893,7 @@ mod tests {
 
         // And it is still recoverable once the read succeeds.
         assert_eq!(
-            led.mark_lane_reviewed("claude", |_| Baseline::Hash(555), |_| None),
+            led.mark_lane_reviewed("claude", |_| (Baseline::Hash(555), None)),
             (1, 0)
         );
         assert_eq!(led.unreviewed_count("claude"), 0);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -31390,16 +31390,28 @@ impl App {
         self.tree.agent_touched = std::sync::Arc::new(paths);
     }
 
-    /// The newest local-history snapshot of `path`, which is the content the
-    /// user is looking at when they mark a row reviewed (#345).
+    /// Snapshot `bytes` as `path`'s review baseline and return the millis
+    /// that names it (#345).
     ///
-    /// `None` when the store has nothing for the file: snapshots are
-    /// best-effort and recorded on a background thread, so a review can land
-    /// before the first one exists. The row is still REVIEWED — it just has
-    /// no baseline content to diff against later.
-    fn newest_snapshot_millis(history_root: &Path, path: &Path) -> Option<u64> {
+    /// The store is only ever written by croft's OWN saves; the agent-write
+    /// path that creates lane rows records nothing. So adopting whatever
+    /// snapshot happened to be newest anchored the review to an unrelated
+    /// earlier save and then labelled the diff "(reviewed)" — the exact
+    /// "baseline other than the one claimed" the diff refuses elsewhere.
+    /// Recording here is what makes the anchor name the reviewed content.
+    ///
+    /// `record_in` dedupes identical content and, inside the merge window,
+    /// REPLACES the newest entry instead of appending — so the snapshot that
+    /// ends up holding these bytes need not be at `millis`. Read the store
+    /// back rather than assuming, and return `None` when nothing holds them:
+    /// history is best-effort, and a row with no anchor is still reviewed,
+    /// it just cannot show a diff.
+    fn record_review_baseline(history_root: &Path, path: &Path, bytes: &[u8]) -> Option<u64> {
+        let millis = now_millis();
+        let _ = crate::history::record_in(history_root, path, bytes, millis);
         crate::history::entries_in(history_root, path)
-            .first()
+            .into_iter()
+            .find(|s| std::fs::read(&s.file).is_ok_and(|held| held == bytes))
             .map(|s| s.millis)
     }
 
@@ -31415,6 +31427,14 @@ impl App {
     /// the one claimed is worse than no diff, because the user cannot see
     /// which one they got.
     pub(crate) fn diff_agent_lane_row(&mut self, agent: &str, path: &Path) {
+        // "Restore Snapshot" writes to the path recorded here, and only
+        // `open_timeline_diff` cleared it. Browsing a.txt's timeline and then
+        // opening this diff on b.txt left restore armed at a.txt, so the
+        // command would overwrite a file the user was not even looking at.
+        // Disarm on every exit below, including the refusals: a refused diff
+        // leaves the PREVIOUS diff on screen, and arming restore to that is
+        // exactly the stale pairing this guards.
+        self.history_restore = None;
         let Some(row) = self
             .agent_ledger
             .lane(agent)
@@ -31466,6 +31486,9 @@ impl App {
             return;
         }
         self.tag_open_diff(crate::widgets::diff::DiffSource::FixedLeft { left_text: text });
+        // Armed to the snapshot now on screen, matching `open_timeline_diff`:
+        // "Restore Snapshot" puts back the version the user reviewed.
+        self.history_restore = Some((path.to_path_buf(), millis, content));
         self.focus_pane(Pane::Editor);
         self.status = format!("{rel}: changes since you last reviewed it");
     }
@@ -31482,17 +31505,38 @@ impl App {
     }
 
     fn mark_agent_file_reviewed_inner(&mut self, agent: &str, path: &Path) -> bool {
-        match crate::agent_lane::read_baseline(path) {
-            crate::agent_lane::Baseline::Hash(hash) => {
-                let snap = Self::newest_snapshot_millis(&self.history_root, path);
+        // A file too big to hash is too big to snapshot: `read_baseline`
+        // stamps those from metadata rather than slurping 4 MiB+, and
+        // copying one into the history store on every review would be worse.
+        // It reviews with NO anchor - honest, and the diff then says it has
+        // nothing to compare against.
+        if std::fs::metadata(path).is_ok_and(|m| m.len() > crate::agent_lane::MAX_HASH_BYTES) {
+            return match crate::agent_lane::read_baseline(path) {
+                crate::agent_lane::Baseline::Hash(hash) => {
+                    self.agent_ledger.mark_reviewed(agent, path, hash, None)
+                }
+                crate::agent_lane::Baseline::Gone => self.agent_ledger.forget_path(path),
+                crate::agent_lane::Baseline::Unreadable => {
+                    self.status = format!("Could not read {} to mark it reviewed", path.display());
+                    false
+                }
+            };
+        }
+        // One read, used for BOTH the hash and the snapshot: reading twice
+        // lets a write land in between, and the baseline would then be a hash
+        // of content the anchor does not hold.
+        match std::fs::read(path) {
+            Ok(bytes) => {
+                let hash = crate::agent_lane::content_hash(&bytes);
+                let snap = Self::record_review_baseline(&self.history_root, path, &bytes);
                 self.agent_ledger.mark_reviewed(agent, path, hash, snap)
             }
-            // Nothing left to review: drop the row rather than baselining a
-            // file that is not there.
-            crate::agent_lane::Baseline::Gone => self.agent_ledger.forget_path(path),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                self.agent_ledger.forget_path(path)
+            }
             // Unreadable right now is NOT reviewed: say so instead of
             // clearing content the user has not seen.
-            crate::agent_lane::Baseline::Unreadable => {
+            Err(_) => {
                 self.status = format!("Could not read {} to mark it reviewed", path.display());
                 false
             }
@@ -31502,11 +31546,26 @@ impl App {
     /// Mark an agent's whole lane reviewed (#345).
     pub(crate) fn mark_agent_lane_reviewed(&mut self, agent: &str) -> usize {
         let root = self.history_root.clone();
-        let (reviewed, dropped) =
-            self.agent_ledger
-                .mark_lane_reviewed(agent, crate::agent_lane::read_baseline, |path| {
-                    Self::newest_snapshot_millis(&root, path)
-                });
+        // Same contract as the single-file path: the anchor must hold the
+        // bytes that were hashed, so read once and snapshot THOSE. Reading
+        // separately in the two closures would let a write land between them.
+        let (reviewed, dropped) = self.agent_ledger.mark_lane_reviewed(agent, |path| {
+            // Too big to hash is too big to snapshot: stamp it and
+            // review with no anchor, as the single-file path does.
+            if std::fs::metadata(path).is_ok_and(|m| m.len() > crate::agent_lane::MAX_HASH_BYTES) {
+                return (crate::agent_lane::read_baseline(path), None);
+            }
+            match std::fs::read(path) {
+                Ok(bytes) => (
+                    crate::agent_lane::Baseline::Hash(crate::agent_lane::content_hash(&bytes)),
+                    Self::record_review_baseline(&root, path, &bytes),
+                ),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    (crate::agent_lane::Baseline::Gone, None)
+                }
+                Err(_) => (crate::agent_lane::Baseline::Unreadable, None),
+            }
+        });
         // A file that vanished was not REVIEWED; saying so would tell the
         // user they looked at something that is not there.
         let gone = match dropped {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -31390,6 +31390,86 @@ impl App {
         self.tree.agent_touched = std::sync::Arc::new(paths);
     }
 
+    /// The newest local-history snapshot of `path`, which is the content the
+    /// user is looking at when they mark a row reviewed (#345).
+    ///
+    /// `None` when the store has nothing for the file: snapshots are
+    /// best-effort and recorded on a background thread, so a review can land
+    /// before the first one exists. The row is still REVIEWED — it just has
+    /// no baseline content to diff against later.
+    fn newest_snapshot_millis(history_root: &Path, path: &Path) -> Option<u64> {
+        crate::history::entries_in(history_root, path)
+            .first()
+            .map(|s| s.millis)
+    }
+
+    /// Diff one agent-lane row against the snapshot that was its baseline
+    /// when the user last marked it reviewed (#345), rather than against
+    /// HEAD.
+    ///
+    /// Refuses rather than falling back to a different baseline. A row with
+    /// no recorded snapshot (never reviewed, or reviewed before the store
+    /// had one) and a row whose snapshot has since been PRUNED — the store
+    /// keeps 50 per file against a 1s autosave, so this is a live case, not
+    /// only a legacy one — both say so. A diff against a baseline other than
+    /// the one claimed is worse than no diff, because the user cannot see
+    /// which one they got.
+    pub(crate) fn diff_agent_lane_row(&mut self, agent: &str, path: &Path) {
+        let Some(row) = self
+            .agent_ledger
+            .lane(agent)
+            .into_iter()
+            .find(|f| f.path == path)
+        else {
+            self.status = format!("{} is not in {agent}'s lane", path.display());
+            return;
+        };
+        let Some(millis) = row.reviewed_millis else {
+            self.status = if row.reviewed_hash.is_some() {
+                format!(
+                    "{} was reviewed before a snapshot existed - nothing to diff against",
+                    path.display()
+                )
+            } else {
+                format!("{} has not been reviewed yet", path.display())
+            };
+            return;
+        };
+        let Some(snap_file) = crate::history::snapshot_file_in(&self.history_root, path, millis)
+        else {
+            self.status = format!(
+                "The snapshot {} was reviewed against is no longer available",
+                path.display()
+            );
+            return;
+        };
+        let Ok(content) = std::fs::read(&snap_file) else {
+            self.status = format!("Could not read the reviewed snapshot of {}", path.display());
+            return;
+        };
+        // Snapshots hold raw bytes; decode like the local-history diff above
+        // so a UTF-16 file diffs as text rather than mojibake.
+        let enc = encoding_rs::Encoding::for_bom(&content)
+            .map(|(e, _)| e)
+            .unwrap_or(encoding_rs::UTF_8);
+        let text = enc.decode(&content).0.into_owned();
+        let rel = match path.strip_prefix(&self.tree.root) {
+            Ok(r) => r.to_string_lossy().into_owned(),
+            Err(_) => path.display().to_string(),
+        };
+        let label = std::path::PathBuf::from(format!("{rel} (reviewed)"));
+        if let Err(e) = self
+            .editor
+            .open_head_diff_with_text(label, &text, path, false)
+        {
+            self.status = format!("Could not open the reviewed diff: {e}");
+            return;
+        }
+        self.tag_open_diff(crate::widgets::diff::DiffSource::FixedLeft { left_text: text });
+        self.focus_pane(Pane::Editor);
+        self.status = format!("{rel}: changes since you last reviewed it");
+    }
+
     /// Mark one file reviewed in one agent's lane (#345): the content on
     /// DISK now becomes the baseline, so the row returns only on a later
     /// write.
@@ -31404,7 +31484,8 @@ impl App {
     fn mark_agent_file_reviewed_inner(&mut self, agent: &str, path: &Path) -> bool {
         match crate::agent_lane::read_baseline(path) {
             crate::agent_lane::Baseline::Hash(hash) => {
-                self.agent_ledger.mark_reviewed(agent, path, hash)
+                let snap = Self::newest_snapshot_millis(&self.history_root, path);
+                self.agent_ledger.mark_reviewed(agent, path, hash, snap)
             }
             // Nothing left to review: drop the row rather than baselining a
             // file that is not there.
@@ -31420,9 +31501,12 @@ impl App {
 
     /// Mark an agent's whole lane reviewed (#345).
     pub(crate) fn mark_agent_lane_reviewed(&mut self, agent: &str) -> usize {
-        let (reviewed, dropped) = self
-            .agent_ledger
-            .mark_lane_reviewed(agent, crate::agent_lane::read_baseline);
+        let root = self.history_root.clone();
+        let (reviewed, dropped) =
+            self.agent_ledger
+                .mark_lane_reviewed(agent, crate::agent_lane::read_baseline, |path| {
+                    Self::newest_snapshot_millis(&root, path)
+                });
         // A file that vanished was not REVIEWED; saying so would tell the
         // user they looked at something that is not there.
         let gone = match dropped {
@@ -34387,6 +34471,29 @@ impl App {
                 } else {
                     rows.join(" \u{b7} ")
                 };
+            }
+            Cmd::DiffAgentFileSinceReview => {
+                match self.editor.path.clone() {
+                    None => self.status = String::from("No file open"),
+                    Some(path) => {
+                        // The first lane holding it. A file two agents both
+                        // touched has one baseline per lane, and diffing
+                        // against an arbitrary second one would silently
+                        // answer a different question than the row shows.
+                        let agent = self
+                            .agent_ledger
+                            .agents()
+                            .into_iter()
+                            .map(String::from)
+                            .find(|a| self.agent_ledger.lane(a).iter().any(|f| f.path == path));
+                        match agent {
+                            None => {
+                                self.status = String::from("No agent has changed this file");
+                            }
+                            Some(agent) => self.diff_agent_lane_row(&agent, &path),
+                        }
+                    }
+                }
             }
             Cmd::MarkAgentLaneReviewed => {
                 let agents: Vec<String> = self

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -12594,6 +12594,98 @@ fn saving_records_a_local_history_snapshot_that_diffs_and_restores() {
     );
 }
 
+/// The agent review diff must not leave another file's "Restore Snapshot"
+/// armed (#345): it opens a snapshot diff like the TIMELINE does, so it
+/// owes the same disarm, or restore silently overwrites a file the user is
+/// not looking at.
+#[test]
+fn the_review_diff_disarms_another_files_restore() {
+    let tmp = tempfile::tempdir().unwrap();
+    let hist = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a.txt");
+    let b = tmp.path().join("b.txt");
+    std::fs::write(&a, "a-disk\n").unwrap();
+    std::fs::write(&b, "b-disk\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.history_root = hist.path().to_path_buf();
+
+    // a.txt's timeline snapshot is on screen: restore is armed for a.txt.
+    crate::history::record_in(&app.history_root, &a, b"a-old\n", 1000).unwrap();
+    app.editor.open(&a).unwrap();
+    app.open_timeline_diff(a.clone(), "local:1000".into());
+    assert!(app.history_restore.is_some(), "staging: a's snapshot armed");
+
+    // b.txt is in an agent lane and has never been reviewed, so the diff
+    // REFUSES - and a refusal leaves a's diff on screen, which is exactly
+    // when a stale restore is most dangerous.
+    let working = vec![String::from("claude")];
+    app.agent_ledger.record_write(&b, 7, &working);
+    app.diff_agent_lane_row("claude", &b);
+    assert!(
+        app.history_restore.is_none(),
+        "the review diff left the previous file's restore armed"
+    );
+    app.restore_history_snapshot();
+    assert_eq!(
+        std::fs::read_to_string(&a).unwrap(),
+        "a-disk\n",
+        "restore wrote a stale snapshot over an unrelated file"
+    );
+}
+
+/// Marking a file reviewed records a snapshot of the bytes it just hashed,
+/// so the row can be diffed against what the user actually approved (#345).
+///
+/// The store is written only by croft's own saves; the agent-write path
+/// records nothing. Adopting whatever snapshot was newest anchored the
+/// review to an unrelated earlier save and then labelled it "(reviewed)".
+#[test]
+fn reviewing_anchors_to_the_content_it_baselined_not_an_older_save() {
+    let tmp = tempfile::tempdir().unwrap();
+    let hist = tempfile::tempdir().unwrap();
+    let f = tmp.path().join("touched.rs");
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.history_root = hist.path().to_path_buf();
+
+    // An OLD, unrelated save is already in the store - the trap: it is the
+    // newest snapshot at review time but is not what the agent wrote.
+    crate::history::record_in(&app.history_root, &f, b"an older user save\n", 1000).unwrap();
+
+    // The agent writes; the user never saved this content in croft.
+    std::fs::write(&f, "what the agent wrote\n").unwrap();
+    let working = vec![String::from("claude")];
+    app.agent_ledger.record_write(
+        &f,
+        crate::agent_lane::content_hash(b"what the agent wrote\n"),
+        &working,
+    );
+
+    assert!(app.mark_agent_file_reviewed("claude", &f));
+    let millis = app.agent_ledger.lane("claude")[0]
+        .reviewed_millis
+        .expect("the review recorded an anchor");
+    let snap = crate::history::snapshot_file_in(&app.history_root, &f, millis)
+        .expect("the anchor names a snapshot that exists");
+    assert_eq!(
+        std::fs::read(&snap).unwrap(),
+        b"what the agent wrote\n",
+        "the anchor must hold the reviewed content, not the older save"
+    );
+    assert_ne!(
+        millis, 1000,
+        "it must not adopt the unrelated older snapshot"
+    );
+
+    // And the diff opens against that content rather than refusing.
+    std::fs::write(&f, "what the agent wrote next\n").unwrap();
+    app.diff_agent_lane_row("claude", &f);
+    assert!(
+        app.status.contains("since you last reviewed"),
+        "the diff opens against the reviewed baseline: {}",
+        app.status
+    );
+}
+
 /// A snapshot click that fails (pruned .snap, unreadable file) must disarm
 /// "Restore Snapshot": the palette entry otherwise writes whatever snapshot
 /// was viewed BEFORE over a file that is not even on screen.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -45679,7 +45679,7 @@ fn a_single_root_review_queue_reads_as_it_always_did() {
     std::fs::write(&f, "x").unwrap();
     app.agent_ledger.record_write(&f, 1, &working);
     let hash = app.agent_ledger.lane("claude")[0].current_hash;
-    app.agent_ledger.mark_reviewed("claude", &f, hash);
+    app.agent_ledger.mark_reviewed("claude", &f, hash, None);
     assert_eq!(
         app.agent_lane_rows(),
         vec![String::from("claude: 0 to review ()")],

--- a/src/release_notes/0.1.921.md
+++ b/src/release_notes/0.1.921.md
@@ -1,0 +1,1 @@
+feature: diff a file an agent changed against the version you last marked reviewed, instead of against HEAD. Marking a file reviewed now remembers which local snapshot it approved, and a row whose snapshot is gone says so rather than quietly diffing against something else.

--- a/src/widgets/command_palette.rs
+++ b/src/widgets/command_palette.rs
@@ -210,6 +210,9 @@ pub enum Command {
     MarkAgentLaneReviewed,
     /// Summarise each agent's review queue (#345).
     ShowAgentLane,
+    /// Diff the active file against the snapshot it was last reviewed
+    /// against (#345).
+    DiffAgentFileSinceReview,
     /// Mark the active file reviewed in every agent lane holding it (#345).
     MarkAgentFileReviewed,
     /// Have the navigator fix the diagnostic under the caret as a streamed,
@@ -409,6 +412,7 @@ pub const ALL_COMMANDS: &[Command] = &[
     Command::MarkAgentLaneReviewed,
     Command::ShowAgentLane,
     Command::MarkAgentFileReviewed,
+    Command::DiffAgentFileSinceReview,
     Command::FixProblemWithNavigator,
     Command::SendHttpRequest,
     Command::CopyHttpRequestAsCurl,
@@ -595,6 +599,7 @@ impl Command {
             Command::MarkAgentLaneReviewed => "Agents: Mark Changed Files Reviewed",
             Command::ShowAgentLane => "Agents: Show Changed Files",
             Command::MarkAgentFileReviewed => "Agents: Mark This File Reviewed",
+            Command::DiffAgentFileSinceReview => "Agents: Diff This File Since Review",
             Command::FixProblemWithNavigator => "Problems: Fix With Navigator",
             Command::SendHttpRequest => "HTTP: Send Request Under Caret",
             Command::CopyHttpRequestAsCurl => "HTTP: Copy Request as curl",
@@ -783,6 +788,7 @@ impl Command {
             Command::MarkAgentLaneReviewed => "",
             Command::ShowAgentLane => "",
             Command::MarkAgentFileReviewed => "",
+            Command::DiffAgentFileSinceReview => "",
             Command::FixProblemWithNavigator => "",
             Command::SendHttpRequest => "Cmd+Enter",
             Command::CopyHttpRequestAsCurl => "",
@@ -968,6 +974,7 @@ impl Command {
             Command::MarkAgentLaneReviewed => "agents_mark_reviewed",
             Command::ShowAgentLane => "agents_show_lane",
             Command::MarkAgentFileReviewed => "agents_mark_file_reviewed",
+            Command::DiffAgentFileSinceReview => "agents_diff_since_review",
             Command::FixProblemWithNavigator => "problems_fix_navigator",
             Command::SendHttpRequest => "http_send_request",
             Command::CopyHttpRequestAsCurl => "http_copy_curl",


### PR DESCRIPTION
Criterion 2 of #345: "Diff for a row compares against the last-reviewed snapshot, verified after two rounds of edits."

Marking a file reviewed recorded only a content hash. A hash answers "changed?" but not "changed how?", so a lane row could show that an agent had touched a file again without being able to show what it did since you looked.

## What changed

`LaneFile` gains `reviewed_millis`: the local-history snapshot holding the content that became the baseline. `Agents: Diff This File Since Review` opens the working file against that snapshot rather than against HEAD.

The anchor is recorded from the same bytes the baseline hash is taken from. That matters more than it first looks: the history store is written only by croft's **own** saves — the agent-write path that creates lane rows records nothing — so adopting whatever snapshot happened to be newest would anchor the review to an unrelated earlier save and then label that diff "(reviewed)". `record_in` also dedupes identical content and replaces inside the merge window, so the store is read back rather than assuming the timestamp names a file.

## Refusals

A row with no usable baseline says which reason, rather than falling back to a HEAD diff:

- never reviewed
- reviewed before a snapshot existed
- the snapshot has since been pruned — the store keeps 50 per file against a 1s autosave, so this is a live case, not only a legacy one

A diff against a baseline other than the one claimed is worse than no diff, because nothing on screen tells you which one you got.

Files over `MAX_HASH_BYTES` keep `read_baseline`'s stamp path rather than being slurped and copied into the history store on every review. They review with no anchor, and the diff says so.

## Review findings fixed before this was opened

- **Stale restore (data loss).** Opening this diff left "Restore Snapshot" armed at whatever file the TIMELINE last showed, so restoring would have overwritten a file the user was not looking at. Disarmed on entry — refusals included, since a refused diff leaves the previous one on screen — and armed to this snapshot on success. The repo already had a test for this shape on the timeline path; this adds the matching one here.
- **Split read.** The whole-lane path took the hash and the anchor from two separate reads, so a write landing between them left the baseline hash describing content the anchor does not hold. One closure now returns both from one read.

## Verification

`cargo check` clean, `clippy -D warnings` clean, 15 tests pass.

Both new behaviours were mutation-tested rather than trusted: removing the restore disarm fails `the_review_diff_disarms_another_files_restore`, and reverting the anchor to "newest snapshot" fails `reviewing_anchors_to_the_content_it_baselined_not_an_older_save`. Each mutation was applied to an asserted anchor and the file restored afterwards, so a mutation that silently failed to apply cannot read as a survived one.

Part of #345. Criteria 1 (attribution while working) and 3 (badge counts and tree decorations) are already on main; this is criterion 2.
