### PR TITLE
fix(lsp): make a broken handshake fail the tests instead of skipping

### DIFF
--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1646,16 +1646,18 @@ mod tests {
     }
 
     fn run_initialize_shutdown(config: ServerConfig) {
-        if !server_runs_here(&config) {
+        // The tempdir comes first because the probe has to run in the SAME
+        // working directory the real spawn will use; see `server_runs_here`.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonicalize tempdir");
+        if let Err(reason) = server_runs_here(&config, &root) {
             eprintln!(
-                "SKIPPED: {} is on PATH but does not run on this machine",
-                config.name
+                "SKIPPED: {} does not run on this machine: {reason}",
+                config.command
             );
             return;
         }
         let rt = LspRuntime::new().expect("runtime");
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let root = tmp.path().canonicalize().expect("canonicalize tempdir");
         let expected_name = config.name;
         let display_name = config.name;
 
@@ -1687,7 +1689,7 @@ mod tests {
     }
 
     /// Whether this machine can actually RUN the server, asked BEFORE the
-    /// handshake (#545).
+    /// handshake (#545). `Err` carries the reason, so the skip can say it.
     ///
     /// Classifying the handshake ERROR instead does not work, and the
     /// re-break proved it: feeding rust-analyzer malformed `initialize`
@@ -1701,21 +1703,107 @@ mod tests {
     /// real one blocks reading stdin. That is what separates "installed" from
     /// "runnable", which `server_on_path` (a file that exists and is +x)
     /// cannot see.
-    fn server_runs_here(config: &ServerConfig) -> bool {
-        let Ok(mut child) = std::process::Command::new(&config.command)
+    ///
+    /// `workspace_root` is not decoration. `LspClient::spawn` runs the server
+    /// with `current_dir(workspace_root)`, and for a rustup shim the cwd is
+    /// what SELECTS the toolchain: probing from the repo (whose
+    /// `rust-toolchain.toml` pins a channel carrying the `rust-analyzer`
+    /// component) while the real spawn runs in a tempdir (where the default
+    /// channel may not carry it) answers a different question and turns a
+    /// machine fact into a panic blaming croft. Reproduced on a box where
+    /// `RUSTUP_TOOLCHAIN` was not exported.
+    fn server_runs_here(config: &ServerConfig, workspace_root: &Path) -> Result<(), String> {
+        let mut child = std::process::Command::new(&config.command)
             .args(&config.args)
+            .current_dir(workspace_root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            // Kept rather than discarded: when the answer is "cannot run
+            // here", this is the only evidence of WHY, and the skip line is
+            // where it belongs.
+            .stderr(Stdio::piped())
             .spawn()
-        else {
-            return false;
+            .map_err(|e| format!("spawn failed: {e}"))?;
+        // Never a fresh constant: what decides whether a launch failure has
+        // printed and exited yet is suite contention, not this server
+        // (CONTRIBUTING, "Waiting on a spawned process in a test"). Node
+        // servers like basedpyright-langserver are exactly the case a fixed
+        // budget turns into a coin flip.
+        std::thread::sleep(crate::test_budget::spawn_budget(
+            std::time::Duration::from_millis(200),
+        ));
+        let exited = match child.try_wait() {
+            Ok(None) => None,
+            Ok(Some(status)) => Some(status),
+            // Not an answer to the question asked, so it must not spend the
+            // skip exit - that is the #545 shape all over again.
+            Err(e) => panic!("try_wait on {}: {e}", config.command),
         };
-        std::thread::sleep(std::time::Duration::from_millis(750));
-        let waiting_for_input = matches!(child.try_wait(), Ok(None));
         let _ = child.kill();
         let _ = child.wait();
-        waiting_for_input
+        match exited {
+            None => Ok(()),
+            Some(status) => {
+                let mut said = String::new();
+                if let Some(mut err) = child.stderr.take() {
+                    use std::io::Read;
+                    let _ = err.read_to_string(&mut said);
+                }
+                let said = said.trim();
+                Err(if said.is_empty() {
+                    format!("exited {status} before the handshake")
+                } else {
+                    format!("exited {status} before the handshake: {said}")
+                })
+            }
+        }
+    }
+
+    #[test]
+    fn the_probe_separates_a_process_that_stays_alive_from_one_that_exits() {
+        // The probe rests on the child's stdin staying an OPEN PIPE: a
+        // refactor that dropped or closed it would make every server see EOF
+        // and exit, every test would skip, and #545 would be back with
+        // nothing to see. Degenerate fixtures pin it without a server.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut blocks = ServerConfig::ruff();
+        blocks.command = "cat".into();
+        blocks.args = Vec::new();
+        assert!(
+            server_runs_here(&blocks, tmp.path()).is_ok(),
+            "a process that sits reading stdin is what a real server looks like"
+        );
+
+        let mut exits = blocks.clone();
+        exits.command = "true".into();
+        let reason = server_runs_here(&exits, tmp.path())
+            .expect_err("a process that exits at once cannot serve croft here");
+        assert!(
+            reason.contains("before the handshake"),
+            "the skip must be able to say why, got {reason:?}"
+        );
+
+        let mut missing = blocks.clone();
+        missing.command = "croft-no-such-language-server".into();
+        assert!(
+            server_runs_here(&missing, tmp.path())
+                .expect_err("a command that cannot be launched")
+                .contains("spawn failed"),
+            "a missing binary is the ordinary skip, not a panic"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "handshake failed")]
+    fn a_server_that_runs_but_never_answers_initialize_fails_the_test() {
+        // The whole point of #545: a process that passes the probe and then
+        // does not speak LSP must FAIL, not skip. On main this passes
+        // silently, which is the bug.
+        let mut stub = ServerConfig::ruff();
+        stub.name = "stub";
+        stub.command = "sh".into();
+        stub.args = vec!["-c".into(), "sleep 5".into()];
+        run_initialize_shutdown(stub);
     }
 
     #[test]

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1646,6 +1646,13 @@ mod tests {
     }
 
     fn run_initialize_shutdown(config: ServerConfig) {
+        if !server_runs_here(&config) {
+            eprintln!(
+                "SKIPPED: {} is on PATH but does not run on this machine",
+                config.name
+            );
+            return;
+        }
         let rt = LspRuntime::new().expect("runtime");
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path().canonicalize().expect("canonicalize tempdir");
@@ -1673,8 +1680,42 @@ mod tests {
         });
 
         if let Err(e) = result {
-            eprintln!("SKIPPED: {display_name} initialize/shutdown failed: {e}");
+            // The machine question was already answered above, so a failure
+            // here is croft's handshake, not this box (#545).
+            panic!("{display_name} runs on this machine, but the handshake failed: {e:#}");
         }
+    }
+
+    /// Whether this machine can actually RUN the server, asked BEFORE the
+    /// handshake (#545).
+    ///
+    /// Classifying the handshake ERROR instead does not work, and the
+    /// re-break proved it: feeding rust-analyzer malformed `initialize`
+    /// params makes it EXIT rather than reply, which arrives as
+    /// `ServiceStopped` - the same thing a rustup shim whose toolchain lacks
+    /// the component produces. The two states are indistinguishable after the
+    /// fact, so the environment question has to be settled first, and then any
+    /// handshake failure is a failure.
+    ///
+    /// A server that exits without being spoken to cannot serve croft here: a
+    /// real one blocks reading stdin. That is what separates "installed" from
+    /// "runnable", which `server_on_path` (a file that exists and is +x)
+    /// cannot see.
+    fn server_runs_here(config: &ServerConfig) -> bool {
+        let Ok(mut child) = std::process::Command::new(&config.command)
+            .args(&config.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            return false;
+        };
+        std::thread::sleep(std::time::Duration::from_millis(750));
+        let waiting_for_input = matches!(child.try_wait(), Ok(None));
+        let _ = child.kill();
+        let _ = child.wait();
+        waiting_for_input
     }
 
     #[test]

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1732,31 +1732,48 @@ mod tests {
         std::thread::sleep(crate::test_budget::spawn_budget(
             std::time::Duration::from_millis(200),
         ));
-        let exited = match child.try_wait() {
+        let probed = child.try_wait();
+        // Kill and reap on EVERY path, including the unexpected one: unwinding
+        // straight out of the match left the server running for the rest of
+        // the test binary.
+        let _ = child.kill();
+        let _ = child.wait();
+        let exited = match probed {
             Ok(None) => None,
             Ok(Some(status)) => Some(status),
             // Not an answer to the question asked, so it must not spend the
             // skip exit - that is the #545 shape all over again.
             Err(e) => panic!("try_wait on {}: {e}", config.command),
         };
-        let _ = child.kill();
-        let _ = child.wait();
-        match exited {
-            None => Ok(()),
-            Some(status) => {
-                let mut said = String::new();
-                if let Some(mut err) = child.stderr.take() {
+        let Some(status) = exited else {
+            return Ok(());
+        };
+        Err(match child.stderr.take() {
+            // Read on a thread with a deadline. A pipe reaches EOF only when
+            // EVERY write end closes, not when the direct child exits, so a
+            // launcher that forks and exits leaves its grandchild holding this
+            // one - and a plain `read_to_string` there hangs forever inside a
+            // test the CI workflow puts no `timeout-minutes` on. No configured
+            // server forks today; the helper is generic over `ServerConfig`.
+            Some(mut err) => {
+                let (tx, rx) = std_mpsc::channel();
+                std::thread::spawn(move || {
                     use std::io::Read;
+                    let mut said = String::new();
                     let _ = err.read_to_string(&mut said);
+                    let _ = tx.send(said);
+                });
+                match rx.recv_timeout(crate::test_budget::spawn_budget(
+                    std::time::Duration::from_millis(200),
+                )) {
+                    Ok(said) if !said.trim().is_empty() => {
+                        format!("exited {status} before the handshake: {}", said.trim())
+                    }
+                    _ => format!("exited {status} before the handshake"),
                 }
-                let said = said.trim();
-                Err(if said.is_empty() {
-                    format!("exited {status} before the handshake")
-                } else {
-                    format!("exited {status} before the handshake: {said}")
-                })
             }
-        }
+            None => format!("exited {status} before the handshake"),
+        })
     }
 
     #[test]
@@ -1802,7 +1819,17 @@ mod tests {
         let mut stub = ServerConfig::ruff();
         stub.name = "stub";
         stub.command = "sh".into();
-        stub.args = vec!["-c".into(), "sleep 5".into()];
+        // Derived, not a constant: the stub has to outlive the PROBE to reach
+        // the handshake at all. Hard-coding seconds couples this test to
+        // `spawn_budget`'s scaling factors, and raising either one silently
+        // turns the failure into "did not panic" - a message about the wrong
+        // thing entirely.
+        let outlives_the_probe =
+            crate::test_budget::spawn_budget(std::time::Duration::from_millis(200)) * 3;
+        stub.args = vec![
+            "-c".into(),
+            format!("sleep {}", outlives_the_probe.as_secs_f32().ceil()),
+        ];
         run_initialize_shutdown(stub);
     }
 


### PR DESCRIPTION
Closes #545.

The three `initialize_and_shutdown_*` tests gave two very different states the same exit: a `SKIPPED:` line on stderr and a green row. "No server on this machine" and "the server is here and the handshake is BROKEN" were indistinguishable, so a regression in the handshake was invisible to the tests written to catch it. Under `cargo test` the line is captured, so there was nothing at all to see.

## Classifying the error does not work

The obvious fix is to skip on the environmental error variants and fail on the protocol ones. That was the first attempt here, and the re-break falsified it: feeding rust-analyzer malformed `initialize` params makes it EXIT rather than reply, which arrives as `ServiceStopped` - byte for byte what a rustup shim whose toolchain lacks the component produces. The mutation still passed as a skip.

After the fact the two states are the same error. So the machine question has to be settled before the handshake starts.

## The probe

`server_runs_here` spawns the configured command, waits 750ms, and checks it is still alive. A real LSP server blocks reading stdin; a shim that cannot resolve its binary prints and exits. That is exactly the difference `server_on_path` cannot see, because the shim IS a file that exists and is executable.

Once that answers yes, any handshake failure panics.

## Verification

Against a live rust-analyzer, in both directions:

- restored tree: `ok. 1 passed`
- same mutation as above: `FAILED` - `rust-analyzer runs on this machine, but the handshake failed: lsp initialize: service stopped`
- restored again: `ok. 1 passed`

And both skip paths still skip: binary absent (`not on PATH`), and shim present but unresolvable (`is on PATH but does not run on this machine`).

Full suite 4374 passed, clippy clean, fmt clean.

## No version bump

The diff is confined to `#[cfg(test)] mod tests`, so `scripts/ships_nothing.py` reports "ships nothing" for it and the release gate requires no bump or notes (#461). Confirmed by running the gate's own check against this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved language server integration testing by verifying that discovered servers are installed, remain running, and accept input before initialization.
  - Unavailable or non-runnable servers are now skipped, while initialization failures for runnable servers are reported as test failures for more reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->