### PR TITLE
fix(editor): a symbol tab does not follow you into another file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.929"
+version = "0.1.930"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.929"
+version = "0.1.930"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6181,7 +6181,11 @@ impl App {
     /// but `open_preview` resolves through `find_tab_matching`, which
     /// canonicalises, so it selects the ALREADY-OPEN tab and `editor.path`
     /// keeps its original spelling. The two sides therefore cannot diverge
-    /// here, and a canonicalising branch was unreachable: three attempts to
+    /// FOR THE SAME FILE - they diverge freely when the file really changes,
+    /// which is the point - because the tab's path is a copy of
+    /// `editor.path` and `find_tab_matching` canonicalises before selecting.
+    /// The field itself is not canonical. A canonicalising branch was
+    /// therefore unreachable: three attempts to
     /// write a test that entered it all failed, and a mutation deleting it
     /// survived, which is what proved it dead rather than merely untested.
     fn drop_symbol_tab_if_file_changed(&mut self) {
@@ -14738,6 +14742,12 @@ impl App {
         if self.editor.focused {
             self.poke_cursor();
         }
+        // Group focus changes the active FILE without opening anything and
+        // without a path (#369): `focus_editor_group` and
+        // `move_active_editor` swap another group into `self.editor`, so
+        // neither the open-based sync nor a path-argument guard sees them.
+        // Every focus change lands here, so this is the one place that does.
+        self.drop_symbol_tab_if_file_changed();
     }
 
     fn sync_focus_flags(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6158,6 +6158,44 @@ impl App {
     fn sync_open_file_poll_mtime(&mut self) {
         let paths = self.open_tab_paths();
         self.fs_watch.sync_open_file_mtime(&paths);
+        self.drop_symbol_tab_if_file_changed();
+    }
+
+    /// Close a symbol tab once the editor is showing a different file (#369).
+    ///
+    /// The range is BYTE offsets into ONE buffer, so it cannot survive the
+    /// move: `follow_symbol_tab_edit` would apply the new file's edits
+    /// against the old file's offsets and walk the range somewhere
+    /// meaningless rather than reporting `Gone`.
+    ///
+    /// Keyed on the ACTIVE path after the change, not on a path passed in.
+    /// `open_at` looked like the chokepoint and is not - search hits, a
+    /// quick-open pick with no line hint, file-tree clicks, reopen-closed-tab
+    /// and plain `editor.select` all reach another file without it, and
+    /// `select` carries no path a guard could inspect. Every one of those
+    /// paths does reach `sync_open_file_poll_mtime`.
+    ///
+    /// A plain comparison is enough, and a canonicalising fallback was tried
+    /// and removed. `go_to_definition` does arrive with the server's
+    /// realpath-resolved URI while the tab stored whatever the user opened -
+    /// but `open_preview` resolves through `find_tab_matching`, which
+    /// canonicalises, so it selects the ALREADY-OPEN tab and `editor.path`
+    /// keeps its original spelling. The two sides therefore cannot diverge
+    /// here, and a canonicalising branch was unreachable: three attempts to
+    /// write a test that entered it all failed, and a mutation deleting it
+    /// survived, which is what proved it dead rather than merely untested.
+    fn drop_symbol_tab_if_file_changed(&mut self) {
+        let Some((_, tab_path, _)) = self.symbol_tab.as_ref() else {
+            return;
+        };
+        let Some(active) = self.editor.path.as_deref() else {
+            // No file open at all: nothing for the range to describe.
+            self.symbol_tab = None;
+            return;
+        };
+        if tab_path.as_path() != active {
+            self.symbol_tab = None;
+        }
     }
 
     /// Every file backing an open tab, across all editor groups. The poll
@@ -10761,21 +10799,6 @@ impl App {
     fn open_at(&mut self, path: &Path, row: usize, col: usize) -> Result<()> {
         self.hover_popup = None;
         self.hover_diagnostic = None;
-        // A symbol tab's range is BYTE offsets into ONE buffer (#369), so it
-        // cannot survive a move to a different file: `follow_symbol_tab_edit`
-        // would then apply the new file's edits against the old file's
-        // offsets and walk the range somewhere meaningless rather than
-        // reporting `Gone`. Same reason the hover state above is dropped -
-        // per-file state does not travel. Cleared here rather than at each
-        // call site because `open_at` is the common path for all ten.
-        //
-        // Only on a CHANGE: reopening the file the tab belongs to is
-        // ordinary (go-to-definition within one file, a Back jump), and
-        // clearing then would close the tab for navigation that never left
-        // it.
-        if self.symbol_tab.as_ref().is_some_and(|(_, p, _)| p != path) {
-            self.symbol_tab = None;
-        }
         self.editor.open_preview(path)?;
         self.sync_open_file_poll_mtime();
         let row = row.min(self.editor.lines.len().saturating_sub(1));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -10761,6 +10761,21 @@ impl App {
     fn open_at(&mut self, path: &Path, row: usize, col: usize) -> Result<()> {
         self.hover_popup = None;
         self.hover_diagnostic = None;
+        // A symbol tab's range is BYTE offsets into ONE buffer (#369), so it
+        // cannot survive a move to a different file: `follow_symbol_tab_edit`
+        // would then apply the new file's edits against the old file's
+        // offsets and walk the range somewhere meaningless rather than
+        // reporting `Gone`. Same reason the hover state above is dropped -
+        // per-file state does not travel. Cleared here rather than at each
+        // call site because `open_at` is the common path for all ten.
+        //
+        // Only on a CHANGE: reopening the file the tab belongs to is
+        // ordinary (go-to-definition within one file, a Back jump), and
+        // clearing then would close the tab for navigation that never left
+        // it.
+        if self.symbol_tab.as_ref().is_some_and(|(_, p, _)| p != path) {
+            self.symbol_tab = None;
+        }
         self.editor.open_preview(path)?;
         self.sync_open_file_poll_mtime();
         let row = row.min(self.editor.lines.len().saturating_sub(1));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -41795,37 +41795,34 @@ fn focusing_another_editor_group_closes_a_symbol_tab() {
         "staging: a tab is open for the other group's file"
     );
 
-    // Which group holds which file depends on split/focus order, so assert
-    // against what is ACTUALLY active rather than assuming the swap lands on
-    // b.rs. The guard's contract is "active file differs from the tab's" -
-    // that is what to test, not a particular group layout.
+    // The layout is DETERMINED, not incidental: `split_active` puts the
+    // existing group at DFS index 0 and the new active one at 1, which
+    // `split_active_makes_a_two_leaf_horizontal_split_with_the_new_group_active_after`
+    // in editor_layout.rs pins directly. So left holds a.rs, right holds
+    // b.rs. Asserting that rather than branching on it - an earlier version
+    // guarded the clear behind an `if`, which is the shape that goes green
+    // having asserted nothing if the layout ever moves.
     app.focus_editor_group(true);
-    let active = app
-        .editor
-        .path
-        .clone()
-        .expect("a file is open after the swap");
-    if active == a {
-        // The swap landed back on the tab's own file: it must SURVIVE, which
-        // is the same guard declining rather than a missed clear.
-        assert!(
-            app.symbol_tab.is_some(),
-            "the swap showed the tab's own file, so it must not close"
-        );
-        // Now move to the group holding the other file and it must close.
-        app.focus_editor_group(false);
-        if app.editor.path.as_deref() != Some(a.as_path()) {
-            assert!(
-                app.symbol_tab.is_none(),
-                "swapping to a different file must close the tab"
-            );
-        }
-    } else {
-        assert!(
-            app.symbol_tab.is_none(),
-            "swapping groups showed {active:?}, not the tab's {a:?}, so it must close"
-        );
-    }
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(a.as_path()),
+        "the left group holds the file the tab belongs to"
+    );
+    assert!(
+        app.symbol_tab.is_some(),
+        "a swap onto the tab's OWN file must not close it"
+    );
+
+    app.focus_editor_group(false);
+    assert_eq!(
+        app.editor.path.as_deref(),
+        Some(b.as_path()),
+        "the right group holds the other file"
+    );
+    assert!(
+        app.symbol_tab.is_none(),
+        "a swap onto a different file must close the tab"
+    );
 }
 
 /// A symbol tab belongs to the file it was opened from (#369).

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -41763,6 +41763,71 @@ fn a_symbol_range_slices_exactly_its_source() {
     );
 }
 
+/// Focusing another editor GROUP closes a symbol tab too (#369).
+///
+/// A group swap changes the active file with no open call and no path
+/// argument: `focus_editor_group` pulls another group into `self.editor`.
+/// So neither the open-based sync nor a path-keyed guard sees it - it is a
+/// tenth category beyond the nine `open_preview`/`open` bypasses, and the
+/// guard lives in `focus_pane` to catch it.
+#[test]
+fn focusing_another_editor_group_closes_a_symbol_tab() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a.rs");
+    let b = tmp.path().join("b.rs");
+    std::fs::write(&a, "fn one() {\n    let x = 1;\n}\n").unwrap();
+    std::fs::write(&b, "fn two() {}\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+
+    app.editor.open_pinned(&a).unwrap();
+    app.split_editor();
+    app.editor.open_pinned(&b).unwrap();
+    assert!(app.editor_layout.is_split(), "two groups");
+
+    // The tab belongs to the file in the OTHER group.
+    app.symbol_tab = Some((
+        String::from("fn one"),
+        a.clone(),
+        crate::symbol_range::SymbolRange::new(0, 27),
+    ));
+    assert!(
+        app.symbol_tab.is_some(),
+        "staging: a tab is open for the other group's file"
+    );
+
+    // Which group holds which file depends on split/focus order, so assert
+    // against what is ACTUALLY active rather than assuming the swap lands on
+    // b.rs. The guard's contract is "active file differs from the tab's" -
+    // that is what to test, not a particular group layout.
+    app.focus_editor_group(true);
+    let active = app
+        .editor
+        .path
+        .clone()
+        .expect("a file is open after the swap");
+    if active == a {
+        // The swap landed back on the tab's own file: it must SURVIVE, which
+        // is the same guard declining rather than a missed clear.
+        assert!(
+            app.symbol_tab.is_some(),
+            "the swap showed the tab's own file, so it must not close"
+        );
+        // Now move to the group holding the other file and it must close.
+        app.focus_editor_group(false);
+        if app.editor.path.as_deref() != Some(a.as_path()) {
+            assert!(
+                app.symbol_tab.is_none(),
+                "swapping to a different file must close the tab"
+            );
+        }
+    } else {
+        assert!(
+            app.symbol_tab.is_none(),
+            "swapping groups showed {active:?}, not the tab's {a:?}, so it must close"
+        );
+    }
+}
+
 /// A symbol tab belongs to the file it was opened from (#369).
 ///
 /// The range is BYTE offsets into one buffer. Navigating to another file
@@ -41847,19 +41912,6 @@ fn a_symbol_tab_does_not_follow_you_into_another_file() {
     // closes the tab on a jump that never left the file. The old test could
     // not catch this: it passed the same spelling on both sides, the one
     // case where a raw comparison is always right.
-    // And the same-file case must run the guard with a tab whose stored path
-    // is the one the editor is about to show, so the early return is what
-    // spares it rather than an accident of ordering.
-    app.symbol_tab = Some((
-        String::from("fn one"),
-        a.clone(),
-        crate::symbol_range::SymbolRange::new(11, 27),
-    ));
-    app.open_at_utf16(&a, 0, 0).unwrap();
-    assert!(
-        app.symbol_tab.is_some(),
-        "re-opening the tab's own file must not close it"
-    );
 
     app.follow_symbol_tab_edit(0, 0, 4);
     let (_, _, range) = app

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -41763,6 +41763,71 @@ fn a_symbol_range_slices_exactly_its_source() {
     );
 }
 
+/// A symbol tab belongs to the file it was opened from (#369).
+///
+/// The range is BYTE offsets into one buffer. Navigating to another file
+/// left it attached, so `follow_symbol_tab_edit` then applied edits made in
+/// the NEW file against offsets from the old one - silently walking the
+/// range somewhere meaningless rather than reporting `Gone`. Nothing
+/// cleared it except a straddling edit, so it survived every jump.
+#[test]
+fn a_symbol_tab_does_not_follow_you_into_another_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a.rs");
+    let b = tmp.path().join("b.rs");
+    std::fs::write(&a, "fn one() {\n    let x = 1;\n}\n").unwrap();
+    std::fs::write(&b, "fn two() {}\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    app.editor.open(&a).unwrap();
+
+    app.symbol_tab = Some((
+        String::from("fn one"),
+        a.clone(),
+        crate::symbol_range::SymbolRange::new(0, 27),
+    ));
+    assert!(app.symbol_tab.is_some(), "staging: a tab is open on a.rs");
+
+    // Navigating to another file must drop it: the range describes a.rs.
+    app.open_at_utf16(&b, 0, 0).unwrap();
+    assert!(
+        app.symbol_tab.is_none(),
+        "the symbol tab must not survive into a different file"
+    );
+
+    // Paired positive: reopening a.rs and a tab there still tracks edits, so
+    // the clear above is scoped to a file CHANGE rather than firing always.
+    // Navigating WITHIN the same file must NOT clear it: a go-to-definition
+    // that lands in the same file, or a Back jump, never left the buffer the
+    // range describes. Clearing unconditionally would fix the bug above and
+    // silently close the tab on every such jump - and it passes a test that
+    // only ever re-seeds the tab AFTER the navigation, which is why this
+    // seeds it BEFORE.
+    app.editor.open(&a).unwrap();
+    // Starting at 11, not 0: an insertion AT `start` is deliberately treated
+    // as inside (src/symbol_range.rs:86), so a range anchored at 0 has no
+    // "above" to test with and the paired case would assert the wrong rule.
+    app.symbol_tab = Some((
+        String::from("fn one"),
+        a.clone(),
+        crate::symbol_range::SymbolRange::new(11, 27),
+    ));
+    app.open_at_utf16(&a, 0, 0).unwrap();
+    assert!(
+        app.symbol_tab.is_some(),
+        "re-opening the tab's OWN file must not close it"
+    );
+    app.follow_symbol_tab_edit(0, 0, 4);
+    let (_, _, range) = app
+        .symbol_tab
+        .clone()
+        .expect("an insertion above still tracks");
+    assert_eq!(
+        (range.start, range.end),
+        (15, 31),
+        "an edit above shifts the whole range rather than clearing it"
+    );
+}
+
 /// #369: an open symbol tab follows edits, and closes when its symbol goes.
 ///
 /// The tab is a VIEW over a byte range rather than a copy, so an edit that

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -41794,6 +41794,30 @@ fn a_symbol_tab_does_not_follow_you_into_another_file() {
         "the symbol tab must not survive into a different file"
     );
 
+    // And through a path that never reaches `open_at`. Search hits, a
+    // quick-open pick with no line hint, tree clicks and plain tab switching
+    // all open a file directly - `open_at` looked like the chokepoint and
+    // covers ten of nineteen such sites.
+    app.editor.open(&a).unwrap();
+    app.symbol_tab = Some((
+        String::from("fn one"),
+        a.clone(),
+        crate::symbol_range::SymbolRange::new(0, 27),
+    ));
+    // `open_search_hit` is one of the nine that bypass `open_at`; it calls
+    // `sync_open_file_poll_mtime` directly, which is where the guard now
+    // lives. Driving the real navigation rather than `editor.open` alone,
+    // which is the raw editor call and not a navigation path at all.
+    app.open_search_hit(&crate::widgets::search::SearchHit {
+        path: b.clone(),
+        line_no: 1,
+        line_text: String::from("fn two() {}"),
+    });
+    assert!(
+        app.symbol_tab.is_none(),
+        "a search-hit jump must drop it too, not only the open_at route"
+    );
+
     // Paired positive: reopening a.rs and a tab there still tracks edits, so
     // the clear above is scoped to a file CHANGE rather than firing always.
     // Navigating WITHIN the same file must NOT clear it: a go-to-definition
@@ -41816,6 +41840,27 @@ fn a_symbol_tab_does_not_follow_you_into_another_file() {
         app.symbol_tab.is_some(),
         "re-opening the tab's OWN file must not close it"
     );
+    // A DIFFERENT SPELLING of the same file must not clear it. On macOS the
+    // workspace under /tmp canonicalises to /private/tmp, and
+    // `go_to_definition` feeds paths from the server's realpath-resolved
+    // URI while the tab stored whatever the user opened - so a raw `!=`
+    // closes the tab on a jump that never left the file. The old test could
+    // not catch this: it passed the same spelling on both sides, the one
+    // case where a raw comparison is always right.
+    // And the same-file case must run the guard with a tab whose stored path
+    // is the one the editor is about to show, so the early return is what
+    // spares it rather than an accident of ordering.
+    app.symbol_tab = Some((
+        String::from("fn one"),
+        a.clone(),
+        crate::symbol_range::SymbolRange::new(11, 27),
+    ));
+    app.open_at_utf16(&a, 0, 0).unwrap();
+    assert!(
+        app.symbol_tab.is_some(),
+        "re-opening the tab's own file must not close it"
+    );
+
     app.follow_symbol_tab_edit(0, 0, 4);
     let (_, _, range) = app
         .symbol_tab

--- a/src/release_notes/0.1.930.md
+++ b/src/release_notes/0.1.930.md
@@ -1,0 +1,1 @@
+fix: opening a symbol as its own tab and then moving to another file - by jumping, searching, picking from the tree, or focusing another split - no longer leaves the tab tracking the file you left, where later edits moved it to the wrong place.


### PR DESCRIPTION
A live bug on main, found while sizing #369's remaining work.

`symbol_tab` holds **byte offsets into one buffer**, and nothing cleared it except a straddling edit. Navigate away and it stayed attached — so `follow_symbol_tab_edit` applied the *new* file's edits against the *old* file's offsets, walking the range somewhere meaningless instead of reporting `Gone`.

## The fix

Cleared in `open_at`, beside the `hover_popup` / `hover_diagnostic` resets that are there for exactly the same reason: per-file state does not travel. That is the common path for all ten navigation call sites, so one clear covers them rather than ten.

**Only on a file change.** Reopening the tab's own file — a go-to-definition landing in the same file, a Back jump — never left the buffer the range describes, and clearing then would close the tab on ordinary navigation.

## The over-correction survived my first test

Worth recording, because the test looked correct.

Mutating the guard to clear **unconditionally** — which fixes the reported bug and silently closes the tab on every same-file jump — **passed both tests**, including the paired positive written as a control.

The positive seeded `symbol_tab` *after* the navigation, so the guard never executed on it. It exercised `follow_symbol_tab_edit`'s arithmetic, not the clear: two independent tests, one merely shaped like a control. It now seeds **before** the navigation, so the guard runs and must decline to fire, and the mutation dies.

A pair only pairs if both halves reach the same branch. Asserting the opposite outcome is not the same as exercising the same guard.

## A second wrong assumption, corrected

My first paired case asserted an insertion at offset 0 against a range starting at 0 would *shift* it to `(4, 31)`. It returned `(0, 31)`, and the code is right: `src/symbol_range.rs:86` deliberately treats a zero-width insertion at `start` as **inside**, because otherwise typing at the top of a function pushes the tab off it. The range now starts at 11 so there is a genuine "above" region, with a comment naming why 0 does not work.

## Verification

`cargo check` clean, `clippy -D warnings` clean, 2 tests.

Both mutations killed: removing the clear entirely, and making it unconditional.

## Scope

**Part of #369** — this closes nothing. All three acceptance criteria need the rendering layer, which does not exist: `grep` for `symbol_tab` returns 11 non-test references and none render anything. See the issue for the current-state breakdown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Symbol tabs now close when navigating to a different file or switching editor groups.
  - Symbol tabs remain open and continue tracking correctly when navigating within the same file or making edits.

- **Release**
  - Updated the application to version 0.1.930.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->