### PR TITLE
fix(problems): give each producer's rows their own owner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.930"
+version = "0.1.932"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.930"
+version = "0.1.932"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3820,8 +3820,13 @@ pub struct App {
     pub git_output_log: Vec<String>,
     /// Build diagnostics from the problem matchers (#119): finished-command
     /// output scanned into PROBLEMS entries, keyed by resolved file path.
+    /// Paired with the producer that installed it (the pane uid, or
+    /// `PROJECT_CHECK_ID` for the whole-project sweep). Without the pairing
+    /// a re-run removed the whole entry and took the OTHER producer's rows
+    /// with it, and the second producer to reach a file could not clear its
+    /// own rows at all (#532).
     build_diagnostics:
-        std::collections::HashMap<PathBuf, Vec<crate::widgets::problems::ProblemItem>>,
+        std::collections::HashMap<PathBuf, Vec<(u64, crate::widgets::problems::ProblemItem)>>,
     /// Which files each terminal pane contributed, keyed by the pane's
     /// STABLE uid (Vec positions shift on close/insert/reorder), so a
     /// pane's next scanned command replaces its previous run's diagnostics
@@ -8522,7 +8527,15 @@ impl App {
         }
         if let Some(files) = self.build_diag_files_by_pane.remove(&pane) {
             for f in files {
-                self.build_diagnostics.remove(&f);
+                // Filter, never remove: another producer may hold rows on
+                // this same file, and dropping the entry took them too
+                // (#532). The entry goes only once nothing is left in it.
+                if let Some(rows) = self.build_diagnostics.get_mut(&f) {
+                    rows.retain(|(owner, _)| *owner != pane);
+                    if rows.is_empty() {
+                        self.build_diagnostics.remove(&f);
+                    }
+                }
             }
         }
         let base = cwd.unwrap_or(self.workspace_root()).to_path_buf();
@@ -8537,19 +8550,26 @@ impl App {
                 }
             };
             let entry = self.build_diagnostics.entry(path.clone()).or_default();
-            if entry.is_empty() {
+            // Unconditionally: recording only when the entry was empty meant
+            // the SECOND producer to reach a file never listed it, so its
+            // next run had nothing to clear (#532). `touched` is this
+            // producer's own file list, not a set of first-touchers.
+            if !touched.contains(&path) {
                 touched.push(path);
             }
-            entry.push(crate::widgets::problems::ProblemItem {
-                line: d.line,
-                col: d.col,
-                // Build tools report characters (rustc counts code points),
-                // not the UTF-16 units an LSP position carries.
-                col_utf16: false,
-                severity: d.severity,
-                message: d.message,
-                source: d.source.to_string(),
-            });
+            entry.push((
+                pane,
+                crate::widgets::problems::ProblemItem {
+                    line: d.line,
+                    col: d.col,
+                    // Build tools report characters (rustc counts code
+                    // points), not the UTF-16 units an LSP position carries.
+                    col_utf16: false,
+                    severity: d.severity,
+                    message: d.message,
+                    source: d.source.to_string(),
+                },
+            ));
         }
         self.build_diag_files_by_pane.insert(pane, touched);
         self.rebuild_problems();
