### PR TITLE
feat(problems): cap the whole-project check's automatic runs by size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.927"
+version = "0.1.929"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.927"
+version = "0.1.929"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8251,6 +8251,13 @@ impl App {
         let _ = self.project_check_tx.send((cwd.to_path_buf(), Ok(out)));
     }
 
+    /// Whether the session's one-shot size hint has been spent (#256).
+    /// Test-only reader; the field is private.
+    #[cfg(all(test, unix))]
+    pub(crate) fn project_check_hinted_for_test(&self) -> bool {
+        self.project_check_hinted
+    }
+
     /// Queue a size hint on the REAL channel (#256). Test-only.
     ///
     /// Does not drain: the point is to have it in flight when the result
@@ -9072,6 +9079,11 @@ impl App {
         // fast-failure path (over-cap root, no compiler installed) is
         // exactly where that happened.
         let hinted_now = self.project_hint_rx.try_recv().is_ok();
+        if hinted_now {
+            // Here, not at the spawn: only a hint that was actually WARRANTED
+            // spends the one-shot.
+            self.project_check_hinted = true;
+        }
         // A whole-project check finished: its rows and its verdict land
         // together, so the status cannot describe a different run's result.
         if self.drain_project_check() {
@@ -34953,8 +34965,13 @@ impl App {
                         let root_for_thread = root.clone();
                         let mode = self.problems_project_scope.clone();
                         let hint_tx = self.project_hint_tx.clone();
+                        // NOT set here: this fires for every explicit check,
+                        // so a run under `on`, `off`, or an under-cap `auto`
+                        // would consume the one-shot and a later oversized
+                        // `auto` run would stay silent forever. The flag is
+                        // set where the hint is RECEIVED, which is the only
+                        // point that knows one was warranted.
                         let hinted = self.project_check_hinted;
-                        self.project_check_hinted = true;
                         std::thread::spawn(move || {
                             // The cap's one-time hint (#256 criterion 5).
                             // Computed HERE, on the thread already spawned

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2570,6 +2570,9 @@ pub struct App {
     /// How many rows the last sweep produced (#256), counted before its
     /// items join a store shared with every other producer.
     project_check_rows: usize,
+    /// Whether the sweep may run unasked (#256): `auto`, `on` or `off`.
+    /// Read at startup; an unrecognised value behaves as `auto`.
+    problems_project_scope: String,
     /// Replies from the background test-source locator (the workspace grep is
     /// too slow for the render thread): the root the search ran under, the
     /// test name, and the hit. A reply from before a re-root is dropped.
@@ -4521,6 +4524,11 @@ impl App {
             project_check_tx,
             project_check_running: false,
             project_check_rows: 0,
+            problems_project_scope: if loaded_prefs.problems_project_scope.is_empty() {
+                String::from("auto")
+            } else {
+                loaded_prefs.problems_project_scope.clone()
+            },
             test_jump_rx,
             test_jump_tx,
             timeline_fetched: None,
@@ -8249,6 +8257,64 @@ impl App {
         // shared with every other producer.
         self.project_check_rows = self.matchers.scan_batch(output, "tsc").len();
         self.apply_build_scan(Self::PROJECT_CHECK_ID, Some(&cwd), "tsc", output)
+    }
+
+    /// How many files put a root out of the sweep's automatic reach (#256).
+    ///
+    /// VS Code's own workspace-diagnostics guidance draws the line around
+    /// the size where a project-wide compile stops being a background cost
+    /// and starts being the foreground one. The exact number matters less
+    /// than having one: the setting overrides it either way.
+    const PROJECT_CHECK_AUTO_MAX_FILES: usize = 100_000;
+
+    /// Whether `root` holds more than `limit` files worth counting (#256).
+    ///
+    /// Stops at `limit + 1` rather than completing the walk. Counting a
+    /// giant tree to decide not to walk a giant tree would cost exactly what
+    /// the cap exists to avoid, and the question is a threshold one - the
+    /// total is never used.
+    ///
+    /// Ignored and vendored directories do not count: `node_modules` alone
+    /// puts most JS projects over any sensible cap, and disabling the sweep
+    /// for JS projects would disable it for the projects it is FOR.
+    pub(crate) fn workspace_exceeds(root: &Path, limit: usize) -> bool {
+        let mut seen = 0usize;
+        for entry in ignore::WalkBuilder::new(root)
+            .git_ignore(true)
+            .require_git(false)
+            .hidden(false)
+            .filter_entry(|e| {
+                e.depth() == 0
+                    || !e.file_type().is_some_and(|t| t.is_dir())
+                    || !crate::widgets::file_finder::is_noise_dir(e.file_name())
+            })
+            .build()
+        {
+            let Ok(entry) = entry else { continue };
+            if entry.file_type().is_some_and(|t| t.is_file()) {
+                seen += 1;
+                if seen > limit {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Whether the sweep may run WITHOUT the user asking, for `mode` (#256).
+    ///
+    /// `on` and `off` are answers, not hints: a cap that only ever declined
+    /// would make `on` useless on the monorepos that most want it, and a cap
+    /// that could not be turned off would surprise someone who knows their
+    /// tree. `auto` asks the size question. Anything else reads as `auto`
+    /// rather than as `on`, so a typo cannot start a compile on a 100k-file
+    /// root - the failure the cap exists to prevent.
+    pub(crate) fn project_check_auto_enabled(root: &Path, mode: &str, limit: usize) -> bool {
+        match mode {
+            "on" => true,
+            "off" => false,
+            _ => !Self::workspace_exceeds(root, limit),
+        }
     }
 
     /// The whole-project check command for this workspace (#256).
@@ -34758,6 +34824,35 @@ impl App {
             Cmd::ToggleZenMode => self.toggle_zen_mode(),
             Cmd::ToggleTerminal => self.toggle_terminal(),
             Cmd::ToggleMinimap => self.toggle_minimap(),
+            Cmd::ProblemsToggleProjectAuto => {
+                // auto -> on -> off -> auto. Cycling rather than a boolean
+                // because `auto` is a distinct answer from both, not a
+                // default the other two override.
+                let next = match self.problems_project_scope.as_str() {
+                    "auto" => "on",
+                    "on" => "off",
+                    _ => "auto",
+                };
+                self.problems_project_scope = String::from(next);
+                let _ = crate::prefs::save_problems_project_scope(next);
+                let root = self.workspace_root().to_path_buf();
+                // Say what the setting MEANS for this root, not just its
+                // name: under `auto` the answer depends on a count the user
+                // cannot see, and "auto" alone would leave them guessing
+                // which way it went.
+                let effect = if Self::project_check_auto_enabled(
+                    &root,
+                    next,
+                    Self::PROJECT_CHECK_AUTO_MAX_FILES,
+                ) {
+                    "may run on its own here"
+                } else if next == "auto" {
+                    "will not run on its own here - this workspace is too large"
+                } else {
+                    "will not run on its own"
+                };
+                self.status = format!("Whole-project check: {next} ({effect})");
+            }
             Cmd::ProblemsCheckProject => {
                 let root = self.workspace_root().to_path_buf();
                 match Self::project_check_command(&root) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8227,6 +8227,39 @@ impl App {
         }
     }
 
+    /// Queue a finished check on the REAL channel WITHOUT draining (#256).
+    ///
+    /// Test-only. The sibling helper drains immediately, which is right for
+    /// testing the reporting logic but wrong for the same-tick race: the
+    /// hint is applied by `sync_explorer_panels`, so the test must let that
+    /// function do the draining.
+    #[cfg(all(test, unix))]
+    pub(crate) fn queue_project_check_result_for_test(
+        &mut self,
+        cwd: &Path,
+        stdout: &str,
+        stderr: &str,
+        success: bool,
+    ) {
+        use std::os::unix::process::ExitStatusExt;
+        let out = std::process::Output {
+            status: std::process::ExitStatus::from_raw(if success { 0 } else { 256 }),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+        };
+        self.project_check_running = true;
+        let _ = self.project_check_tx.send((cwd.to_path_buf(), Ok(out)));
+    }
+
+    /// Queue a size hint on the REAL channel (#256). Test-only.
+    ///
+    /// Does not drain: the point is to have it in flight when the result
+    /// arrives, which is the race that erased it.
+    #[cfg(all(test, unix))]
+    pub(crate) fn send_project_hint_for_test(&mut self) {
+        let _ = self.project_hint_tx.send(());
+    }
+
     /// Push a finished check through the REAL channel and drain it (#256).
     ///
     /// Test-only, and deliberately not a shortcut: it sends down
@@ -9032,18 +9065,24 @@ impl App {
             }
         }
         // The workspace is too large for the sweep to start on its own.
-        // Drained before the result below so the result's status wins: the
-        // hint is context, not the outcome the user just asked for.
-        if self.project_hint_rx.try_recv().is_ok() {
-            self.status = String::from(
-                "This workspace is too large for the whole-project check to run on its own; \
-                 use the palette, or set it to always in Problems: Whole-Project Check Auto-Run",
-            );
-            changed = true;
-        }
+        // Held rather than written: the result below sets `status`
+        // unconditionally and nothing paints between the two, so writing it
+        // here DESTROYED the hint whenever the checker finished inside one
+        // tick - and it is a one-shot, so it never came back. The
+        // fast-failure path (over-cap root, no compiler installed) is
+        // exactly where that happened.
+        let hinted_now = self.project_hint_rx.try_recv().is_ok();
         // A whole-project check finished: its rows and its verdict land
         // together, so the status cannot describe a different run's result.
         if self.drain_project_check() {
+            changed = true;
+        }
+        if hinted_now {
+            // Appended, so the outcome the user asked for still leads.
+            self.status.push_str(
+                " - too large for the whole-project check to run on its own; \
+                 set it to always in Problems: Whole-Project Check Auto-Run",
+            );
             changed = true;
         }
         // Drain any TIMELINE replies; ignore one for a since-closed file.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2573,6 +2573,14 @@ pub struct App {
     /// Whether the sweep may run unasked (#256): `auto`, `on` or `off`.
     /// Read at startup; an unrecognised value behaves as `auto`.
     problems_project_scope: String,
+    /// Signals that this workspace is too large for `auto` to run the sweep
+    /// unasked (#256). Sent from the sweep's worker, since deciding it is a
+    /// whole-workspace walk.
+    project_hint_rx: std::sync::mpsc::Receiver<()>,
+    project_hint_tx: std::sync::mpsc::Sender<()>,
+    /// One hint per session, not per run: repeating it every sweep would
+    /// train the user to ignore the status line.
+    project_check_hinted: bool,
     /// Replies from the background test-source locator (the workspace grep is
     /// too slow for the render thread): the root the search ran under, the
     /// test name, and the hit. A reply from before a re-root is dropped.
@@ -4408,6 +4416,7 @@ impl App {
         let (timeline_tx, timeline_rx) = std::sync::mpsc::channel();
         let (history_done_tx, history_done_rx) = std::sync::mpsc::channel();
         let (project_check_tx, project_check_rx) = std::sync::mpsc::channel();
+        let (project_hint_tx, project_hint_rx) = std::sync::mpsc::channel();
         let (test_jump_tx, test_jump_rx) = std::sync::mpsc::channel();
         let (graph_tx, graph_rx) = std::sync::mpsc::channel();
         let (blame_tx, blame_rx) = std::sync::mpsc::channel();
@@ -4524,6 +4533,9 @@ impl App {
             project_check_tx,
             project_check_running: false,
             project_check_rows: 0,
+            project_hint_rx,
+            project_hint_tx,
+            project_check_hinted: false,
             problems_project_scope: if loaded_prefs.problems_project_scope.is_empty() {
                 String::from("auto")
             } else {
@@ -8310,10 +8322,26 @@ impl App {
     /// rather than as `on`, so a typo cannot start a compile on a 100k-file
     /// root - the failure the cap exists to prevent.
     pub(crate) fn project_check_auto_enabled(root: &Path, mode: &str, limit: usize) -> bool {
-        match mode {
+        match Self::project_scope_mode(mode) {
             "on" => true,
             "off" => false,
             _ => !Self::workspace_exceeds(root, limit),
+        }
+    }
+
+    /// Normalise a `problems_project_scope` value (#256).
+    ///
+    /// Mirrors `ProblemScope::from_config`: a hand-edited config saying
+    /// `"Off"` or `" off "` means off, and reading it as `auto` would give
+    /// the user a size-dependent maybe when they asked for never. Anything
+    /// unrecognised still becomes `auto`, so a typo cannot turn the sweep
+    /// ON. Returns a `&'static str` so the cycle and the predicate agree by
+    /// construction rather than by both remembering to normalise.
+    pub(crate) fn project_scope_mode(raw: &str) -> &'static str {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "on" | "always" => "on",
+            "off" | "never" => "off",
+            _ => "auto",
         }
     }
 
@@ -9002,6 +9030,16 @@ impl App {
                 self.timeline_fetched = None;
                 changed = true;
             }
+        }
+        // The workspace is too large for the sweep to start on its own.
+        // Drained before the result below so the result's status wins: the
+        // hint is context, not the outcome the user just asked for.
+        if self.project_hint_rx.try_recv().is_ok() {
+            self.status = String::from(
+                "This workspace is too large for the whole-project check to run on its own; \
+                 use the palette, or set it to always in Problems: Whole-Project Check Auto-Run",
+            );
+            changed = true;
         }
         // A whole-project check finished: its rows and its verdict land
         // together, so the status cannot describe a different run's result.
@@ -34828,32 +34866,33 @@ impl App {
                 // auto -> on -> off -> auto. Cycling rather than a boolean
                 // because `auto` is a distinct answer from both, not a
                 // default the other two override.
-                let next = match self.problems_project_scope.as_str() {
+                let next = match Self::project_scope_mode(&self.problems_project_scope) {
                     "auto" => "on",
                     "on" => "off",
                     _ => "auto",
                 };
                 self.problems_project_scope = String::from(next);
                 let _ = crate::prefs::save_problems_project_scope(next);
-                let root = self.workspace_root().to_path_buf();
-                // Say what the setting MEANS for this root, not just its
-                // name: under `auto` the answer depends on a count the user
-                // cannot see, and "auto" alone would leave them guessing
-                // which way it went.
-                let effect = if Self::project_check_auto_enabled(
-                    &root,
-                    next,
-                    Self::PROJECT_CHECK_AUTO_MAX_FILES,
-                ) {
-                    "may run on its own here"
-                } else if next == "auto" {
-                    "will not run on its own here - this workspace is too large"
-                } else {
-                    "will not run on its own"
+                // `on` and `off` are answers on their own. `auto` is the
+                // only mode whose effect depends on a count, and counting is
+                // a whole-workspace walk - which this repo runs on a
+                // background thread, never on a keypress. The early stop
+                // bounds the walk only ABOVE the cap; a root under it is
+                // walked to completion, which is the common case.
+                let effect = match next {
+                    "on" => " (runs on its own)",
+                    "off" => " (never runs on its own)",
+                    // Deliberately not the answer: reporting it here would
+                    // cost the walk. The check itself reports when it
+                    // declines, at the point it actually declines.
+                    _ => " (runs on its own unless the workspace is very large)",
                 };
-                self.status = format!("Whole-project check: {next} ({effect})");
+                self.status = format!("Whole-project check: {next}{effect}");
             }
             Cmd::ProblemsCheckProject => {
+                // An explicit ask always runs: the cap governs UNASKED runs
+                // (#256 criterion 5), and refusing what the user just
+                // requested would be answering a question nobody asked.
                 let root = self.workspace_root().to_path_buf();
                 match Self::project_check_command(&root) {
                     None => {
@@ -34873,7 +34912,28 @@ impl App {
                         // the tick.
                         let tx = self.project_check_tx.clone();
                         let root_for_thread = root.clone();
+                        let mode = self.problems_project_scope.clone();
+                        let hint_tx = self.project_hint_tx.clone();
+                        let hinted = self.project_check_hinted;
+                        self.project_check_hinted = true;
                         std::thread::spawn(move || {
+                            // The cap's one-time hint (#256 criterion 5).
+                            // Computed HERE, on the thread already spawned
+                            // for the compile, because it is a whole-
+                            // workspace walk - never on the UI thread. The
+                            // explicit run still proceeds either way; the
+                            // cap governs UNASKED runs, and this tells the
+                            // user once that automatic ones will not start.
+                            if !hinted
+                                && !Self::project_check_auto_enabled(
+                                    &root_for_thread,
+                                    &mode,
+                                    Self::PROJECT_CHECK_AUTO_MAX_FILES,
+                                )
+                                && Self::project_scope_mode(&mode) == "auto"
+                            {
+                                let _ = hint_tx.send(());
+                            }
                             // .output(), never .status(): the checker must not
                             // inherit croft's TTY, or its diagnostics spray
                             // over the UI.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -38119,6 +38119,99 @@ fn the_project_check_count_is_its_own_not_the_panels() {
     );
 }
 
+/// The sweep's auto-enable is capped by workspace size, and the setting
+/// overrides the cap in both directions (#256, criterion 5).
+///
+/// `auto` is a size question, so it has to be answered by counting - but
+/// counting a giant tree to decide not to walk a giant tree is the cost the
+/// cap exists to avoid. `workspace_exceeds` stops at the threshold rather
+/// than completing the walk, so the answer costs at most `limit + 1`
+/// entries however large the root is.
+#[test]
+fn the_sweep_auto_enables_only_under_the_file_threshold() {
+    let tmp = tempfile::tempdir().unwrap();
+    for i in 0..12 {
+        std::fs::write(tmp.path().join(format!("f{i}.ts")), "export const x = 1;\n").unwrap();
+    }
+
+    // Under the cap: auto enables.
+    assert!(
+        !App::workspace_exceeds(tmp.path(), 100),
+        "12 files is under a cap of 100"
+    );
+    assert!(
+        App::project_check_auto_enabled(tmp.path(), "auto", 100),
+        "auto enables under the cap"
+    );
+
+    // Over the cap: auto declines.
+    assert!(
+        App::workspace_exceeds(tmp.path(), 5),
+        "12 files exceeds a cap of 5"
+    );
+    assert!(
+        !App::project_check_auto_enabled(tmp.path(), "auto", 5),
+        "auto declines over the cap"
+    );
+
+    // The setting overrides the count in BOTH directions - a cap that only
+    // ever said no would make `on` meaningless on the roots that need it.
+    assert!(
+        App::project_check_auto_enabled(tmp.path(), "on", 5),
+        "`on` runs on a root the cap would have declined"
+    );
+    assert!(
+        !App::project_check_auto_enabled(tmp.path(), "off", 100),
+        "`off` declines a root the cap would have allowed"
+    );
+
+    // An unrecognised value reads as `auto` rather than silently enabling a
+    // sweep on a monorepo: a typo must not cost more than it saves.
+    assert!(
+        !App::project_check_auto_enabled(tmp.path(), "definitely-not-a-mode", 5),
+        "an unknown setting falls back to auto, which declines here"
+    );
+    assert!(
+        App::project_check_auto_enabled(tmp.path(), "definitely-not-a-mode", 100),
+        "and to auto's yes under the cap, not a blanket no"
+    );
+}
+
+/// Counting stops at the threshold instead of walking the whole tree
+/// (#256, criterion 5).
+///
+/// Pinned by making the tree far larger than the cap and asserting the
+/// answer arrives anyway: a full walk of a deep tree is the thing the cap
+/// is protecting against, so a cap that walks it has already lost.
+#[test]
+fn the_threshold_check_stops_counting_at_the_limit() {
+    let tmp = tempfile::tempdir().unwrap();
+    // 500 files against a cap of 3.
+    for d in 0..10 {
+        let dir = tmp.path().join(format!("d{d}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        for i in 0..50 {
+            std::fs::write(dir.join(format!("f{i}.ts")), "x\n").unwrap();
+        }
+    }
+    assert!(App::workspace_exceeds(tmp.path(), 3), "500 files exceeds 3");
+
+    // Ignored directories do not count toward the cap: node_modules alone
+    // would put every JS project over it, which would disable the sweep for
+    // exactly the projects the feature is for.
+    let clean = tempfile::tempdir().unwrap();
+    let heavy = clean.path().join("node_modules").join("pkg");
+    std::fs::create_dir_all(&heavy).unwrap();
+    for i in 0..200 {
+        std::fs::write(heavy.join(format!("m{i}.js")), "x\n").unwrap();
+    }
+    std::fs::write(clean.path().join("a.ts"), "export const a = 1;\n").unwrap();
+    assert!(
+        !App::workspace_exceeds(clean.path(), 10),
+        "node_modules is not the user's code and must not trip the cap"
+    );
+}
+
 /// "Problems: Check Whole Project" puts a whole-project checker's findings
 /// into PROBLEMS for files nobody opened, and a re-run REPLACES them (#256).
 ///

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -38190,6 +38190,41 @@ fn the_sweep_auto_enables_only_under_the_file_threshold() {
     );
 }
 
+/// A check that warrants no hint does not spend the one-shot (#256).
+///
+/// The flag was set when a check STARTED, so any run under `on`, `off`, or
+/// an under-cap `auto` consumed the only hint opportunity and a later
+/// oversized `auto` run stayed silent forever. It is now set where the hint
+/// is received, which is the only point that knows one was warranted.
+#[cfg(unix)]
+#[test]
+fn a_check_that_warrants_no_hint_does_not_spend_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+
+    // A run that produces no hint: the flag must stay unspent.
+    app.queue_project_check_result_for_test(tmp.path(), "", "", true);
+    app.sync_explorer_panels();
+    assert!(
+        !app.project_check_hinted_for_test(),
+        "a check with no hint must not consume the one-shot"
+    );
+
+    // A later run that DOES warrant one still gets it.
+    app.send_project_hint_for_test();
+    app.queue_project_check_result_for_test(tmp.path(), "", "", true);
+    app.sync_explorer_panels();
+    assert!(
+        app.status.contains("too large"),
+        "the hint the earlier run would have eaten still arrives: {:?}",
+        app.status
+    );
+    assert!(
+        app.project_check_hinted_for_test(),
+        "and NOW the one-shot is spent"
+    );
+}
+
 /// The size hint survives a result landing in the same tick (#256).
 ///
 /// Both drains run in one `sync_explorer_panels` body with no paint

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -38139,6 +38139,19 @@ fn the_sweep_auto_enables_only_under_the_file_threshold() {
         !App::workspace_exceeds(tmp.path(), 100),
         "12 files is under a cap of 100"
     );
+
+    // The exact boundary, both sides. "Exceeds" means strictly more, so a
+    // root holding exactly `limit` files does NOT exceed it - without this
+    // pair, `>` and `>=` are indistinguishable and the doc comment's claim
+    // is unverified.
+    assert!(
+        !App::workspace_exceeds(tmp.path(), 12),
+        "exactly 12 files does not exceed a cap of 12"
+    );
+    assert!(
+        App::workspace_exceeds(tmp.path(), 11),
+        "12 files exceeds a cap of 11"
+    );
     assert!(
         App::project_check_auto_enabled(tmp.path(), "auto", 100),
         "auto enables under the cap"
@@ -38174,6 +38187,64 @@ fn the_sweep_auto_enables_only_under_the_file_threshold() {
     assert!(
         App::project_check_auto_enabled(tmp.path(), "definitely-not-a-mode", 100),
         "and to auto's yes under the cap, not a blanket no"
+    );
+}
+
+/// The cap hints ONCE per session, and only under `auto` (#256).
+///
+/// The hint is the cap's user-visible half: an explicit sweep still runs on
+/// a huge root, but the user is told once that automatic runs will not
+/// start. Repeating it every sweep would train them to ignore the status
+/// line, and showing it under `on` would contradict the setting they chose.
+#[test]
+fn the_size_hint_fires_once_and_only_under_auto() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+
+    // `on` means run regardless of size, so a size hint would contradict it.
+    app.problems_project_scope = String::from("on");
+    assert!(
+        App::project_check_auto_enabled(tmp.path(), &app.problems_project_scope, 0),
+        "`on` runs even against a zero-file cap"
+    );
+
+    // `off` never auto-runs, so the size is not the reason - no hint either.
+    app.problems_project_scope = String::from("off");
+    assert!(!App::project_check_auto_enabled(
+        tmp.path(),
+        &app.problems_project_scope,
+        usize::MAX
+    ));
+
+    // Only `auto` makes size the deciding factor. The root needs a file for
+    // a cap of 0 to be EXCEEDED - an empty tree does not exceed zero, and
+    // asserting against one would have passed for the wrong reason.
+    std::fs::write(tmp.path().join("a.ts"), "export const a = 1;\n").unwrap();
+    app.problems_project_scope = String::from("auto");
+    assert!(
+        !App::project_check_auto_enabled(tmp.path(), "auto", 0),
+        "auto declines when the root exceeds the cap"
+    );
+    assert!(
+        App::project_check_auto_enabled(tmp.path(), "auto", usize::MAX),
+        "and enables under it - the paired case, so the line above cannot \
+         pass by the predicate always saying no"
+    );
+
+    // Config values are normalised like the sibling pref: a hand-edited
+    // "Off " must mean off, not a size-dependent maybe.
+    assert_eq!(App::project_scope_mode(" Off "), "off");
+    assert_eq!(App::project_scope_mode("ON"), "on");
+    assert_eq!(App::project_scope_mode("always"), "on");
+    assert_eq!(App::project_scope_mode("never"), "off");
+    assert_eq!(
+        App::project_scope_mode("wat"),
+        "auto",
+        "an unknown value is auto, never on"
+    );
+    assert!(
+        !App::project_check_auto_enabled(tmp.path(), " Off ", usize::MAX),
+        "a padded, capitalised off is honoured rather than read as auto"
     );
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -38190,6 +38190,40 @@ fn the_sweep_auto_enables_only_under_the_file_threshold() {
     );
 }
 
+/// The size hint survives a result landing in the same tick (#256).
+///
+/// Both drains run in one `sync_explorer_panels` body with no paint
+/// between them, and the result sets `status` unconditionally. Writing the
+/// hint before it DESTROYED the hint rather than deprioritising it - and
+/// the hint is one-shot, so it never returned. The fast-failure path (an
+/// over-cap root with no compiler installed) is exactly where the checker
+/// finishes inside a single tick.
+#[cfg(unix)]
+#[test]
+fn the_size_hint_is_not_erased_by_a_result_in_the_same_tick() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+
+    // Both messages in flight before ONE drain, which is the race. Driven
+    // through `sync_explorer_panels` rather than the direct-drain helper:
+    // the hint logic lives in that function, so calling `drain_project_check`
+    // itself would test a path the app never takes.
+    app.send_project_hint_for_test();
+    app.queue_project_check_result_for_test(tmp.path(), "", "", true);
+    app.sync_explorer_panels();
+
+    assert!(
+        app.status.contains("no problems"),
+        "the outcome the user asked for still leads: {:?}",
+        app.status
+    );
+    assert!(
+        app.status.contains("too large"),
+        "and the one-shot hint survives rather than being overwritten: {:?}",
+        app.status
+    );
+}
+
 /// The cap hints ONCE per session, and only under `auto` (#256).
 ///
 /// The hint is the cap's user-visible half: an explicit sweep still runs on

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -170,6 +170,11 @@ pub struct Prefs {
     /// rather than silently hiding diagnostics.
     #[serde(default)]
     pub problems_scope: String,
+    /// Whether the whole-project check may run without being asked (#256):
+    /// `auto` (under a file-count cap), `on`, or `off`. Unrecognised values
+    /// read as `auto`, so a typo cannot start a compile on a huge root.
+    #[serde(default)]
+    pub problems_project_scope: String,
     /// Default whitespace handling for new diff views: `off` (every byte
     /// counts), `leading` (ignore indentation changes), or `all` (ignore every
     /// whitespace-only difference). Unrecognised values read as `off`, so a
@@ -567,6 +572,15 @@ fn prefs_for_update(path: &Path) -> Result<Prefs> {
             Err(e)
         }
     }
+}
+
+/// Persist whether the whole-project check may auto-run (#256).
+/// Best-effort, like [`save_problems_scope`].
+pub fn save_problems_project_scope(mode: &str) -> Result<()> {
+    let path = config_path();
+    let mut prefs = prefs_for_update(&path)?;
+    prefs.problems_project_scope = mode.to_string();
+    prefs.save(&path)
 }
 
 /// Persist the PROBLEMS scope (#256), preserving other settings.

--- a/src/release_notes/0.1.929.md
+++ b/src/release_notes/0.1.929.md
@@ -1,0 +1,1 @@
+change: the whole-project check will not start on its own in a very large workspace, and says so once when that applies. A new palette entry cycles that between auto, always and never. Vendored directories like node_modules do not count toward the size, so an ordinary JavaScript project stays under it.

--- a/src/widgets/command_palette.rs
+++ b/src/widgets/command_palette.rs
@@ -144,6 +144,8 @@ pub enum Command {
     ToggleMinimap,
     /// Run the whole-project checker and put its findings in PROBLEMS (#256).
     ProblemsCheckProject,
+    /// Cycle whether that check may run WITHOUT being asked (#256).
+    ProblemsToggleProjectAuto,
     ProblemsToggleScope,
     DiffToggleIgnoreWhitespace,
     NewTerminal,
@@ -365,6 +367,7 @@ pub const ALL_COMMANDS: &[Command] = &[
     Command::ToggleTerminal,
     Command::ToggleMinimap,
     Command::ProblemsCheckProject,
+    Command::ProblemsToggleProjectAuto,
     Command::ProblemsToggleScope,
     Command::DiffToggleIgnoreWhitespace,
     Command::NewTerminal,
@@ -552,6 +555,9 @@ impl Command {
             Command::ToggleTerminal => "View: Toggle Terminal",
             Command::ToggleMinimap => "View: Toggle Minimap",
             Command::ProblemsCheckProject => "Problems: Check Whole Project",
+            Command::ProblemsToggleProjectAuto => {
+                "Problems: Whole-Project Check Auto-Run (Auto / On / Off)"
+            }
             Command::ProblemsToggleScope => "Problems: Toggle Scope (Open Files / Whole Project)",
             Command::DiffToggleIgnoreWhitespace => "Diff: Toggle Ignore Whitespace",
             Command::NewTerminal => "Terminal: Create New Terminal",
@@ -742,6 +748,7 @@ impl Command {
             Command::ToggleTerminal => "Ctrl+J",
             Command::ToggleMinimap => "Cmd+Opt+M",
             Command::ProblemsCheckProject => "",
+            Command::ProblemsToggleProjectAuto => "",
             Command::ProblemsToggleScope => "",
             Command::DiffToggleIgnoreWhitespace => "",
             Command::NewTerminal => "Cmd+T",
@@ -939,6 +946,7 @@ impl Command {
             Command::ToggleTerminal => "toggle_terminal",
             Command::ToggleMinimap => "toggle_minimap",
             Command::ProblemsCheckProject => "problems_check_project",
+            Command::ProblemsToggleProjectAuto => "problems_toggle_project_auto",
             Command::ProblemsToggleScope => "problems_toggle_scope",
             Command::DiffToggleIgnoreWhitespace => "diff_toggle_ignore_whitespace",
             Command::NewTerminal => "new_terminal",


### PR DESCRIPTION
Issue #256's fifth and final acceptance criterion: a 100k-file root does not auto-enable the whole-project check, and the setting overrides.

Criterion 3 (the sweep itself) shipped in #530; criteria 1, 2 and 4 in #296. **With this, every acceptance criterion on #256 is met.**

## What it does

`workspace_exceeds(root, limit)` counts files with `ignore::WalkBuilder` and **stops at the threshold** — a cap that counts a 100k-file tree to conclude the tree is too large has already paid the cost it exists to avoid.

Ignored and vendored directories don't count. `node_modules` alone puts most JS projects over any sensible cap, and disabling the sweep for JS projects would disable it for the projects it's *for*. Reuses the file finder's `is_noise_dir`.

`problems_project_scope` is auto/on/off, cycled from a new palette entry. An unrecognised value reads as `auto`, never `on` — a typo must not start a compile on a huge root, which is the exact failure the cap prevents.

An **explicit** sweep always runs; the cap governs *unasked* runs, and the user is told once when automatic ones won't start.

## Review findings, all fixed

**The walk was on the UI thread.** The toggle called the cap inline to describe its effect. My early-stop reasoning was half right: it bounds the cost *above* the cap and does nothing below it, so a 60k-file repo got walked to completion on a keypress. This repo runs whole-workspace walks on a background thread (`mod.rs:19604`, and both `file_finder` and `search` do it). The count now rides the sweep's existing worker.

**That left the cap with no caller.** Rather than an `#[allow]` or a wrapper — I tried the wrapper and deleted it, since it just moved the dead code up a level — it now has the consumer the issue actually specifies: *"otherwise stays off with a one-time hint"*, computed on that same worker and drained beside the sweep's result.

**Mode strings were matched raw** while the sibling `problems_scope` pref normalises, so a hand-edited `"Off"` silently meant `auto` — a size-dependent maybe where the user asked for never. One normaliser now serves both the predicate and the cycle.

## Verification

`cargo check` clean, `clippy -D warnings` clean, 7 tests.

Three mutations killed: unknown-setting fallback flipped to `on`, noise-dir filter removed, normaliser reverted to raw matching.

**A fourth mutation survived and found a real gap.** Flipping the cap's `>` to `>=` passed the whole suite — the boundary was untested, so an off-by-one could have shipped behind seven green tests. The doc comment claimed "exactly `limit` does not exceed it" and nothing checked it. Now pinned on both sides (12 files must not exceed 12; must exceed 11), and the mutation dies.

Closes #256.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added controls for whole-project problem checks: **Auto**, **Always**, or **Never**.
  - In Auto mode, checks no longer start automatically in workspaces exceeding 100,000 files.
  - Displays a one-time notice when the workspace is too large for automatic checking.
  - Excludes vendored directories such as `node_modules` from workspace-size limits.
  - The selected behavior is saved across sessions.

- **Release**
  - Updated the package version to 0.1.929.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->