### PR TITLE
ci: make the dependency install prove it worked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,27 @@ jobs:
         # prompt from wedging every spawned zsh before its first prompt
         # (croft never calls compinit; the runner's own zsh startup does).
         run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh poppler-utils
+          set -euo pipefail
+          # `apt-get update && apt-get install` looked equivalent and was not
+          # (#549). A command on the LEFT of an `&&` is exempt from `set -e`
+          # by design, so when `update` failed on a THIRD-PARTY index the
+          # runner image ships and croft does not need (a Chrome repo hash
+          # mismatch), the install was skipped, this step still went green,
+          # and eight PDF tests failed minutes later with "these tests need a
+          # PDF rasteriser" on a PR that touches no PDF code.
+          #
+          # A partial index failure must not decide whether the install runs:
+          # apt resolves these two packages from the indexes it did fetch.
+          sudo apt-get update \
+            || echo "::warning::apt-get update reported errors; installing from the indexes it has"
+          sudo apt-get install -y --no-install-recommends zsh poppler-utils
+          # Without this the step can only report that it RAN, not that it
+          # worked, and those are the same colour. The suite's own skip
+          # message names pdftoppm, so name it here too.
+          for tool in pdftoppm zsh; do
+            command -v "$tool" >/dev/null \
+              || { echo "::error::$tool is missing after the install step"; exit 1; }
+          done
           for d in /usr/share/zsh /usr/local/share/zsh; do
             if [ -d "$d" ]; then sudo chmod -R go-w "$d"; fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,16 +218,30 @@ jobs:
           #
           # A partial index failure must not decide whether the install runs:
           # apt resolves these two packages from the indexes it did fetch.
-          sudo apt-get update \
-            || echo "::warning::apt-get update reported errors; installing from the indexes it has"
+          # A transient mirror hiccup is what set #549 off in the first
+          # place, and the install below is what actually gates the step, so
+          # retry before giving up on the index refresh.
+          for attempt in 1 2 3; do
+            sudo apt-get update && break
+            echo "::warning::apt-get update failed (attempt $attempt)"
+            sleep 5
+          done
           sudo apt-get install -y --no-install-recommends zsh poppler-utils
           # Without this the step can only report that it RAN, not that it
-          # worked, and those are the same colour. The suite's own skip
-          # message names pdftoppm, so name it here too.
-          for tool in pdftoppm zsh; do
-            command -v "$tool" >/dev/null \
-              || { echo "::error::$tool is missing after the install step"; exit 1; }
-          done
+          # worked, and those are the same colour.
+          #
+          # Each tool is probed the way ITS CONSUMER resolves it, which is not
+          # the same question for the two of them. `pdf::which` walks PATH, so
+          # `command -v` is right (and stricter: it also wants the executable
+          # bit). The terminal tests take `/bin/zsh` by literal path and SKIP
+          # when it is missing, so a zsh present only elsewhere on PATH would
+          # pass a `command -v` probe and leave those tests silently
+          # uncovered - the same false green this step exists to remove, moved
+          # one level up. It holds today only because usrmerge symlinks /bin.
+          command -v pdftoppm >/dev/null \
+            || { echo "::error::pdftoppm is missing after the install step"; exit 1; }
+          [ -x /bin/zsh ] \
+            || { echo "::error::/bin/zsh is missing after the install step"; exit 1; }
           for d in /usr/share/zsh /usr/local/share/zsh; do
             if [ -d "$d" ]; then sudo chmod -R go-w "$d"; fi
           done


### PR DESCRIPTION
Closes #549.

The `Install suite runtime dependencies` step could pass while installing nothing. On PR #547 — a debug-picker change touching no PDF code — `apt-get update` hit a hash mismatch on a Chrome repo the runner image ships and croft does not need, and eight tests then failed with `these tests need a PDF rasteriser`.

## The cause is a bash rule, not apt

A command on the LEFT of an `&&` list is exempt from `set -e` by design. So `apt-get update && apt-get install …` skipped the install when update failed, the script continued to the chmod loop, and the step ended on a success.

Demonstrated rather than asserted, with a control in the same run:

| Command | Exit |
|---|---|
| `bash -e -c 'false && echo ran; for d in /tmp; do :; done'` | **0** — this step's shape: green, nothing installed |
| `bash -e -c 'false; echo unreachable'` | 1 — control: the same failure DOES trip `set -e` outside an `&&` |
| the new script with a missing tool | 1, naming the tool |

## Two changes

A partial index failure no longer decides whether the install runs — apt resolves both packages from the indexes it did fetch, and a genuinely failed *install* still fails the step. And the step asserts `pdftoppm` and `zsh` exist afterwards, because without that it can only report that it RAN, not that it worked, and those are the same colour.

This is self-testing: `pull_request` runs the workflow from the merge commit, so if the new script is wrong, this PR's own job fails.

## Scope

No version bump — the release gate's shipped-file filter covers `src/`, `assets/`, `build.rs` and the manifests, and this touches only the workflow.

#548 is a separate, genuine flake in the same area (two `src/pdf.rs` tests racing a deadline). This one is not that: here the rasteriser was absent, not slow.