@@ -8664,7 +8684,7 @@ impl App {
                 }
             }
             if let Some(build) = self.build_diagnostics.get(path) {
-                items.extend(build.iter().cloned());
+                items.extend(build.iter().map(|(_, item)| item.clone()));
             }
             if items.is_empty() {
                 continue;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8472,11 +8472,10 @@ impl App {
     /// Recorded at install time rather than summed from the store: a file's
     /// entry in `build_diagnostics` holds EVERY producer's items for that
     /// file, so summing it double-counts a file the sweep and a pane both
-    /// report - and undercounts in the reverse order, because
-    /// `install_build_diags` records a path only when the entry was empty,
-    /// so the second producer to reach a shared file never lists it.
-    /// Filtering on the item's `source` would not help either: a pane
-    /// running tsc produces the same source string as this sweep.
+    /// report. Filtering on the item's `source` would not help either: a
+    /// pane running tsc produces the same source string as this sweep.
+    /// (The rows do carry an owner since #532, so an owner-filtered count
+    /// would work - but this field is already exact and cheaper.)
     fn project_check_count(&self) -> usize {
         self.project_check_rows
     }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -38028,7 +38028,6 @@ fn a_project_checker_that_failed_to_run_does_not_report_a_clean_project() {
 ///
 /// #530 made this routine rather than rare: the whole-project sweep reports
 /// every file in the project, so it overlaps any pane build by default.
-#[cfg(unix)]
 #[test]
 fn each_producer_clears_only_its_own_rows_from_a_shared_file() {
     let tmp = tempfile::tempdir().unwrap();
@@ -38084,11 +38083,13 @@ fn each_producer_clears_only_its_own_rows_from_a_shared_file() {
 /// reporting (#256).
 ///
 /// `build_diagnostics[f]` holds every producer's items for that file, so
-/// summing the store double-counts a shared file - and undercounts in the
-/// reverse order, because `install_build_diags` records a path only when the
-/// entry was empty, so the second producer to reach a shared file never
-/// lists it. Both orderings are pinned because they fail in opposite
-/// directions and one alone would look correct.
+/// summing the store double-counts a shared file. Both orderings are pinned
+/// because they fail in opposite directions and one alone would look
+/// correct.
+///
+/// The undercount this doc used to also describe - the second producer never
+/// listing a shared file, so it could not clear its rows - was the other half
+/// of #532 and is fixed; the rows carry an owner now.
 #[cfg(unix)]
 #[test]
 fn a_file_both_producers_report_is_not_double_counted() {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -38017,6 +38017,69 @@ fn a_project_checker_that_failed_to_run_does_not_report_a_clean_project() {
     );
 }
 
+/// Each producer clears only ITS OWN rows from a shared file (#532).
+///
+/// `build_diagnostics` held one flat `Vec` per file, so a re-run removed the
+/// whole entry and took the other producer's rows with it - and
+/// `install_build_diags` recorded a path in `touched` only when the entry was
+/// empty, so the SECOND producer to reach a file never listed it and could
+/// not clear its rows at all. Two halves of one problem: rows did not carry
+/// who produced them.
+///
+/// #530 made this routine rather than rare: the whole-project sweep reports
+/// every file in the project, so it overlaps any pane build by default.
+#[cfg(unix)]
+#[test]
+fn each_producer_clears_only_its_own_rows_from_a_shared_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shared = tmp.path().join("shared.ts");
+    std::fs::write(&shared, "export const a = 1;\n").unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    let line = |code: &str| format!("shared.ts(1,1): error {code}: boom.\n");
+
+    // Pane 1 reports the file, then the sweep reports it too.
+    app.apply_build_scan(1, Some(tmp.path()), "tsc", &line("TS1001"));
+    app.ingest_project_check(Some(tmp.path()), &line("TS2002"));
+    app.rebuild_problems();
+    let rows = |app: &App| -> Vec<String> {
+        app.problems
+            .groups()
+            .iter()
+            .filter(|g| g.path == shared)
+            .flat_map(|g| g.items.iter().map(|i| i.message.clone()))
+            .collect()
+    };
+    assert_eq!(
+        rows(&app).len(),
+        2,
+        "both producers' rows are on the shared file, got {:?}",
+        rows(&app)
+    );
+
+    // The SECOND producer re-runs clean. Its row must go; the pane's stays.
+    app.ingest_project_check(Some(tmp.path()), "");
+    app.rebuild_problems();
+    let after = rows(&app);
+    assert_eq!(
+        after.len(),
+        1,
+        "the sweep's row goes and the pane's remains, got {after:?}"
+    );
+    assert!(
+        after[0].contains("TS1001"),
+        "the surviving row is the PANE's, not the sweep's: {after:?}"
+    );
+
+    // And the reverse: the pane re-runs clean, leaving nothing.
+    app.apply_build_scan(1, Some(tmp.path()), "tsc", "");
+    app.rebuild_problems();
+    assert!(
+        rows(&app).is_empty(),
+        "with both producers clean the file has no rows, got {:?}",
+        rows(&app)
+    );
+}
+
 /// A file BOTH the sweep and a pane report is counted once, by whoever is
 /// reporting (#256).
 ///

--- a/src/release_notes/0.1.932.md
+++ b/src/release_notes/0.1.932.md
@@ -1,0 +1,1 @@
+fix: when a build and the whole-project check both report errors in the same file, re-running one no longer clears the other's rows from PROBLEMS, and a fixed error now disappears whichever of them found it.


### PR DESCRIPTION
Closes #532 — which turned out to be **two** bugs sharing one cause: rows in `build_diagnostics` did not carry who produced them.

## Both halves

**Removal deleted too much.** A producer's re-run did `build_diagnostics.remove(&f)`, dropping the whole entry — so it took the *other* producer's rows for that file with it.

**Recording captured too little.** `install_build_diags` pushed a path into its `touched` list only `if entry.is_empty()`, so the **second** producer to reach a file never listed it, and its next run had nothing to clear.

They fail in opposite directions, which is why either alone looks plausible in isolation: one over-deletes, one under-deletes.

## The fix

Each row now carries its producer — the pane uid, or `PROJECT_CHECK_ID` for the whole-project sweep. Removal filters by owner and drops the entry only once nothing is left in it; every reported path is recorded rather than only the first toucher.

`ProblemItem` is unchanged: the pairing happens in the store's value type, so the LSP path and the three construction sites are untouched. The rebuild flattens the producer away when merging.

## Why now

Pre-existing, but #530 made it routine rather than rare. Before that the only producers were terminal panes, so overlap needed two panes building the same file. The whole-project sweep reports **every** file in the project, so it overlaps any pane build by default.

## Verification

Build clean, lints clean under `-D warnings`, 3 tests.

Both mutations killed — restoring `remove(&f)`, and restoring `if entry.is_empty()`. The test pins both directions: the sweep re-running clean must leave the pane's row, and the pane re-running clean must leave nothing. Either assertion alone would pass while the other half was broken.

One note on the gates: the combined build/lint/test run was killed for memory on this host (~74 MB free), so the stages are run separately. That was environmental — the kill produced no output at all, so it never compiled the change.
