### PR TITLE
feat(log): Ctrl+click a path:line printed in a rendered log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.921"
+version = "0.1.924"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.921"
+version = "0.1.924"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29286,6 +29286,51 @@ impl App {
         true
     }
 
+    /// Ctrl+click a `path:line` printed in a RENDERED log (#257).
+    ///
+    /// Scanned against the escape-free text, not the raw bytes: the
+    /// reference's column in the file is not its column on screen once SGR
+    /// sequences are stripped, and a path can sit inside an escape entirely.
+    /// `log_cell_at` already maps a screen cell to that text's column.
+    ///
+    /// Dispatched ahead of `begin_log_selection`, which runs before the
+    /// editor's own Ctrl handling and would otherwise swallow the gesture
+    /// into a selection drag. Relative paths resolve against the workspace
+    /// root - a log has no shell cwd to consult, unlike a terminal pane.
+    fn log_file_click(&mut self, col: u16, row: u16) -> bool {
+        let scroll = self.editor.scroll;
+        let Some(log) = self.editor.log.as_ref() else {
+            return false;
+        };
+        if !rect_contains(log.last_body, col, row) {
+            return false;
+        }
+        let (line, column) = log_cell_at(log, scroll, col, row);
+        let Some(text) = log.visible_text(line).map(str::to_string) else {
+            return false;
+        };
+        let Some(fr) = crate::file_ref::file_ref_at(&text, column) else {
+            return false;
+        };
+        let raw = std::path::PathBuf::from(&fr.path);
+        let abs = if let Some(rest) = fr.path.strip_prefix("~/") {
+            match std::env::var_os("HOME") {
+                Some(h) => std::path::PathBuf::from(h).join(rest),
+                None => return false,
+            }
+        } else if raw.is_absolute() {
+            raw
+        } else {
+            self.tree.root.join(raw)
+        };
+        // Only when it resolves to a real file, which is also what filters
+        // lookalikes like `host.com:443`.
+        if !abs.is_file() {
+            return false;
+        }
+        self.open_resolved_file_ref(&abs, fr.line, fr.column)
+    }
+
     /// Extend a live log drag and finish it on release.
     fn update_log_selection(&mut self, m: MouseEvent) -> bool {
         let scroll = self.editor.scroll;
@@ -37935,6 +37980,13 @@ impl App {
                 // the rendered view starts a drag-selection over what the
                 // user can SEE, not the source buffer beneath it.
                 if self.begin_preview_selection(m.column, m.row) {
+                    return;
+                }
+                // Before the selection: a Ctrl+click on a printed
+                // `path:line` follows it rather than starting a drag (#257).
+                if m.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.log_file_click(m.column, m.row)
+                {
                     return;
                 }
                 if self.begin_log_selection(m.column, m.row) {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2885,26 +2885,40 @@ fn the_swallow_guard_reads_the_clicked_terminal_not_the_active_one() {
 /// A `path:line` printed in a RENDERED ANSI log is Ctrl+clickable, the
 /// same as one printed in a terminal pane (#257).
 ///
-/// The rendered view strips the escapes, so the reference is scanned
-/// against the text the user can SEE - the raw bytes would put the column
-/// in the wrong place, or hide the path inside an escape entirely.
+/// The reference is scanned against the text the user SEES. The fixture is
+/// built so that matters: the second path sits after a 36-character SGR run
+/// with no printed width, so its visible column falls INSIDE an escape
+/// sequence in the raw bytes. A raw-bytes scan finds no reference at that
+/// column at all, which is what makes this test turn on the mapping rather
+/// than merely coexist with it.
 ///
 /// Ctrl is what separates it from a selection drag: `begin_log_selection`
-/// runs before the editor's Ctrl handling, so without this the modifier
-/// click just starts a selection.
+/// runs before the editor's Ctrl handling, so without the guard the modifier
+/// click would just start a selection.
 #[test]
 fn a_file_reference_in_a_rendered_log_is_ctrl_clickable() {
     let tmp = tempfile::tempdir().unwrap();
-    // The file the log points AT.
-    let target = tmp.path().join("src.rs");
-    std::fs::write(&target, "one\ntwo\nthree\n").unwrap();
+    let first = tmp.path().join("first.rs");
+    let second = tmp.path().join("second.rs");
+    std::fs::write(&first, "a\nb\nc\n").unwrap();
+    std::fs::write(&second, "one\ntwo\nthree\nfour\nfive\nsix\nseven\n").unwrap();
 
-    // A log line with SGR escapes around the reference, so the escape-free
-    // column mapping is exercised rather than bypassed.
+    // An SGR run with zero printed width, placed BETWEEN the two references
+    // so the second one's screen column and byte offset diverge. It must be
+    // LONGER than the path itself, or the shifted column still lands inside
+    // the raw path token and both implementations agree - tempdir paths are
+    // ~50 characters and vary per platform, so scale it rather than picking
+    // a constant that silently stops discriminating. The assertion below
+    // proves the fixture actually discriminates.
+    let esc = "\x1b[1;3;4;38;2;255;0;0m".repeat(second.display().to_string().len() / 10 + 4);
     let log = tmp.path().join("build.log");
     std::fs::write(
         &log,
-        format!("\x1b[31merror\x1b[0m: {}:2 failed\n", target.display()),
+        format!(
+            "{}:1 {esc}then {}:7 end\nconnecting to host.com:443\n",
+            first.display(),
+            second.display()
+        ),
     )
     .unwrap();
 
@@ -2915,49 +2929,82 @@ fn a_file_reference_in_a_rendered_log_is_ctrl_clickable() {
         "the log must open in the rendered view, or this tests nothing"
     );
 
-    let backend = ratatui::backend::TestBackend::new(120, 30);
+    let backend = ratatui::backend::TestBackend::new(200, 30);
     let mut term = ratatui::Terminal::new(backend).unwrap();
     term.draw(|frame| app.render(frame)).unwrap();
-
-    // Find the cell holding the target path in the RENDERED text.
     let body = app.editor.log.as_ref().unwrap().last_body;
-    let text = app
-        .editor
-        .log
-        .as_ref()
-        .unwrap()
-        .visible_text(0)
-        .expect("line 0 is parsed")
-        .to_string();
-    let at = text
-        .find("src.rs")
-        .expect("the path is visible after stripping");
-    let col = body.x + u16::try_from(at).unwrap();
 
-    let before = app.editor.path.clone();
+    let visible = |app: &App, line: usize| -> String {
+        app.editor
+            .log
+            .as_ref()
+            .unwrap()
+            .visible_text(line)
+            .expect("line is parsed")
+            .to_string()
+    };
+
+    // The second reference: visible column lands inside an escape in the raw
+    // bytes, so only the escape-free scan can resolve it.
+    let text = visible(&app, 0);
+    let at = text.find("second.rs").expect("visible after stripping");
+    let raw = std::fs::read_to_string(&log).unwrap();
+    let raw_line = raw.lines().next().unwrap();
+    assert!(
+        crate::file_ref::file_ref_at(raw_line, at)
+            .is_none_or(|fr| fr.path != second.display().to_string()),
+        "fixture is wrong: a raw-bytes scan at column {at} already finds this \
+         reference, so the test would pass without the escape-free mapping"
+    );
+
     app.handle_mouse(MouseEvent {
         kind: MouseEventKind::Down(MouseButton::Left),
-        column: col,
+        column: body.x + u16::try_from(at).unwrap(),
         row: body.y,
         modifiers: KeyModifiers::CONTROL,
     });
     assert_eq!(
         app.editor.path.as_deref(),
-        Some(target.as_path()),
-        "Ctrl+click on a path in a rendered log opens that file (was {before:?})"
+        Some(second.as_path()),
+        "Ctrl+click on a path after an escape run opens that file"
     );
     assert_eq!(
-        app.editor.cursor_row, 1,
-        "and lands on the referenced line (0-based)"
+        app.editor.cursor_row, 6,
+        "and lands on the referenced line (`:7`, 0-based)"
     );
 
-    // Without Ctrl the same cell still starts a selection, so the ref click
-    // did not eat the ordinary gesture.
+    // A lookalike must NOT be opened: only `is_file()` separates
+    // `host.com:443` from a real reference, and nothing else asserts it.
+    app.editor.open(&log).unwrap();
+    term.draw(|frame| app.render(frame)).unwrap();
+    let host_line = visible(&app, 1);
+    let hat = host_line
+        .find("host.com")
+        .expect("the lookalike is on line 1");
+    app.handle_mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: body.x + u16::try_from(hat).unwrap(),
+        row: body.y + 1,
+        modifiers: KeyModifiers::CONTROL,
+    });
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(log.as_path()),
+        "`host.com:443` resolves to no file, so the click must not navigate"
+    );
+    assert!(
+        app.editor.log.as_ref().is_some_and(|l| l.dragging),
+        "and it falls through to a selection drag rather than being eaten"
+    );
+
+    // Without Ctrl the same cell still starts a selection drag. `has_selection`
+    // needs a != b, so a press alone is not yet a selection: the anchor IS the
+    // head until a drag moves it.
     app.editor.open(&log).unwrap();
     term.draw(|frame| app.render(frame)).unwrap();
     app.handle_mouse(MouseEvent {
         kind: MouseEventKind::Down(MouseButton::Left),
-        column: col,
+        column: body.x + u16::try_from(at).unwrap(),
         row: body.y,
         modifiers: KeyModifiers::NONE,
     });
@@ -2966,9 +3013,6 @@ fn a_file_reference_in_a_rendered_log_is_ctrl_clickable() {
         Some(log.as_path()),
         "a plain click stays in the log"
     );
-    // `has_selection` needs a != b, so a press alone is not yet a selection:
-    // the anchor IS the head until a drag moves it. What distinguishes the
-    // two paths is that the plain press armed a drag at all.
     assert!(
         app.editor.log.as_ref().is_some_and(|l| l.dragging),
         "a plain click still begins a selection drag"

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2882,6 +2882,99 @@ fn the_swallow_guard_reads_the_clicked_terminal_not_the_active_one() {
     );
 }
 
+/// A `path:line` printed in a RENDERED ANSI log is Ctrl+clickable, the
+/// same as one printed in a terminal pane (#257).
+///
+/// The rendered view strips the escapes, so the reference is scanned
+/// against the text the user can SEE - the raw bytes would put the column
+/// in the wrong place, or hide the path inside an escape entirely.
+///
+/// Ctrl is what separates it from a selection drag: `begin_log_selection`
+/// runs before the editor's Ctrl handling, so without this the modifier
+/// click just starts a selection.
+#[test]
+fn a_file_reference_in_a_rendered_log_is_ctrl_clickable() {
+    let tmp = tempfile::tempdir().unwrap();
+    // The file the log points AT.
+    let target = tmp.path().join("src.rs");
+    std::fs::write(&target, "one\ntwo\nthree\n").unwrap();
+
+    // A log line with SGR escapes around the reference, so the escape-free
+    // column mapping is exercised rather than bypassed.
+    let log = tmp.path().join("build.log");
+    std::fs::write(
+        &log,
+        format!("\x1b[31merror\x1b[0m: {}:2 failed\n", target.display()),
+    )
+    .unwrap();
+
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open(&log).unwrap();
+    assert!(
+        app.editor.log.is_some(),
+        "the log must open in the rendered view, or this tests nothing"
+    );
+
+    let backend = ratatui::backend::TestBackend::new(120, 30);
+    let mut term = ratatui::Terminal::new(backend).unwrap();
+    term.draw(|frame| app.render(frame)).unwrap();
+
+    // Find the cell holding the target path in the RENDERED text.
+    let body = app.editor.log.as_ref().unwrap().last_body;
+    let text = app
+        .editor
+        .log
+        .as_ref()
+        .unwrap()
+        .visible_text(0)
+        .expect("line 0 is parsed")
+        .to_string();
+    let at = text
+        .find("src.rs")
+        .expect("the path is visible after stripping");
+    let col = body.x + u16::try_from(at).unwrap();
+
+    let before = app.editor.path.clone();
+    app.handle_mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: col,
+        row: body.y,
+        modifiers: KeyModifiers::CONTROL,
+    });
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(target.as_path()),
+        "Ctrl+click on a path in a rendered log opens that file (was {before:?})"
+    );
+    assert_eq!(
+        app.editor.cursor_row, 1,
+        "and lands on the referenced line (0-based)"
+    );
+
+    // Without Ctrl the same cell still starts a selection, so the ref click
+    // did not eat the ordinary gesture.
+    app.editor.open(&log).unwrap();
+    term.draw(|frame| app.render(frame)).unwrap();
+    app.handle_mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: col,
+        row: body.y,
+        modifiers: KeyModifiers::NONE,
+    });
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(log.as_path()),
+        "a plain click stays in the log"
+    );
+    // `has_selection` needs a != b, so a press alone is not yet a selection:
+    // the anchor IS the head until a drag moves it. What distinguishes the
+    // two paths is that the plain press armed a drag at all.
+    assert!(
+        app.editor.log.as_ref().is_some_and(|l| l.dragging),
+        "a plain click still begins a selection drag"
+    );
+}
+
 #[test]
 fn a_prefix_click_defers_to_the_builtin_for_a_file_reference_too() {
     // The built-in Ctrl+click tries `terminal_url_click` OR

--- a/src/release_notes/0.1.924.md
+++ b/src/release_notes/0.1.924.md
@@ -1,0 +1,1 @@
+feature: Ctrl+click a file path printed in a colour log to jump straight to that line, the same as in a terminal pane. The path is read from the text as displayed, so escape sequences around it no longer put the click in the wrong place.


### PR DESCRIPTION
A `path:line` printed in a rendered ANSI log is now Ctrl+clickable, the same as one printed in a terminal pane.

This is the last unmet acceptance criterion of #257. The rest of that issue shipped across #293, #393, #402, #490 and #188 — the issue body still reads as a greenfield proposal, so I walked the criteria individually and commented the delta there.

## Why it did not work

The plumbing was all present and simply never connected. `log_view::visible_text`'s own doc comment names "`path:line` scanning" among its intended consumers:

> The escape-free text of `idx`, for find, selection, copy, and `path:line` scanning — every consumer that must see what the user sees rather than the raw bytes.

Nothing ever called it for that. A modifier click in a rendered log started a selection instead, because `begin_log_selection` is dispatched ahead of the editor's Ctrl handling and returns early — so the gesture never reached the code that would have followed the reference.

## What changed

`log_file_click` scans the **escape-free** text, not the raw bytes. That distinction is the substance of the change rather than a detail: once SGR sequences are stripped, a reference's column on screen is not its column in the file, and a path can sit inside an escape entirely. `log_cell_at` already maps a screen cell to a column in that text, and `cell_map::CellMap` was already doing the same job for copy and selection.

Dispatched ahead of `begin_log_selection` and guarded on CONTROL, so a plain click still starts a selection drag.

Relative paths resolve against the workspace root. A log has no shell cwd to consult, unlike a terminal pane — `terminal_file_click` asks the pane's live shell, which has no analogue here. The click only lands when the resolved path is a real file, which also filters lookalikes like `host.com:443`.

## Verification

`cargo check` clean, `clippy -D warnings` clean, tests pass.

The test asserts Ctrl+click follows the reference and lands on the right line, that `host.com:443` does NOT navigate, and that a plain click at the same cell still begins a selection drag.

Both halves are mutation-verified: removing the dispatch fails it, and dropping the CONTROL guard fails it too. The second matters because a feature that works but swallows ordinary clicks would otherwise pass.

### The fixture had to be made to discriminate

The first version of this test *named* escape-free mapping and could not fail on it. The escapes shifted the offset by 9 characters while the tempdir path is ~50, so the visible column still landed inside the raw path token and a raw-bytes scan returned the same `FileRef`. Both mutations still killed it — it detected a missing dispatch fine — so mutation testing alone gave a clean result to a test that did not check its own headline claim.

Two further fixtures looked correct and were not: a longer escape run keeps the column inside the token (the run pushes the token right by the same amount), and a short `/tmp/w/` model path worked in arithmetic but failed at column 136 on real tempdirs.

What works is putting the escape run BETWEEN two references and scaling it past the path length, so the second reference's visible column falls inside an escape in the raw bytes — where a raw-bytes scan finds nothing at all. The test now asserts its own fixture discriminates, with a message blaming the fixture rather than the code, so a later edit that quietly destroys that property fails loudly instead of passing.

Two smaller corrections the failing runs surfaced: `has_selection()` is false after a plain press by design (`begin_log_selection` sets anchor == head, and it requires them to differ), so the control asserts `dragging`; and `host.com:443` matches the `path:line` pattern with only `is_file()` rejecting it, which nothing asserted — now covered.

Closes #257.
