### PR TITLE
ci: fail the artifact-kind check for a target it cannot assert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,12 +101,18 @@ jobs:
         # this catches: `file` names the architecture, so a mismatch here is
         # a wrong artifact rather than a missing one.
         run: |
+          set -euo pipefail
           bin="target/${{ matrix.target }}/release/croft"
           test -x "$bin"
           file "$bin"
           case "${{ matrix.target }}" in
             *-linux-musl) file "$bin" | grep -q 'ELF 64-bit LSB' ;;
             *-apple-darwin) file "$bin" | grep -q 'Mach-O 64-bit' ;;
+            # A `case` with no match exits 0, so without this arm the whole
+            # assertion becomes a silent no-op for any target the list does
+            # not name - green step, unchecked artifact, confident comment
+            # above it (#551). Adding a target now has to add its assertion.
+            *) echo "::error::no artifact-kind assertion for ${{ matrix.target }}"; exit 1 ;;
           esac
 
       - name: Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,20 +98,27 @@ jobs:
 
       - name: The artifact must exist and be the right kind of binary
         # A cross build that silently produced a host binary is the failure
-        # this catches: `file` names the architecture, so a mismatch here is
-        # a wrong artifact rather than a missing one.
+        # this catches, and catching it means reading the ARCHITECTURE `file`
+        # names, not only the container format. Matching `ELF 64-bit LSB` on
+        # both musl legs let an x86-64 binary pass as aarch64 - the comment
+        # claimed an assertion the check did not make, which is the same
+        # false green as the missing arm below (#551).
         run: |
           set -euo pipefail
           bin="target/${{ matrix.target }}/release/croft"
-          test -x "$bin"
+          test -x "$bin" || { echo "::error::no artifact at $bin"; exit 1; }
           file "$bin"
+          # Exact triples, not suffixes: a typo in a matrix target then reaches
+          # the catch-all rather than silently matching `*-linux-musl`.
           case "${{ matrix.target }}" in
-            *-linux-musl) file "$bin" | grep -q 'ELF 64-bit LSB' ;;
-            *-apple-darwin) file "$bin" | grep -q 'Mach-O 64-bit' ;;
+            x86_64-unknown-linux-musl)  file "$bin" | grep -qE 'ELF 64-bit LSB.*x86-64' ;;
+            aarch64-unknown-linux-musl) file "$bin" | grep -qE 'ELF 64-bit LSB.*aarch64' ;;
+            x86_64-apple-darwin)        file "$bin" | grep -qE 'Mach-O 64-bit.*x86_64' ;;
+            aarch64-apple-darwin)       file "$bin" | grep -qE 'Mach-O 64-bit.*arm64' ;;
             # A `case` with no match exits 0, so without this arm the whole
             # assertion becomes a silent no-op for any target the list does
-            # not name - green step, unchecked artifact, confident comment
-            # above it (#551). Adding a target now has to add its assertion.
+            # not name - green step, unchecked artifact (#551). Adding a
+            # target now has to add its assertion.
             *) echo "::error::no artifact-kind assertion for ${{ matrix.target }}"; exit 1 ;;
           esac
 

--- a/scripts/check_binstall_contract.py
+++ b/scripts/check_binstall_contract.py
@@ -43,6 +43,26 @@ EXPECTED_TARGETS = {
 }
 
 
+def matrix_targets(text: str) -> set:
+    """The triples the build matrix actually names.
+
+    Searching the whole file for each triple answers a different question:
+    whether the NAME appears anywhere. It appears in the artifact-kind
+    assertion's case arms, and it would appear in a comment, so a target
+    dropped from the matrix left this check green while no release carried it
+    (#554). The matrix block is the corpus; a mention outside it is not a
+    build.
+    """
+    block = re.search(
+        r"^\s*matrix:\s*$(.*?)(?=^\s{0,6}\S)",
+        text,
+        re.M | re.S,
+    )
+    if not block:
+        fail("no build matrix in release.yml")
+    return set(re.findall(r"^\s*-\s*target:\s*(\S+)\s*$", block.group(1), re.M))
+
+
 def fail(msg: str) -> None:
     print(f"binstall contract: {msg}", file=sys.stderr)
     sys.exit(1)
@@ -161,7 +181,8 @@ def main() -> None:
         fail("release.yml does not trigger on v* tags, but pkg-url assumes it")
 
     # 5. Every expected target is actually built.
-    missing = sorted(t for t in EXPECTED_TARGETS if t not in workflow)
+    built = matrix_targets(workflow)
+    missing = sorted(EXPECTED_TARGETS - built)
     if missing:
         fail("release.yml does not build " + ", ".join(missing))
 

--- a/scripts/tests/test_binstall_contract.py
+++ b/scripts/tests/test_binstall_contract.py
@@ -98,6 +98,40 @@ class BinstallContract(unittest.TestCase):
         self.assertEqual(r.returncode, 1)
         self.assertIn("aarch64-apple-darwin", r.stderr)
 
+    def test_a_dropped_target_is_caught_even_when_its_name_survives(self):
+        """The trap this check fell into (#554).
+
+        The artifact-kind assertion names every triple in a `case` arm, so a
+        target dropped from the MATRIX still appears in the file. Substring
+        searching the whole workflow then reports agreement while no release
+        carries that platform - a check that cannot fail, in the checker
+        written to stop exactly that.
+        """
+        tree = self.build_tree(
+            workflow_sub=("          - target: aarch64-apple-darwin\n", "")
+        )
+        workflow = tree / ".github" / "workflows" / "release.yml"
+        text = workflow.read_text()
+        # The name survives elsewhere, exactly as the real workflow has it.
+        self.assertNotIn("- target: aarch64-apple-darwin", text)
+        workflow.write_text(
+            text.replace(
+                "      - name: Package",
+                "      - name: Assert\n"
+                "        run: |\n"
+                "          case \"$T\" in\n"
+                "            aarch64-apple-darwin) echo mach-o ;;\n"
+                "          esac\n"
+                "      - name: Package",
+                1,
+            )
+        )
+        self.assertIn("aarch64-apple-darwin", workflow.read_text())
+
+        r = self.run_checker(tree)
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("aarch64-apple-darwin", r.stderr)
+
     def test_losing_the_tag_trigger_is_caught(self):
         """pkg-url hard-codes the v-prefixed tag; without the trigger no
         release is ever produced at that URL."""


### PR DESCRIPTION
Closes #551.

The `case` that verifies a release artifact is the right kind of binary has no `*)` arm, and a `case` with no matching branch exits 0. So for any target outside the four in today's matrix, the assertion is a silent no-op — green step, unchecked artifact, and a comment above it still claiming it catches "a cross build that silently produced a host binary".

Not broken today. Guaranteed to break silently the day a fifth target is added, which is exactly when nobody is looking at this line.

## Verified, all three paths

| Case | Result |
|---|---|
| unmatched target, no default arm | **exit 0** — assertion skipped |
| unmatched target, with the new arm | exit 1, `::error::no artifact-kind assertion for <target>` |
| matched target, with the new arm | passes as before |

The four current targets are unaffected.

Also added `set -euo pipefail`: the step relied on the Actions default shell, and `file "$bin" | grep -q` would not have reported a failing `file`.

## Scope

No version bump — the release gate's shipped-file filter covers `src/`, `assets/`, `build.rs` and the manifests, and this touches only a workflow. Same class as #549/#550, found while reviewing that one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release builds now fail with a clear error when an unsupported target is encountered, preventing invalid binary-type checks from passing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->