### PR TITLE
feat(terminal): Copy and Paste on the pane's right-click menu (#540)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "croft-software"
-version = "0.1.935"
+version = "0.1.936"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "croft-software"
-version = "0.1.935"
+version = "0.1.936"
 edition = "2024"
 description = "VSCode-style TUI written in Rust"
 license = "MIT"

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -555,7 +555,7 @@ Disabling takes effect immediately for the viewers and Vim (a disabled PDF/CSV v
 | `Cmd+K` `]` | Give every collapsed pane its width back, restoring the even split in one gesture |
 | Click a rail row | While maximized: hand that terminal the maximized pane (the highlight marks the active one), so you can shuffle between full-size terminals |
 | Wheel over the rail | Scroll the rail when there are more terminals than it has rows; switching panes always scrolls the new one back into view |
-| Right-click a terminal pane | Open the pane menu: **Rename Terminal**, **Clear**, **Quick Select**, **Copy Mode**, **Command History**, **Open Scrollback in Editor**, **Reopen Closed Terminal** (while one is in its undo window), **Maximize Terminal** (or **Restore Terminal Split**), **Collapse Terminal** (or **Expand Terminal**), **Broadcast Input** (and, while broadcasting, **Exclude from Broadcast**) |
+| Right-click a terminal pane | Open the pane menu: **Copy** (while the pane has a selection), **Paste**, **Rename Terminal**, **Clear**, **Quick Select**, **Copy Mode**, **Command History**, **Open Scrollback in Editor**, **Reopen Closed Terminal** (while one is in its undo window), **Maximize Terminal** (or **Restore Terminal Split**), **Collapse Terminal** (or **Expand Terminal**), **Broadcast Input** (and, while broadcasting, **Exclude from Broadcast**) |
 
 Collapse and maximize are orthogonal and compose: entering maximize ignores the collapse flags rather than clearing them, and leaving it puts the strips back. Collapse is per-session and deliberately not saved with the pane layout, so a workspace never reopens with half its terminals folded away.
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1291,6 +1291,11 @@ enum MenuAction {
     /// Terminal pane right-click: collapse the pane at `idx` to a strip, or
     /// expand it again (#313).
     ToggleCollapseTerminal(usize),
+    /// Terminal pane right-click: copy the pane's selection to the clipboard.
+    /// Offered only while the pane HAS one, so the entry never copies nothing.
+    TerminalCopySelection,
+    /// Terminal pane right-click: paste the host clipboard into the pane.
+    TerminalPaste,
     /// Terminal pane right-click: enter quick-select hint mode on the pane.
     TerminalQuickSelect,
     /// Terminal pane right-click: enter copy mode (keyboard selection with
@@ -1411,6 +1416,8 @@ fn shortcut_for(action: &MenuAction) -> Option<&'static str> {
         // that chord really does toggle both ways. Advertising a shortcut
         // beside a label it cannot perform is worse than showing none.
         MenuAction::ToggleCollapseTerminal(_) => None,
+        MenuAction::TerminalCopySelection => Some("⌘C"),
+        MenuAction::TerminalPaste => Some("⌘V"),
         MenuAction::TerminalQuickSelect => Some("⌃⇧Space"),
         MenuAction::TerminalCopyMode => Some("⌃⇧Y"),
         MenuAction::TerminalCommandHistory => Some("⌃⇧H"),
@@ -29629,21 +29636,7 @@ impl App {
         // through to the shell unchanged, and Cmd+V — when not eaten by
         // the host terminal's menu shortcut — would do nothing useful.
         if is_clipboard_paste_key(key) {
-            match crate::clipboard::read_string() {
-                Some(text) if !text.is_empty() => {
-                    self.paste_terminal_input(text.as_bytes());
-                }
-                Some(_) => {
-                    self.status = String::from("Cmd+V: clipboard is empty");
-                }
-                None if self.drop_relay_active() => {
-                    self.request_remote_clipboard();
-                }
-                None => {
-                    self.status =
-                        String::from("Cmd+V: clipboard read failed (no pbpaste / NSPasteboard)");
-                }
-            }
+            self.paste_clipboard_into_terminal();
             return;
         }
         // Any other keystroke clears the selection so the user's input is
@@ -29694,6 +29687,32 @@ impl App {
         }
         copy_to_clipboard(&text);
         self.status = format!("Copied {} chars to clipboard", text.chars().count());
+    }
+
+    /// Paste the host clipboard into the terminal: the chord (Cmd+V /
+    /// Ctrl+V / Ctrl+Shift+V) and the pane menu's "Paste" both land here, so
+    /// bracketed paste, broadcast fan-out and the remote-clipboard fallback
+    /// behave identically whichever one the user reached for.
+    ///
+    /// The messages name the ACTION rather than the chord: the menu route has
+    /// no Cmd+V in it, and a status line quoting a key the user never pressed
+    /// reads as a bug report about the wrong thing.
+    fn paste_clipboard_into_terminal(&mut self) {
+        match crate::clipboard::read_string() {
+            Some(text) if !text.is_empty() => {
+                self.paste_terminal_input(text.as_bytes());
+            }
+            Some(_) => {
+                self.status = String::from("Paste: clipboard is empty");
+            }
+            None if self.drop_relay_active() => {
+                self.request_remote_clipboard();
+            }
+            None => {
+                self.status =
+                    String::from("Paste: clipboard read failed (no pbpaste / NSPasteboard)");
+            }
+        }
     }
 
     /// Start a mouse selection over a rendered ANSI log (#257).
@@ -38185,16 +38204,38 @@ impl App {
                     // Each of them is also a gesture on a grid the user
                     // cannot see while the pane is a strip.
                     let folded = self.terminals.get(idx).is_some_and(|t| t.collapsed);
-                    let mut items = vec![
-                        MenuEntry::Item {
-                            label: String::from("Rename Terminal"),
-                            action: MenuAction::RenameTerminal(idx),
-                        },
-                        MenuEntry::Item {
-                            label: String::from("Clear"),
-                            action: MenuAction::ClearTerminal(idx),
-                        },
-                    ];
+                    let mut items: Vec<MenuEntry> = Vec::new();
+                    // Copy and Paste lead the menu, as they do in VS Code's
+                    // terminal. Both act on the ACTIVE pane, so a folded one
+                    // offers neither: focus has already walked to an expanded
+                    // neighbour, and pasting into a grid the user cannot see
+                    // is worse than not offering the entry at all.
+                    if !folded {
+                        // Copy appears only while there is something to copy.
+                        // The menu model has no disabled state, and an entry
+                        // that silently copies nothing is worse than no entry.
+                        if self.terminals[idx]
+                            .selection()
+                            .is_some_and(|s| s.has_area())
+                        {
+                            items.push(MenuEntry::Item {
+                                label: String::from("Copy"),
+                                action: MenuAction::TerminalCopySelection,
+                            });
+                        }
+                        items.push(MenuEntry::Item {
+                            label: String::from("Paste"),
+                            action: MenuAction::TerminalPaste,
+                        });
+                    }
+                    items.push(MenuEntry::Item {
+                        label: String::from("Rename Terminal"),
+                        action: MenuAction::RenameTerminal(idx),
+                    });
+                    items.push(MenuEntry::Item {
+                        label: String::from("Clear"),
+                        action: MenuAction::ClearTerminal(idx),
+                    });
                     if !folded {
                         items.extend([
                             MenuEntry::Item {
@@ -42496,6 +42537,8 @@ impl App {
             MenuAction::ToggleZenMode => self.toggle_zen_mode(),
             MenuAction::RenameTerminal(idx) => self.begin_rename_terminal(idx),
             MenuAction::ClearTerminal(idx) => self.clear_terminal_at(idx),
+            MenuAction::TerminalCopySelection => self.copy_terminal_selection(),
+            MenuAction::TerminalPaste => self.paste_clipboard_into_terminal(),
             MenuAction::TerminalQuickSelect => self.open_terminal_quick_select(),
             MenuAction::TerminalCopyMode => self.open_terminal_copy_mode(),
             MenuAction::TerminalCommandHistory => self.open_command_history(),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -44229,6 +44229,8 @@ fn a_folded_strips_menu_offers_nothing_that_acts_on_the_active_pane() {
     };
     let folded = labels(&app);
     for entry in [
+        "Copy",
+        "Paste",
         "Quick Select",
         "Copy Mode",
         "Command History",
@@ -44259,6 +44261,7 @@ fn a_folded_strips_menu_offers_nothing_that_acts_on_the_active_pane() {
     ));
     let expanded = labels(&app);
     for entry in [
+        "Paste",
         "Quick Select",
         "Copy Mode",
         "Command History",
@@ -44269,6 +44272,105 @@ fn a_folded_strips_menu_offers_nothing_that_acts_on_the_active_pane() {
             "{entry:?} belongs on an expanded pane's menu: {expanded:?}"
         );
     }
+}
+
+/// #540: the terminal pane menu carried every terminal gesture except the
+/// two a right-click is most often reached for. Copy is offered only while
+/// the pane has a selection - the menu model has no disabled state, so an
+/// entry that would copy nothing is worse than no entry - and both entries
+/// go through the same routes the Cmd+C / Cmd+V chords already use.
+#[test]
+fn the_pane_menu_copies_a_selection_and_pastes_the_clipboard() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut app = App::new(tmp.path().to_path_buf()).unwrap();
+    // A silent child: the grid then holds exactly what the test feeds it,
+    // with no shell prompt racing the selection coordinates.
+    app.terminals[0] = crate::widgets::terminal::PtyTerminal::new_running(
+        "/bin/sh",
+        &[String::from("-c"), String::from("sleep 60")],
+        tmp.path(),
+    )
+    .unwrap();
+    app.show_terminal = true;
+    app.focus_pane(Pane::Terminal);
+    let mut term = ratatui::Terminal::new(ratatui::backend::TestBackend::new(160, 30)).unwrap();
+    term.draw(|f| app.render(f)).unwrap();
+    let area = app.terminals[0].last_area;
+    let inner = app.terminals[0].last_inner;
+    let labels = |app: &App| -> Vec<String> {
+        menu_labels(
+            &app.context_menu
+                .as_ref()
+                .expect("a right-click opens the pane menu")
+                .items,
+        )
+        .iter()
+        .map(|l| l.to_string())
+        .collect()
+    };
+
+    // Nothing selected: Paste is offered, Copy is not.
+    app.handle_mouse(mouse(
+        MouseEventKind::Down(MouseButton::Right),
+        area.x + 1,
+        area.y + 1,
+    ));
+    let empty = labels(&app);
+    assert!(
+        empty.iter().any(|l| l == "Paste"),
+        "Paste needs no selection: {empty:?}"
+    );
+    assert!(
+        !empty.iter().any(|l| l == "Copy"),
+        "Copy must not be offered while there is nothing to copy: {empty:?}"
+    );
+    app.context_menu = None;
+
+    // With a selection, Copy joins the menu and reaches the clipboard. The
+    // row is located in the grid rather than assumed: the pane paints a
+    // launch banner of its own above whatever the child prints.
+    app.terminals[0].feed_bytes_for_test(b"copy-me-540\r\n");
+    let (lines, top) = app.terminals[0].grid_lines();
+    let vrow = (top
+        + lines
+            .iter()
+            .position(|l| l.starts_with("copy-me-540"))
+            .expect("the fed text must reach the grid") as i32) as u16;
+    app.terminals[0].start_selection_at(inner.x, inner.y + vrow);
+    app.terminals[0].extend_selection_to(inner.x + 20, inner.y + vrow);
+    let expected = app.terminals[0].selection_text();
+    assert!(
+        expected.contains("copy-me-540"),
+        "precondition: the selection covers the fed text, got {expected:?}"
+    );
+    app.handle_mouse(mouse(
+        MouseEventKind::Down(MouseButton::Right),
+        area.x + 1,
+        area.y + 1,
+    ));
+    let selected = labels(&app);
+    assert!(
+        selected.iter().any(|l| l == "Copy"),
+        "Copy belongs on a pane that has a selection: {selected:?}"
+    );
+    app.context_menu = None;
+    app.dispatch_menu_action(MenuAction::TerminalCopySelection, tmp.path().to_path_buf());
+    assert_eq!(
+        crate::clipboard::read_string().as_deref(),
+        Some(expected.as_str()),
+        "the menu's Copy must put the selection on the clipboard"
+    );
+
+    // And Paste sends the clipboard on to the pane's child.
+    let before = app.terminals[0].written_bytes_for_test().len();
+    assert!(crate::clipboard::write_string("pasted-540"));
+    app.dispatch_menu_action(MenuAction::TerminalPaste, tmp.path().to_path_buf());
+    let written = app.terminals[0].written_bytes_for_test();
+    let sent = String::from_utf8_lossy(&written[before..]).to_string();
+    assert!(
+        sent.contains("pasted-540"),
+        "the menu's Paste must reach the shell, sent {sent:?}"
+    );
 }
 
 #[test]

--- a/src/release_notes/0.1.936.md
+++ b/src/release_notes/0.1.936.md
@@ -1,0 +1,1 @@
+feature: the terminal pane's right-click menu now leads with Copy and Paste. Copy appears while the pane has a selection and puts it on the system clipboard; Paste sends the clipboard to the shell, bracketed-paste aware and mirrored to every pane while broadcast input is on.


### PR DESCRIPTION
Closes #540.

The terminal pane's right-click menu carried every terminal gesture except the two a right-click is most often reached for. It now leads with **Copy** and **Paste**, the way VS Code's terminal menu does.

## Behaviour

* **Copy** appears only while the pane HAS a selection. The menu model has no disabled state, and an entry that silently copies nothing is worse than no entry. It runs the same `copy_terminal_selection` the Cmd+C / Ctrl+Shift+C chord runs, so secret redaction (`terminal_text_for_copy`) still applies and the selection stays highlighted afterwards.
* **Paste** is always offered on an expanded pane. Both it and the Cmd+V / Ctrl+V / Ctrl+Shift+V chord now go through one new `paste_clipboard_into_terminal`, so bracketed paste, the broadcast-input fan-out and the remote-clipboard fallback behave identically whichever route the user took.
* A **folded** pane offers neither, for the reason the neighbouring entries are already withheld there (#313): both act on the active pane, focus has already walked off the strip to an expanded neighbour, and pasting into a grid the user cannot see is worse than not offering it.
* The two status messages moved from `Cmd+V: …` to `Paste: …`. The menu route has no Cmd+V in it, and a status line quoting a key the user never pressed reads as a bug report about the wrong thing.

The existing pane menu is kept rather than replaced: this is VS Code's `terminal.integrated.rightClickBehavior: "default"`, not the `copyPaste` variant, so no gesture that worked before changes.

## Tests

`the_pane_menu_copies_a_selection_and_pastes_the_clipboard` drives the real gesture: right-click the pane with nothing selected (Paste present, Copy absent), select fed text and right-click again (Copy present), then dispatch each entry and assert the clipboard holds the selection and the pane's child received the pasted bytes. The folded-strip test grows two more entries it must not offer.

Proven non-vacuous by re-breaking, twice, each on a restored tree:

* menu entries removed → `Paste needs no selection: ["Rename Terminal", "Clear", "Quick Select", "Copy Mode", "Command History", "Open Scrollback in Editor"]`
* entries kept, dispatch arms made no-ops → `assertion left == right failed: the menu's Copy must put the selection on the clipboard`
* restored file byte-identical (sha256), test green again.

## Gate

`cargo fmt --check` 0, `cargo clippy --all-targets --all-features -D warnings` 0, `cargo test` 4349 passed / 0 failed (+17 in the second binary).

Docs: `docs/KEYBINDINGS.md` pane-menu row. Version 0.1.935 → 0.1.936 with `src/release_notes/0.1.936.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added **Copy** and **Paste** options to the terminal pane’s right-click context menu.
  - **Copy** appears when text is selected and copies it to the system clipboard.
  - **Paste** sends clipboard content to the terminal, including support for bracketed paste and broadcast input across panes.
  - Added ⌘C and ⌘V shortcut labels to the context menu.

- **Documentation**
  - Updated keybindings documentation to describe the new terminal context-menu actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->