### PR TITLE
feat(lsp): detect workspace/diagnostic support and cache its result ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.932"
+version = "0.1.934"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.932"
+version = "0.1.934"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -1733,6 +1733,10 @@ struct ManagedClient {
     client: Arc<TokioMutex<LspClient>>,
     supports_completion: bool,
     supports_signature_help: bool,
+    /// Whether the server answers `workspace/diagnostic` (#533), read from
+    /// the capability's inner `workspaceDiagnostics` flag rather than the
+    /// outer `Option` - see `workspace_diagnostics_supported`.
+    supports_workspace_diagnostics: bool,
     supports_hover: bool,
     supports_definition: bool,
     supports_document_symbol: bool,
@@ -2333,6 +2337,8 @@ impl WorkerState {
                         let supports = caps.completion_provider.is_some();
                         let supports_signature_help =
                             signature_help_supported(&caps.signature_help_provider);
+                        let supports_workspace_diagnostics =
+                            workspace_diagnostics_supported(&caps.diagnostic_provider);
                         let supports_hover = hover_supported(&caps.hover_provider);
                         let supports_definition = one_of_supported(&caps.definition_provider);
                         let supports_document_symbol =
@@ -2389,6 +2395,7 @@ impl WorkerState {
                             client: Arc::new(TokioMutex::new(client)),
                             supports_completion: supports,
                             supports_signature_help,
+                            supports_workspace_diagnostics,
                             supports_hover,
                             supports_definition,
                             supports_document_symbol,

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -1736,6 +1736,10 @@ struct ManagedClient {
     /// Whether the server answers `workspace/diagnostic` (#533), read from
     /// the capability's inner `workspaceDiagnostics` flag rather than the
     /// outer `Option` - see `workspace_diagnostics_supported`.
+    ///
+    /// Written but not yet read: the request slice filters on it. Verified
+    /// not to warn - a forced non-test rebuild under `-D warnings` with no
+    /// `allow` is clean, because the field is written in a real constructor.
     supports_workspace_diagnostics: bool,
     supports_hover: bool,
     supports_definition: bool,

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -5002,6 +5002,72 @@ fn signature_help_supported(cap: &Option<lsp_types::SignatureHelpOptions>) -> bo
     cap.is_some()
 }
 
+/// Result ids from the last `workspace/diagnostic` pull, per file (#533).
+///
+/// The incrementality contract: send back what the server last told us, and
+/// it answers `Unchanged` for anything that has not moved instead of
+/// resending the diagnostics. Without this every pull is a full re-report of
+/// the whole workspace, which is the cost the pull path exists to avoid.
+///
+/// Keyed by URI string rather than `PathBuf` because that is what the server
+/// echoes back, and round-tripping through a path loses the distinction on
+/// any URI that is not a plain file (a server may report `untitled:` or a
+/// virtual scheme). Comparing what it sent to what it sends is the whole job.
+#[derive(Default)]
+pub struct DiagnosticResultIds {
+    by_uri: std::collections::HashMap<String, String>,
+}
+
+impl DiagnosticResultIds {
+    /// What to send as `previousResultIds` on the next pull.
+    pub fn previous(&self) -> Vec<lsp_types::PreviousResultId> {
+        self.by_uri
+            .iter()
+            .filter_map(|(uri, value)| {
+                Url::parse(uri).ok().map(|uri| lsp_types::PreviousResultId {
+                    uri,
+                    value: value.clone(),
+                })
+            })
+            .collect()
+    }
+
+    /// Record the id a `Full` report carried, or forget the file when it
+    /// carried none.
+    ///
+    /// A report with no `result_id` is the server declining to offer
+    /// incrementality for that file. Keeping the OLD id would then send back
+    /// an id the server never issued for the current content, and a server
+    /// that trusts it answers `Unchanged` for a file that has in fact
+    /// changed - stale diagnostics that never refresh.
+    pub fn record(&mut self, uri: &str, result_id: Option<&str>) {
+        match result_id {
+            Some(id) => {
+                self.by_uri.insert(uri.to_string(), id.to_string());
+            }
+            None => {
+                self.by_uri.remove(uri);
+            }
+        }
+    }
+
+    /// Drop everything, for when the server restarts or the workspace moves.
+    pub fn clear(&mut self) {
+        self.by_uri.clear();
+    }
+
+    /// How many files carry an id, so a caller can tell a cold cache from a
+    /// warm one without reaching inside.
+    pub fn len(&self) -> usize {
+        self.by_uri.len()
+    }
+
+    /// Whether the cache is cold.
+    pub fn is_empty(&self) -> bool {
+        self.by_uri.is_empty()
+    }
+}
+
 /// Whether the server answers `workspace/diagnostic`, the LSP 3.17 PULL of
 /// whole-project diagnostics (#533).
 ///
@@ -6283,6 +6349,52 @@ mod tests {
         assert!(one_of_supported(&on));
         assert!(one_of_supported(&opts));
         assert!(!one_of_supported(&None::<OneOf<bool, ()>>));
+    }
+
+    /// A `Full` report with no `result_id` must FORGET the file, not keep
+    /// the old id (#533).
+    ///
+    /// Keeping it sends back an id the server never issued for the current
+    /// content; a server that trusts it answers `Unchanged` for a file that
+    /// has changed, and the diagnostics never refresh.
+    #[test]
+    fn a_report_without_a_result_id_forgets_the_file() {
+        let mut ids = DiagnosticResultIds::default();
+        assert!(ids.is_empty(), "cold to start");
+
+        ids.record("file:///w/a.rs", Some("v1"));
+        ids.record("file:///w/b.rs", Some("v1"));
+        assert_eq!(ids.len(), 2);
+
+        // b.rs comes back with no id: the server is declining incrementality
+        // for it, so the stale id must go rather than being resent.
+        ids.record("file:///w/b.rs", None);
+        assert_eq!(ids.len(), 1, "the file without an id is forgotten");
+        let sent: Vec<String> = ids
+            .previous()
+            .into_iter()
+            .map(|p| p.uri.to_string())
+            .collect();
+        assert!(
+            sent.iter().any(|u| u.contains("a.rs")),
+            "the file that DID carry an id is still sent: {sent:?}"
+        );
+        assert!(
+            !sent.iter().any(|u| u.contains("b.rs")),
+            "the forgotten file is not sent: {sent:?}"
+        );
+
+        // A new id for the same file replaces rather than accumulating.
+        ids.record("file:///w/a.rs", Some("v2"));
+        assert_eq!(ids.len(), 1, "replacing an id does not add an entry");
+        assert_eq!(
+            ids.previous().first().map(|p| p.value.clone()),
+            Some(String::from("v2")),
+            "the newest id is what goes back"
+        );
+
+        ids.clear();
+        assert!(ids.is_empty(), "a restart drops everything");
     }
 
     /// A server that pulls per-document but NOT per-workspace advertises

--- a/src/lsp/manager.rs
+++ b/src/lsp/manager.rs
@@ -11,16 +11,17 @@ use lsp_types::{
     CodeActionKindLiteralSupport, CodeActionLiteralSupport, CodeActionOrCommand,
     CodeActionProviderCapability, CodeActionResponse, CompletionClientCapabilities,
     CompletionItemCapability, CompletionItemKind, CompletionItemKindCapability, CompletionResponse,
-    DeclarationCapability, DocumentChangeOperation, DocumentChanges, DocumentSymbol,
-    DocumentSymbolClientCapabilities, DocumentSymbolResponse, GotoDefinitionResponse,
-    HoverContents, HoverProviderCapability, ImplementationProviderCapability, Location,
-    MarkedString, MarkupKind, OneOf, Position, PublishDiagnosticsClientCapabilities,
-    SemanticTokenModifier, SemanticTokenType, SemanticTokensClientCapabilities,
-    SemanticTokensClientCapabilitiesRequests, SemanticTokensFullOptions, SemanticTokensRangeResult,
-    SemanticTokensResult, SemanticTokensServerCapabilities,
-    SemanticTokensWorkspaceClientCapabilities, ServerCapabilities, SymbolKind,
-    TextDocumentClientCapabilities, TextEdit, TokenFormat, TypeDefinitionProviderCapability, Url,
-    WindowClientCapabilities, WorkspaceClientCapabilities, WorkspaceEdit,
+    DeclarationCapability, DiagnosticServerCapabilities, DocumentChangeOperation, DocumentChanges,
+    DocumentSymbol, DocumentSymbolClientCapabilities, DocumentSymbolResponse,
+    GotoDefinitionResponse, HoverContents, HoverProviderCapability,
+    ImplementationProviderCapability, Location, MarkedString, MarkupKind, OneOf, Position,
+    PublishDiagnosticsClientCapabilities, SemanticTokenModifier, SemanticTokenType,
+    SemanticTokensClientCapabilities, SemanticTokensClientCapabilitiesRequests,
+    SemanticTokensFullOptions, SemanticTokensRangeResult, SemanticTokensResult,
+    SemanticTokensServerCapabilities, SemanticTokensWorkspaceClientCapabilities,
+    ServerCapabilities, SymbolKind, TextDocumentClientCapabilities, TextEdit, TokenFormat,
+    TypeDefinitionProviderCapability, Url, WindowClientCapabilities, WorkspaceClientCapabilities,
+    WorkspaceEdit,
 };
 use tokio::sync::{Mutex as TokioMutex, mpsc as tokio_mpsc, oneshot};
 
@@ -4994,6 +4995,28 @@ fn signature_help_supported(cap: &Option<lsp_types::SignatureHelpOptions>) -> bo
     cap.is_some()
 }
 
+/// Whether the server answers `workspace/diagnostic`, the LSP 3.17 PULL of
+/// whole-project diagnostics (#533).
+///
+/// The inner `workspace_diagnostics` flag, NOT `Option::is_some`. A server
+/// that supports only per-document pulls still advertises
+/// `diagnosticProvider` with that flag `false`; reading the outer `Option`
+/// would send it a request it does not implement and get `-32601 Unhandled
+/// method` back, which is the exact shape that made croft call
+/// `textDocument/declaration` on vtsls.
+///
+/// Both capability variants carry the same options, so both are unwrapped
+/// rather than treating `RegistrationOptions` as an unconditional yes.
+fn workspace_diagnostics_supported(cap: &Option<DiagnosticServerCapabilities>) -> bool {
+    match cap {
+        Some(DiagnosticServerCapabilities::Options(o)) => o.workspace_diagnostics,
+        Some(DiagnosticServerCapabilities::RegistrationOptions(r)) => {
+            r.diagnostic_options.workspace_diagnostics
+        }
+        None => false,
+    }
+}
+
 /// Flatten an LSP `SignatureHelp` into the widget-facing [`SignatureInfo`]
 /// list, resolving each parameter label to a (start, end) char range within
 /// the signature label so the popup can bold the active parameter. The active
@@ -6253,6 +6276,46 @@ mod tests {
         assert!(one_of_supported(&on));
         assert!(one_of_supported(&opts));
         assert!(!one_of_supported(&None::<OneOf<bool, ()>>));
+    }
+
+    /// A server that pulls per-document but NOT per-workspace advertises
+    /// `diagnosticProvider` with `workspaceDiagnostics: false` (#533).
+    /// Reading the outer `Option` would send it a request it does not
+    /// implement; the inner flag is the only thing that separates them.
+    #[test]
+    fn workspace_diagnostics_reads_the_inner_flag_not_the_option() {
+        let opts = |workspace: bool| lsp_types::DiagnosticOptions {
+            identifier: None,
+            inter_file_dependencies: false,
+            workspace_diagnostics: workspace,
+            work_done_progress_options: Default::default(),
+        };
+
+        // The trap: present, but per-document only.
+        assert!(!workspace_diagnostics_supported(&Some(
+            DiagnosticServerCapabilities::Options(opts(false))
+        )));
+        // Paired positive, so the assertion above cannot pass by the
+        // predicate simply always saying no.
+        assert!(workspace_diagnostics_supported(&Some(
+            DiagnosticServerCapabilities::Options(opts(true))
+        )));
+
+        // The registration-options variant carries the same flag and must
+        // not read as an unconditional yes.
+        let reg = |workspace: bool| lsp_types::DiagnosticRegistrationOptions {
+            text_document_registration_options: Default::default(),
+            diagnostic_options: opts(workspace),
+            static_registration_options: Default::default(),
+        };
+        assert!(!workspace_diagnostics_supported(&Some(
+            DiagnosticServerCapabilities::RegistrationOptions(reg(false))
+        )));
+        assert!(workspace_diagnostics_supported(&Some(
+            DiagnosticServerCapabilities::RegistrationOptions(reg(true))
+        )));
+
+        assert!(!workspace_diagnostics_supported(&None));
     }
 
     #[test]

--- a/src/release_notes/0.1.934.md
+++ b/src/release_notes/0.1.934.md
@@ -1,0 +1,1 @@
+change: croft now notices which language servers can report problems for a whole project at once, and remembers what each one last told it, groundwork for pulling those problems without opening every file.


### PR DESCRIPTION
The two foundations of #533's pull path: detect which servers answer `workspace/diagnostic`, and cache the result ids that make the pull incremental.

**Part of #533, not a close.** The request itself, `workspace/diagnostic/refresh` handling and PROBLEMS integration remain. Both pieces here are pure and testable without a server, which is why they came first.

## 1. The capability is a trap

`workspace_diagnostics_supported` reads the **inner** `workspaceDiagnostics` flag, not the outer `Option`. A server that pulls per-document but not per-workspace still advertises `diagnosticProvider` — with that flag `false`.

This file already carries a comment recording the same mistake in the other direction: reading `declarationProvider` with `Option::is_some` treated `Some(false)` as supported, so croft called `textDocument/declaration` on vtsls and got `-32601 Unhandled method` back. Sending `workspace/diagnostic` to a document-only provider reproduces it exactly.

Both capability variants carry the same `DiagnosticOptions`, so both are unwrapped — the flag is a required `bool` there, with no `Option` and no default, so a server cannot omit it. Treating `RegistrationOptions` as an unconditional yes is the plausible partial fix, hence a case per variant, each with a paired positive.

The result is stored on `ManagedClient` beside `supports_signature_help`, so the pull can filter clients the way `request_semantic_tokens` filters on `semantic_supports_range`.

## 2. `None` means forget, not keep

A `Full` report carries `result_id: Option<String>`, and `None` is the server **declining** incrementality for that file. So `record(uri, None)` forgets it rather than leaving the previous id.

The spec is stronger than that reasoning: `UnchangedDocumentDiagnosticReport.result_id` is a **required** `String`, and a server may only reply `unchanged` when result ids are provided. So an id is the only thing that licenses an `Unchanged` reply — holding a stale one is exactly what enables a wrong one. The symptom would be diagnostics that never refresh, which reads as the language server being slow rather than as a bug.

Keyed by URI string rather than `PathBuf`, because that is what the server echoes back and round-tripping loses any non-file scheme. `clear()` exists for a server restart, where ids from the old process mean nothing.

## On dead code — a claim I made, retracted, and re-established

This description previously asserted that neither the unconsumed field nor the cache trips `dead_code`, "so the compiler will not catch this being incomplete". A review round said that was wrong — that both warn in a non-test build — and I added `#[allow(dead_code)]` for each.

Tested properly on **this crate** (attributes removed, count asserted at zero, source touched to force a real rebuild, `RUSTFLAGS=-D warnings`, no `--all-targets`): the build is **clean**. The `allow`s suppressed nothing, so they are gone.

The review's evidence was real but came from standalone `rustc` shapes. Here the field is written in a real constructor and the type is `pub` within a private module, which is not the same situation.

Two things nearly hid this, both worth naming because they are the shape this repo's docs warn about:

- The first verification finished in **3.78s** — a cache hit that never recompiled the mutated source, and it reported the opposite conclusion.
- Its restore check looked for three `allow(dead_code)` matches when only two were attributes; the third was a doc comment *mentioning* the attribute. The check reported success while measuring the wrong thing.

The gate script now runs a non-test `-D warnings` build as a standing check. It does not fire today, but it is a real check for a real class of problem.

## Verification

Build clean, non-test build clean under `-D warnings`, lints clean, 2 tests.

Three mutations killed:
- `cap.is_some()` — the documented `-32601` shape
- `RegistrationOptions => true` — unwrapping only one variant
- `record(uri, None)` as a no-op — the stale-id leak

## Note on the gates

This host killed three combined runs for memory (57–78 MB free), and the suite lock was legitimately held for stretches by `code-graph-rag` sessions in other repos. The gate script stages each phase separately for that reason.

Part of #533.
